### PR TITLE
fix: add error handling to AssignDropdown handleRelease

### DIFF
--- a/apps/web/functions/api/agentRepo.ts
+++ b/apps/web/functions/api/agentRepo.ts
@@ -1,8 +1,15 @@
 import type { Agent, AgentWithActivity, CreateAgentInput } from "@agent-kanban/shared";
 import { generateKeypair, computeFingerprint, computeKeyId } from "@agent-kanban/shared";
+import { HTTPException } from "hono/http-exception";
 import type { D1 } from "./db";
 
+const USERNAME_RE = /^[a-z][a-z0-9_-]{1,30}$/;
+
 export async function createAgent(db: D1, ownerId: string, input: CreateAgentInput): Promise<Agent> {
+  if (!USERNAME_RE.test(input.username)) {
+    throw new HTTPException(400, { message: "username must match ^[a-z][a-z0-9_-]{1,30}$" });
+  }
+
   const { publicKeyBase64, privateKeyJwk } = await generateKeypair();
   const fingerprint = await computeFingerprint(publicKeyBase64);
   const id = computeKeyId(fingerprint);
@@ -11,17 +18,17 @@ export async function createAgent(db: D1, ownerId: string, input: CreateAgentInp
   const handoffJson = input.handoff_to ? JSON.stringify(input.handoff_to) : null;
 
   await db.prepare(`
-    INSERT INTO agents (id, owner_id, name, bio, soul, role, handoff_to, runtime, model, skills, public_key, private_key, fingerprint, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO agents (id, owner_id, username, name, bio, soul, role, handoff_to, runtime, model, skills, public_key, private_key, fingerprint, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).bind(
-    id, ownerId, input.name, input.bio ?? null, input.soul ?? null,
+    id, ownerId, input.username, input.name, input.bio ?? null, input.soul ?? null,
     input.role ?? null, handoffJson,
     input.runtime ?? null, input.model ?? null, skillsJson,
     publicKeyBase64, JSON.stringify(privateKeyJwk), fingerprint, now, now,
   ).run();
 
   return {
-    id, owner_id: ownerId, name: input.name, bio: input.bio ?? null,
+    id, owner_id: ownerId, username: input.username, name: input.name, bio: input.bio ?? null,
     soul: input.soul ?? null, role: input.role ?? null, handoff_to: handoffJson,
     runtime: input.runtime ?? null, model: input.model ?? null,
     skills: skillsJson, public_key: publicKeyBase64, fingerprint, created_at: now, updated_at: now,
@@ -30,7 +37,7 @@ export async function createAgent(db: D1, ownerId: string, input: CreateAgentInp
 
 export async function listAgents(db: D1, ownerId: string): Promise<AgentWithActivity[]> {
   const result = await db.prepare(`
-    SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.handoff_to, a.runtime, a.model, a.skills,
+    SELECT a.id, a.owner_id, a.username, a.name, a.bio, a.soul, a.role, a.handoff_to, a.runtime, a.model, a.skills,
       a.public_key, a.fingerprint, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
       (SELECT MAX(tl.created_at) FROM task_logs tl WHERE tl.agent_id = a.id) as last_active_at,
@@ -49,7 +56,7 @@ export async function listAgents(db: D1, ownerId: string): Promise<AgentWithActi
 
 export async function getAgent(db: D1, agentId: string, ownerId: string): Promise<AgentWithActivity | null> {
   return db.prepare(`
-    SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.handoff_to, a.runtime, a.model, a.skills,
+    SELECT a.id, a.owner_id, a.username, a.name, a.bio, a.soul, a.role, a.handoff_to, a.runtime, a.model, a.skills,
       a.public_key, a.fingerprint, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
       (SELECT MAX(tl.created_at) FROM task_logs tl WHERE tl.agent_id = a.id) as last_active_at,

--- a/apps/web/functions/api/agentSessionRepo.ts
+++ b/apps/web/functions/api/agentSessionRepo.ts
@@ -93,6 +93,37 @@ export async function updateSessionUsage(db: D1, sessionId: string, usage: Sessi
   ).run();
 }
 
+export async function getSessionDetail(db: D1, sessionId: string): Promise<any | null> {
+  const session = await db.prepare(`
+    SELECT s.*, m.name as machine_name, a.name as agent_name, a.username as agent_username,
+      a.public_key as agent_public_key, a.fingerprint as agent_fingerprint
+    FROM agent_sessions s
+    JOIN machines m ON s.machine_id = m.id
+    JOIN agents a ON s.agent_id = a.id
+    WHERE s.id = ?
+  `).bind(sessionId).first();
+  if (!session) return null;
+
+  // Find the task this session worked on via task_logs
+  const taskLog = await db.prepare(
+    "SELECT task_id FROM task_logs WHERE session_id = ? AND action = 'claimed' LIMIT 1",
+  ).bind(sessionId).first<{ task_id: string }>();
+
+  const task = taskLog
+    ? await db.prepare("SELECT id, title, status, board_id FROM tasks WHERE id = ?")
+        .bind(taskLog.task_id).first()
+    : null;
+
+  // Get messages for this task sent by or to this agent
+  const messages = taskLog
+    ? (await db.prepare(
+        "SELECT * FROM messages WHERE task_id = ? ORDER BY created_at ASC",
+      ).bind(taskLog.task_id).all()).results
+    : [];
+
+  return { ...session, task, messages };
+}
+
 export async function listSessions(db: D1, agentId: string): Promise<AgentSessionWithMachine[]> {
   const result = await db.prepare(`
     SELECT s.*, m.name as machine_name

--- a/apps/web/functions/api/commentRepo.ts
+++ b/apps/web/functions/api/commentRepo.ts
@@ -1,0 +1,33 @@
+import type { Comment, AuthorType } from "@agent-kanban/shared";
+import { newLongId, type D1 } from "./db";
+
+export async function createComment(
+  db: D1,
+  taskId: string,
+  authorType: AuthorType,
+  authorId: string,
+  content: string,
+  mentions: string[] | null,
+): Promise<Comment> {
+  const id = newLongId();
+  const now = new Date().toISOString();
+  const mentionsJson = mentions?.length ? JSON.stringify(mentions) : null;
+
+  await db.prepare(
+    "INSERT INTO task_comments (id, task_id, author_type, author_id, content, mentions, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+  ).bind(id, taskId, authorType, authorId, content, mentionsJson, now).run();
+
+  return { id, task_id: taskId, author_type: authorType, author_id: authorId, content, mentions: mentionsJson, created_at: now };
+}
+
+export async function listComments(
+  db: D1,
+  taskId: string,
+  since?: string,
+): Promise<Comment[]> {
+  const query = since
+    ? db.prepare("SELECT * FROM task_comments WHERE task_id = ? AND created_at > ? ORDER BY created_at ASC").bind(taskId, since)
+    : db.prepare("SELECT * FROM task_comments WHERE task_id = ? ORDER BY created_at ASC").bind(taskId);
+  const result = await query.all<Comment>();
+  return result.results;
+}

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -6,7 +6,7 @@ import { getBoard, listBoards, createBoard, getBoardByName, updateBoard, deleteB
 import { createRepository, listRepositories, deleteRepository } from "./repositoryRepo";
 import { createTask, listTasks, getTask, updateTask, deleteTask, claimTask, completeTask, releaseTask, assignTask, cancelTask, reviewTask, addTaskLog, getTaskLogs } from "./taskRepo";
 import { createAgent, listAgents, getAgent, getAgentLogs, updateAgent, deleteAgent } from "./agentRepo";
-import { createSession, closeSession, updateSessionUsage, listSessions } from "./agentSessionRepo";
+import { createSession, closeSession, updateSessionUsage, listSessions, getSessionDetail } from "./agentSessionRepo";
 import { detectAndReleaseStale } from "./taskStale";
 import { createSSEResponse } from "./sse";
 import { createMessage, listMessages } from "./messageRepo";
@@ -173,6 +173,12 @@ api.get("/api/agents/:agentId/sessions", async (c) => {
   return c.json(sessions);
 });
 
+api.get("/api/sessions/:sessionId", async (c) => {
+  const detail = await getSessionDetail(c.env.DB, c.req.param("sessionId"));
+  if (!detail) throw new HTTPException(404, { message: "Session not found" });
+  return c.json(detail);
+});
+
 api.patch("/api/agents/:agentId/sessions/:sessionId/usage", async (c) => {
   const body = await c.req.json();
   await updateSessionUsage(c.env.DB, c.req.param("sessionId"), body);
@@ -194,8 +200,8 @@ api.post("/api/tasks", async (c) => {
 });
 
 api.get("/api/tasks", async (c) => {
-  const { repository_id, status, label, board_id, parent, assigned_to } = c.req.query();
-  const tasks = await listTasks(c.env.DB, { repository_id, status, label, board_id, parent, assigned_to });
+  const { repository_id, status, label, board_id, parent, assigned_to, has_checks } = c.req.query();
+  const tasks = await listTasks(c.env.DB, { repository_id, status, label, board_id, parent, assigned_to, has_checks });
   return c.json(tasks);
 });
 

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -10,6 +10,8 @@ import { createSession, closeSession, updateSessionUsage, listSessions } from ".
 import { detectAndReleaseStale } from "./taskStale";
 import { createSSEResponse } from "./sse";
 import { createMessage, listMessages } from "./messageRepo";
+import { createComment, listComments } from "./commentRepo";
+import { createCheck, listChecks, updateCheck, deleteCheck, verifyCheck, checkAllPassed } from "./taskCheckRepo";
 import { updateMachine, listMachines, getMachine, createMachine, deleteMachine } from "./machineRepo";
 import { createAuth } from "./betterAuth";
 
@@ -124,8 +126,8 @@ api.get("/api/agents/:id", async (c) => {
 });
 
 api.post("/api/agents", async (c) => {
-  const body = await c.req.json<{ name: string; bio?: string; soul?: string; role?: string; handoff_to?: string[]; runtime?: string; model?: string; skills?: string[] }>();
-  if (!body.name) throw new HTTPException(400, { message: "name is required" });
+  const body = await c.req.json<{ username: string; name: string; bio?: string; soul?: string; role?: string; handoff_to?: string[]; runtime?: string; model?: string; skills?: string[] }>();
+  if (!body.username || !body.name) throw new HTTPException(400, { message: "username and name are required" });
   const agent = await createAgent(c.env.DB, c.get("ownerId"), body);
   return c.json(agent, 201);
 });
@@ -235,8 +237,9 @@ api.post("/api/tasks/:id/claim", async (c) => {
   const body = await c.req.json().catch(() => ({})) as { agent_id?: string };
   const agentId = c.get("agentId") || body.agent_id;
   if (!agentId) throw new HTTPException(400, { message: "agent_id is required" });
+  const sessionId = c.get("sessionId") || null;
 
-  const task = await claimTask(c.env.DB, c.req.param("id"), agentId);
+  const task = await claimTask(c.env.DB, c.req.param("id"), agentId, sessionId);
   return c.json(task);
 });
 
@@ -349,6 +352,168 @@ api.get("/api/tasks/:id/messages", async (c) => {
   const since = c.req.query("since");
   const messages = await listMessages(c.env.DB, c.req.param("id"), since || undefined);
   return c.json(messages);
+});
+
+// ─── Comments ───
+
+const MENTION_RE = /@([a-z][a-z0-9_-]{1,30})/g;
+
+api.post("/api/tasks/:id/comments", async (c) => {
+  const body = await c.req.json<{ content: string; author_type?: string; author_id?: string }>();
+  if (!body.content) throw new HTTPException(400, { message: "content is required" });
+
+  const taskId = c.req.param("id");
+  const task = await c.env.DB.prepare("SELECT id FROM tasks WHERE id = ?")
+    .bind(taskId).first();
+  if (!task) throw new HTTPException(404, { message: "Task not found" });
+
+  const authorType = body.author_type || (c.get("agentId") ? "agent" : "user");
+  const authorId = body.author_id || (authorType === "agent" ? c.get("agentId") : c.get("ownerId"));
+  if (!authorId) throw new HTTPException(400, { message: "author_id is required" });
+
+  // Extract @mentions
+  const mentions: string[] = [];
+  let match;
+  while ((match = MENTION_RE.exec(body.content)) !== null) {
+    mentions.push(match[1]);
+  }
+
+  const comment = await createComment(
+    c.env.DB, taskId,
+    authorType as "user" | "agent", authorId,
+    body.content, mentions.length > 0 ? mentions : null,
+  );
+
+  // Route @mentions to agent sessions via messages table
+  if (mentions.length > 0) {
+    const placeholders = mentions.map(() => "?").join(",");
+    const agents = await c.env.DB.prepare(
+      `SELECT id, username FROM agents WHERE username IN (${placeholders})`,
+    ).bind(...mentions).all<{ id: string; username: string }>();
+
+    for (const agent of agents.results) {
+      // Find session for this agent on this task via task_logs
+      const log = await c.env.DB.prepare(
+        "SELECT session_id FROM task_logs WHERE task_id = ? AND agent_id = ? AND action = 'claimed' AND session_id IS NOT NULL ORDER BY created_at DESC LIMIT 1",
+      ).bind(taskId, agent.id).first<{ session_id: string }>();
+
+      if (log?.session_id) {
+        await createMessage(c.env.DB, taskId, authorType as "user" | "agent", authorId, body.content);
+      }
+    }
+  }
+
+  return c.json(comment, 201);
+});
+
+api.get("/api/tasks/:id/comments", async (c) => {
+  const task = await c.env.DB.prepare("SELECT id FROM tasks WHERE id = ?")
+    .bind(c.req.param("id")).first();
+  if (!task) throw new HTTPException(404, { message: "Task not found" });
+
+  const since = c.req.query("since");
+  const comments = await listComments(c.env.DB, c.req.param("id"), since || undefined);
+  return c.json(comments);
+});
+
+// ─── Task Checks ───
+
+api.post("/api/tasks/:id/checks", async (c) => {
+  const body = await c.req.json<{ description: string }>();
+  if (!body.description) throw new HTTPException(400, { message: "description is required" });
+
+  const task = await c.env.DB.prepare("SELECT id FROM tasks WHERE id = ?")
+    .bind(c.req.param("id")).first();
+  if (!task) throw new HTTPException(404, { message: "Task not found" });
+
+  const check = await createCheck(c.env.DB, c.req.param("id"), body.description);
+  return c.json(check, 201);
+});
+
+api.get("/api/tasks/:id/checks", async (c) => {
+  const task = await c.env.DB.prepare("SELECT id FROM tasks WHERE id = ?")
+    .bind(c.req.param("id")).first();
+  if (!task) throw new HTTPException(404, { message: "Task not found" });
+
+  const checks = await listChecks(c.env.DB, c.req.param("id"));
+  return c.json(checks);
+});
+
+api.patch("/api/tasks/:id/checks/:checkId", async (c) => {
+  const body = await c.req.json<{ description?: string }>();
+  const check = await updateCheck(c.env.DB, c.req.param("checkId"), body);
+  if (!check) throw new HTTPException(404, { message: "Check not found" });
+  return c.json(check);
+});
+
+api.delete("/api/tasks/:id/checks/:checkId", async (c) => {
+  const deleted = await deleteCheck(c.env.DB, c.req.param("checkId"));
+  if (!deleted) throw new HTTPException(404, { message: "Check not found" });
+  return c.json({ ok: true });
+});
+
+api.post("/api/tasks/:id/checks/:checkId/verify", async (c) => {
+  const body = await c.req.json<{ passed: boolean; agent_id?: string }>();
+  const agentId = c.get("agentId") || body.agent_id;
+  if (!agentId) throw new HTTPException(400, { message: "agent_id is required" });
+
+  const check = await verifyCheck(c.env.DB, c.req.param("checkId"), agentId, body.passed);
+  if (!check) throw new HTTPException(404, { message: "Check not found" });
+
+  const taskId = c.req.param("id");
+  const task = await c.env.DB.prepare("SELECT status, board_id, review_rounds FROM tasks WHERE id = ?")
+    .bind(taskId).first<{ status: string; board_id: string; review_rounds: number }>();
+
+  if (task?.status === "in_review") {
+    const { total, passed: passedCount } = await checkAllPassed(c.env.DB, taskId);
+
+    if (total > 0 && total === passedCount) {
+      // All checks passed → auto-complete
+      await completeTask(c.env.DB, taskId, agentId, "All checks verified", null);
+    } else if (!body.passed) {
+      // A check failed → check ping-pong limit
+      const board = await c.env.DB.prepare("SELECT max_review_rounds FROM boards WHERE id = ?")
+        .bind(task.board_id).first<{ max_review_rounds: number }>();
+      const maxRounds = board?.max_review_rounds ?? 3;
+      const newRounds = task.review_rounds + 1;
+
+      if (newRounds < maxRounds) {
+        // Bounce back to in_progress
+        const now = new Date().toISOString();
+        const logId = (await import("./db")).newLongId();
+
+        // Collect failed check descriptions
+        const failedChecks = await c.env.DB.prepare(
+          "SELECT description FROM task_checks WHERE task_id = ? AND passed = 0",
+        ).bind(taskId).all<{ description: string }>();
+        const failedList = failedChecks.results.map((c) => `- ${c.description}`).join("\n");
+
+        await c.env.DB.batch([
+          c.env.DB.prepare("UPDATE tasks SET status = 'in_progress', review_rounds = ?, updated_at = ? WHERE id = ?")
+            .bind(newRounds, now, taskId),
+          c.env.DB.prepare(
+            "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'moved', ?, ?)",
+          ).bind(logId, taskId, agentId, null, `Review round ${newRounds} failed. Checks not passed:\n${failedList}`, now),
+        ]);
+
+        // Reset failed checks for next round
+        await c.env.DB.prepare("UPDATE task_checks SET passed = 0, verified_by = NULL, verified_at = NULL WHERE task_id = ? AND passed = 0")
+          .bind(taskId).run();
+
+        // Route failure message to original agent session
+        const claimLog = await c.env.DB.prepare(
+          "SELECT session_id FROM task_logs WHERE task_id = ? AND action = 'claimed' AND session_id IS NOT NULL ORDER BY created_at DESC LIMIT 1",
+        ).bind(taskId).first<{ session_id: string }>();
+        if (claimLog?.session_id) {
+          await createMessage(c.env.DB, taskId, "agent", agentId,
+            `Review failed (round ${newRounds}/${maxRounds}). Please fix:\n${failedList}`);
+        }
+      }
+      // else: stays in in_review for human intervention
+    }
+  }
+
+  return c.json(check);
 });
 
 // ─── SSE Stream ───

--- a/apps/web/functions/api/sse.ts
+++ b/apps/web/functions/api/sse.ts
@@ -2,10 +2,11 @@ import type { D1 } from "./db";
 import type { Env } from "./types";
 import { getTaskLogs } from "./taskRepo";
 import { listMessages } from "./messageRepo";
+import { listComments } from "./commentRepo";
 
 interface SSEEvent {
   id: string;
-  type: "log" | "message";
+  type: "log" | "message" | "comment";
   data: string;
   created_at: string;
 }
@@ -45,22 +46,25 @@ export async function createSSEResponse(
     let since: string | undefined;
     if (lastEventId) {
       const ref = await db.prepare(
-        "SELECT created_at FROM task_logs WHERE id = ? UNION SELECT created_at FROM messages WHERE id = ?",
-      ).bind(lastEventId, lastEventId).first<{ created_at: string }>();
+        "SELECT created_at FROM task_logs WHERE id = ? UNION SELECT created_at FROM messages WHERE id = ? UNION SELECT created_at FROM task_comments WHERE id = ?",
+      ).bind(lastEventId, lastEventId, lastEventId).first<{ created_at: string }>();
       since = ref?.created_at;
     }
 
-    const [initialLogs, initialMessages] = await Promise.all([
+    const [initialLogs, initialMessages, initialComments] = await Promise.all([
       getTaskLogs(db, taskId, since),
       listMessages(db, taskId, since),
+      listComments(db, taskId, since),
     ]);
 
     const logEvents: SSEEvent[] = (since ? initialLogs : initialLogs.slice(-50))
       .map((l) => ({ id: l.id, type: "log" as const, data: JSON.stringify(l), created_at: l.created_at }));
     const msgEvents: SSEEvent[] = (since ? initialMessages : initialMessages.slice(-50))
       .map((m) => ({ id: m.id, type: "message" as const, data: JSON.stringify(m), created_at: m.created_at }));
+    const commentEvents: SSEEvent[] = (since ? initialComments : initialComments.slice(-50))
+      .map((c) => ({ id: c.id, type: "comment" as const, data: JSON.stringify(c), created_at: c.created_at }));
 
-    const batch = mergeByTime(logEvents, msgEvents);
+    const batch = mergeByTime(mergeByTime(logEvents, msgEvents), commentEvents);
     for (const event of batch) {
       await write(event);
     }
@@ -74,14 +78,16 @@ export async function createSSEResponse(
     while (Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 2000));
 
-      const [newLogs, newMessages] = await Promise.all([
+      const [newLogs, newMessages, newComments] = await Promise.all([
         getTaskLogs(db, taskId, lastSeen),
         listMessages(db, taskId, lastSeen),
+        listComments(db, taskId, lastSeen),
       ]);
 
       const newLogEvents = newLogs.map((l) => ({ id: l.id, type: "log" as const, data: JSON.stringify(l), created_at: l.created_at }));
       const newMsgEvents = newMessages.map((m) => ({ id: m.id, type: "message" as const, data: JSON.stringify(m), created_at: m.created_at }));
-      const merged = mergeByTime(newLogEvents, newMsgEvents);
+      const newCommentEvents = newComments.map((c) => ({ id: c.id, type: "comment" as const, data: JSON.stringify(c), created_at: c.created_at }));
+      const merged = mergeByTime(mergeByTime(newLogEvents, newMsgEvents), newCommentEvents);
 
       for (const event of merged) {
         await write(event);

--- a/apps/web/functions/api/sse.ts
+++ b/apps/web/functions/api/sse.ts
@@ -102,7 +102,10 @@ export async function createSSEResponse(
   };
 
   // Run in background — don't await
-  run().catch(() => writer.close().catch(() => {}));
+  run().catch((err) => {
+    console.error("[SSE] stream failed:", err instanceof Error ? err.message : err);
+    writer.close().catch(() => {});
+  });
 
   return new Response(readable, {
     headers: {

--- a/apps/web/functions/api/taskCheckRepo.ts
+++ b/apps/web/functions/api/taskCheckRepo.ts
@@ -1,0 +1,83 @@
+import type { TaskCheck } from "@agent-kanban/shared";
+import { newLongId, type D1 } from "./db";
+
+export async function createCheck(
+  db: D1,
+  taskId: string,
+  description: string,
+): Promise<TaskCheck> {
+  const id = newLongId();
+  const now = new Date().toISOString();
+
+  const maxOrder = await db.prepare(
+    "SELECT COALESCE(MAX(sort_order), -1) as max_order FROM task_checks WHERE task_id = ?",
+  ).bind(taskId).first<{ max_order: number }>();
+
+  const sortOrder = (maxOrder?.max_order ?? -1) + 1;
+
+  await db.prepare(
+    "INSERT INTO task_checks (id, task_id, description, passed, sort_order, created_at) VALUES (?, ?, ?, 0, ?, ?)",
+  ).bind(id, taskId, description, sortOrder, now).run();
+
+  return { id, task_id: taskId, description, passed: 0, verified_by: null, verified_at: null, sort_order: sortOrder, created_at: now };
+}
+
+export async function listChecks(
+  db: D1,
+  taskId: string,
+): Promise<TaskCheck[]> {
+  const result = await db.prepare(
+    "SELECT * FROM task_checks WHERE task_id = ? ORDER BY sort_order ASC",
+  ).bind(taskId).all<TaskCheck>();
+  return result.results;
+}
+
+export async function updateCheck(
+  db: D1,
+  checkId: string,
+  updates: { description?: string },
+): Promise<TaskCheck | null> {
+  const existing = await db.prepare("SELECT * FROM task_checks WHERE id = ?").bind(checkId).first<TaskCheck>();
+  if (!existing) return null;
+
+  if (updates.description !== undefined) {
+    await db.prepare("UPDATE task_checks SET description = ? WHERE id = ?").bind(updates.description, checkId).run();
+  }
+
+  return { ...existing, ...updates };
+}
+
+export async function deleteCheck(
+  db: D1,
+  checkId: string,
+): Promise<boolean> {
+  const result = await db.prepare("DELETE FROM task_checks WHERE id = ?").bind(checkId).run();
+  return result.meta.changes > 0;
+}
+
+export async function verifyCheck(
+  db: D1,
+  checkId: string,
+  agentId: string,
+  passed: boolean,
+): Promise<TaskCheck | null> {
+  const existing = await db.prepare("SELECT * FROM task_checks WHERE id = ?").bind(checkId).first<TaskCheck>();
+  if (!existing) return null;
+
+  const now = new Date().toISOString();
+  await db.prepare(
+    "UPDATE task_checks SET passed = ?, verified_by = ?, verified_at = ? WHERE id = ?",
+  ).bind(passed ? 1 : 0, agentId, now, checkId).run();
+
+  return { ...existing, passed: passed ? 1 : 0, verified_by: agentId, verified_at: now };
+}
+
+export async function checkAllPassed(
+  db: D1,
+  taskId: string,
+): Promise<{ total: number; passed: number }> {
+  const result = await db.prepare(
+    "SELECT COUNT(*) as total, SUM(CASE WHEN passed = 1 THEN 1 ELSE 0 END) as passed FROM task_checks WHERE task_id = ?",
+  ).bind(taskId).first<{ total: number; passed: number }>();
+  return { total: result?.total ?? 0, passed: result?.passed ?? 0 };
+}

--- a/apps/web/functions/api/taskRepo.ts
+++ b/apps/web/functions/api/taskRepo.ts
@@ -65,7 +65,7 @@ export async function createTask(db: D1, ownerId: string, input: CreateTaskInput
 
 export async function listTasks(
   db: D1,
-  filters: { repository_id?: string; status?: string; label?: string; board_id?: string; parent?: string; assigned_to?: string },
+  filters: { repository_id?: string; status?: string; label?: string; board_id?: string; parent?: string; assigned_to?: string; has_checks?: string },
 ): Promise<Task[]> {
   let query = `
     SELECT t.*, r.name as repository_name FROM tasks t
@@ -97,6 +97,9 @@ export async function listTasks(
   if (filters.assigned_to) {
     query += " AND t.assigned_to = ?";
     binds.push(filters.assigned_to);
+  }
+  if (filters.has_checks === "true") {
+    query += " AND EXISTS (SELECT 1 FROM task_checks tc WHERE tc.task_id = t.id)";
   }
 
   query += " ORDER BY t.position";

--- a/apps/web/functions/api/taskRepo.ts
+++ b/apps/web/functions/api/taskRepo.ts
@@ -175,7 +175,7 @@ export async function deleteTask(db: D1, taskId: string): Promise<boolean> {
   return result.meta.changes > 0;
 }
 
-export async function claimTask(db: D1, taskId: string, agentId: string): Promise<Task | null> {
+export async function claimTask(db: D1, taskId: string, agentId: string, sessionId: string | null = null): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
   if (task.assigned_to !== agentId) throw new HTTPException(409, { message: "Task is not assigned to this agent" });
@@ -190,7 +190,7 @@ export async function claimTask(db: D1, taskId: string, agentId: string): Promis
     ).bind(now, taskId),
     db.prepare(
       "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'claimed', NULL, ?)"
-    ).bind(logId, taskId, agentId, null, now),
+    ).bind(logId, taskId, agentId, sessionId, now),
   ]);
 
   return { ...task, status: "in_progress", updated_at: now };

--- a/apps/web/migrations/0001_initial.sql
+++ b/apps/web/migrations/0001_initial.sql
@@ -166,12 +166,13 @@ CREATE INDEX "approvalRequest_status_idx" ON "approvalRequest" ("status");
 
 -- Boards
 CREATE TABLE boards (
-  id          TEXT PRIMARY KEY,
-  owner_id    TEXT NOT NULL,
-  name        TEXT NOT NULL,
-  description TEXT,
-  created_at  TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+  id                TEXT PRIMARY KEY,
+  owner_id          TEXT NOT NULL,
+  name              TEXT NOT NULL,
+  description       TEXT,
+  max_review_rounds INTEGER NOT NULL DEFAULT 3,
+  created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at        TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX idx_boards_owner ON boards(owner_id);
 CREATE UNIQUE INDEX idx_boards_owner_name ON boards(owner_id, name);
@@ -206,6 +207,7 @@ CREATE INDEX idx_machines_owner ON machines(owner_id);
 CREATE TABLE agents (
   id              TEXT PRIMARY KEY,
   owner_id        TEXT NOT NULL,
+  username        TEXT NOT NULL UNIQUE,
   name            TEXT NOT NULL,
   bio             TEXT,
   soul            TEXT,
@@ -252,15 +254,16 @@ CREATE TABLE tasks (
   repository_id TEXT REFERENCES repositories(id) ON DELETE SET NULL,
   labels       TEXT,
   priority     TEXT CHECK(priority IN ('low', 'medium', 'high', 'urgent')),
-  created_by   TEXT,
-  assigned_to  TEXT REFERENCES agents(id) ON DELETE SET NULL,
-  result       TEXT,
-  pr_url       TEXT,
-  input        TEXT,
-  created_from TEXT REFERENCES tasks(id) ON DELETE SET NULL,
-  position     INTEGER NOT NULL DEFAULT 0,
-  created_at   TEXT NOT NULL DEFAULT (datetime('now')),
-  updated_at   TEXT NOT NULL DEFAULT (datetime('now'))
+  created_by    TEXT,
+  assigned_to   TEXT REFERENCES agents(id) ON DELETE SET NULL,
+  result        TEXT,
+  pr_url        TEXT,
+  input         TEXT,
+  created_from  TEXT REFERENCES tasks(id) ON DELETE SET NULL,
+  review_rounds INTEGER NOT NULL DEFAULT 0,
+  position      INTEGER NOT NULL DEFAULT 0,
+  created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at    TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX idx_tasks_board ON tasks(board_id);
 CREATE INDEX idx_tasks_status ON tasks(status);
@@ -301,3 +304,28 @@ CREATE TABLE messages (
   created_at  TEXT NOT NULL DEFAULT (datetime('now'))
 );
 CREATE INDEX idx_messages_task ON messages(task_id, created_at);
+
+-- Task comments (human ↔ agent discussion on a task)
+CREATE TABLE task_comments (
+  id          TEXT PRIMARY KEY,
+  task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  author_type TEXT NOT NULL CHECK(author_type IN ('user', 'agent')),
+  author_id   TEXT NOT NULL,
+  content     TEXT NOT NULL,
+  mentions    TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_task_comments_task ON task_comments(task_id, created_at);
+
+-- Task checks (acceptance criteria for review verification)
+CREATE TABLE task_checks (
+  id          TEXT PRIMARY KEY,
+  task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  description TEXT NOT NULL,
+  passed      INTEGER NOT NULL DEFAULT 0,
+  verified_by TEXT,
+  verified_at TEXT,
+  sort_order  INTEGER NOT NULL DEFAULT 0,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_task_checks_task ON task_checks(task_id);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,6 +6,7 @@ import { MachineDetailPage } from "./routes/MachineDetailPage";
 import { AgentsPage } from "./routes/AgentsPage";
 import { AgentDetailPage } from "./routes/AgentDetailPage";
 import { RepositoriesPage } from "./routes/RepositoriesPage";
+import { SessionDetailPage } from "./routes/SessionDetailPage";
 import { AuthPage } from "./routes/AuthPage";
 import { AuthCallbackPage } from "./routes/AuthCallbackPage";
 import { BoardRedirect } from "./routes/BoardRedirect";
@@ -31,6 +32,7 @@ export function App() {
         <Route path="/machines/:id" element={<ProtectedRoute><MachineDetailPage /></ProtectedRoute>} />
         <Route path="/agents" element={<ProtectedRoute><AgentsPage /></ProtectedRoute>} />
         <Route path="/agents/:id" element={<ProtectedRoute><AgentDetailPage /></ProtectedRoute>} />
+        <Route path="/sessions/:sessionId" element={<ProtectedRoute><SessionDetailPage /></ProtectedRoute>} />
         <Route path="/repositories" element={<ProtectedRoute><RepositoriesPage /></ProtectedRoute>} />
         <Route path="/settings" element={<ProtectedRoute><AccountSettingsPage /></ProtectedRoute>} />
       </Routes>

--- a/apps/web/src/components/AssignDropdown.tsx
+++ b/apps/web/src/components/AssignDropdown.tsx
@@ -37,6 +37,8 @@ export function AssignDropdown({ taskId, currentAgent, onAssigned }: AssignDropd
     try {
       await api.tasks.release(taskId);
       onAssigned();
+    } catch (e: any) {
+      alert(e.message);
     } finally {
       setAssigning(false);
       setOpen(false);

--- a/apps/web/src/components/CreateAgentDialog.tsx
+++ b/apps/web/src/components/CreateAgentDialog.tsx
@@ -20,6 +20,7 @@ interface Props {
 export function CreateAgentDialog({ existingRoles, open, onOpenChange, onCreated }: Props) {
   const [step, setStep] = useState<Step>("choose");
   const [selectedTemplate, setSelectedTemplate] = useState<AgentTemplate | null>(null);
+  const [username, setUsername] = useState("");
   const [name, setName] = useState("");
   const [bio, setBio] = useState("");
   const [soul, setSoul] = useState("");
@@ -34,13 +35,14 @@ export function CreateAgentDialog({ existingRoles, open, onOpenChange, onCreated
   function reset() {
     setStep("choose");
     setSelectedTemplate(null);
-    setName(""); setBio(""); setSoul(""); setRole("");
+    setUsername(""); setName(""); setBio(""); setSoul(""); setRole("");
     setHandoffTo([]); setRuntime("claude-code"); setModel(""); setSkills([]);
     setError(null);
   }
 
   function applyTemplate(t: AgentTemplate) {
     setSelectedTemplate(t);
+    setUsername(t.role || t.name.toLowerCase().replace(/[^a-z0-9_-]/g, "-"));
     setName(t.name);
     setBio(t.bio || "");
     setSoul(t.soul || "");
@@ -54,7 +56,7 @@ export function CreateAgentDialog({ existingRoles, open, onOpenChange, onCreated
 
   function startCustom() {
     setSelectedTemplate(null);
-    setName(""); setBio(""); setSoul(""); setRole("");
+    setUsername(""); setName(""); setBio(""); setSoul(""); setRole("");
     setHandoffTo([]); setRuntime("claude-code"); setModel(""); setSkills([]);
     setStep("form");
   }
@@ -65,6 +67,7 @@ export function CreateAgentDialog({ existingRoles, open, onOpenChange, onCreated
     setError(null);
     try {
       await api.agents.create({
+        username: username.trim(),
         name: name.trim(),
         bio: bio.trim() || undefined,
         soul: soul.trim() || undefined,
@@ -104,6 +107,7 @@ export function CreateAgentDialog({ existingRoles, open, onOpenChange, onCreated
           <FormStep
             template={selectedTemplate}
             existingRoles={existingRoles}
+            username={username} setUsername={setUsername}
             name={name} setName={setName}
             bio={bio} setBio={setBio}
             soul={soul} setSoul={setSoul}
@@ -241,6 +245,7 @@ function RecruitStep({ onSelect, onBack }: {
 interface FormStepProps {
   template: AgentTemplate | null;
   existingRoles: string[];
+  username: string; setUsername: (v: string) => void;
   name: string; setName: (v: string) => void;
   bio: string; setBio: (v: string) => void;
   soul: string; setSoul: (v: string) => void;
@@ -256,7 +261,7 @@ interface FormStepProps {
 
 function FormStep(props: FormStepProps) {
   const {
-    template, existingRoles, name, setName, bio, setBio, soul, setSoul, role, setRole,
+    template, existingRoles, username, setUsername, name, setName, bio, setBio, soul, setSoul, role, setRole,
     handoffTo, setHandoffTo, runtime, setRuntime, model, setModel,
     skills, setSkills, creating, error, onBack, onCreate,
   } = props;
@@ -279,6 +284,12 @@ function FormStep(props: FormStepProps) {
       </DialogHeader>
 
       <div className="space-y-4">
+        <div className="space-y-1.5">
+          <Label htmlFor="agent-username">Username</Label>
+          <Input id="agent-username" value={username} onChange={(e) => setUsername(e.target.value.toLowerCase().replace(/[^a-z0-9_-]/g, ""))} placeholder="e.g. bolt" className="font-mono" />
+          <p className="text-[10px] text-muted-foreground">Lowercase, used for @mentions. Cannot be changed.</p>
+        </div>
+
         <div className="grid grid-cols-2 gap-3">
           <div className="space-y-1.5">
             <Label htmlFor="agent-name">Name</Label>
@@ -330,7 +341,7 @@ function FormStep(props: FormStepProps) {
 
       <DialogFooter>
         <Button variant="ghost" onClick={onBack}>Back</Button>
-        <Button onClick={onCreate} disabled={!name.trim() || creating}>
+        <Button onClick={onCreate} disabled={!username.trim() || !name.trim() || creating}>
           {creating ? "Recruiting..." : template ? "Recruit" : "Create"}
         </Button>
       </DialogFooter>

--- a/apps/web/src/components/SubtaskList.tsx
+++ b/apps/web/src/components/SubtaskList.tsx
@@ -8,10 +8,20 @@ interface SubtaskListProps {
 
 export function SubtaskList({ parentId, onTaskClick }: SubtaskListProps) {
   const [subtasks, setSubtasks] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    api.tasks.list({ parent: parentId }).then(setSubtasks).catch(() => {});
+    setError(null);
+    api.tasks.list({ parent: parentId }).then(setSubtasks).catch((err) => {
+      const message = err instanceof Error ? err.message : "Failed to load subtasks";
+      setError(message);
+      console.error("[SubtaskList] fetch failed:", message);
+    });
   }, [parentId]);
+
+  if (error) {
+    return <div className="text-sm text-danger pl-6 md:pl-4">{error}</div>;
+  }
 
   if (subtasks.length === 0) return null;
 

--- a/apps/web/src/components/TaskChecks.tsx
+++ b/apps/web/src/components/TaskChecks.tsx
@@ -1,0 +1,156 @@
+import { useState, useEffect } from "react";
+import { api } from "../lib/api";
+import { formatRelative } from "./TaskDetailFields";
+
+interface TaskChecksProps {
+  taskId: string;
+}
+
+export function TaskChecks({ taskId }: TaskChecksProps) {
+  const [checks, setChecks] = useState<any[]>([]);
+  const [newDescription, setNewDescription] = useState("");
+  const [adding, setAdding] = useState(false);
+
+  const reload = () => api.checks.list(taskId).then(setChecks).catch(() => {});
+
+  useEffect(() => { reload(); }, [taskId]);
+
+  async function handleAdd() {
+    if (!newDescription.trim()) return;
+    setAdding(true);
+    await api.checks.create(taskId, newDescription.trim());
+    setNewDescription("");
+    setAdding(false);
+    reload();
+  }
+
+  async function handleDelete(checkId: string) {
+    await api.checks.delete(taskId, checkId);
+    reload();
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleAdd();
+    }
+  }
+
+  const passedCount = checks.filter((c) => c.passed).length;
+
+  return (
+    <div className="space-y-3">
+      {/* Progress */}
+      {checks.length > 0 && (
+        <div className="flex items-center gap-2">
+          <div className="flex-1 h-1.5 bg-surface-tertiary rounded-full overflow-hidden">
+            <div
+              className="h-full bg-accent rounded-full transition-all"
+              style={{ width: `${(passedCount / checks.length) * 100}%` }}
+            />
+          </div>
+          <span className="text-[11px] font-mono text-content-tertiary">
+            {passedCount}/{checks.length}
+          </span>
+        </div>
+      )}
+
+      {/* Check list */}
+      <div className="space-y-1">
+        {checks.map((check) => (
+          <CheckItem
+            key={check.id}
+            check={check}
+            taskId={taskId}
+            onUpdate={reload}
+            onDelete={() => handleDelete(check.id)}
+          />
+        ))}
+      </div>
+
+      {/* Add new */}
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={newDescription}
+          onChange={(e) => setNewDescription(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Add a check..."
+          disabled={adding}
+          className="flex-1 bg-surface-primary border border-border rounded-md px-3 py-1.5 text-sm text-content-primary placeholder:text-content-tertiary focus:outline-none focus:ring-1 focus:ring-accent"
+        />
+        <button
+          onClick={handleAdd}
+          disabled={!newDescription.trim() || adding}
+          className="px-3 py-1.5 bg-surface-tertiary text-content-secondary rounded-md text-sm font-medium disabled:opacity-50 hover:text-content-primary transition-colors"
+        >
+          Add
+        </button>
+      </div>
+
+      {checks.length === 0 && (
+        <p className="text-sm text-content-tertiary">
+          No checks yet. Add acceptance criteria to enable auto-verification.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function CheckItem({ check, taskId, onUpdate, onDelete }: { check: any; taskId: string; onUpdate: () => void; onDelete: () => void }) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(check.description);
+
+  async function handleSave() {
+    if (draft.trim() && draft !== check.description) {
+      await api.checks.update(taskId, check.id, { description: draft.trim() });
+      onUpdate();
+    }
+    setEditing(false);
+  }
+
+  return (
+    <div className="flex items-start gap-2 group py-1">
+      <div className={`mt-0.5 w-4 h-4 rounded border flex-shrink-0 flex items-center justify-center ${
+        check.passed
+          ? "bg-accent border-accent text-surface-primary"
+          : "border-border"
+      }`}>
+        {check.passed ? <span className="text-[10px]">✓</span> : null}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        {editing ? (
+          <input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={handleSave}
+            onKeyDown={(e) => { if (e.key === "Enter") handleSave(); if (e.key === "Escape") setEditing(false); }}
+            autoFocus
+            className="w-full text-sm bg-transparent border-b border-accent outline-none text-content-primary"
+          />
+        ) : (
+          <span
+            onClick={() => setEditing(true)}
+            className={`text-sm cursor-pointer ${check.passed ? "line-through text-content-tertiary" : "text-content-secondary"}`}
+          >
+            {check.description}
+          </span>
+        )}
+
+        {check.verified_by && (
+          <div className="text-[10px] font-mono text-content-tertiary mt-0.5">
+            verified {formatRelative(check.verified_at)}
+          </div>
+        )}
+      </div>
+
+      <button
+        onClick={onDelete}
+        className="text-content-tertiary hover:text-error opacity-0 group-hover:opacity-100 transition-opacity text-xs"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/TaskDetail.tsx
+++ b/apps/web/src/components/TaskDetail.tsx
@@ -3,8 +3,8 @@ import { api } from "../lib/api";
 import { useSSE } from "../hooks/useSSE";
 import { useSession } from "../lib/auth-client";
 import { EditableText, EditableTextarea, Field, FieldLabel } from "./TaskDetailFields";
-import { ActivityLog } from "./ActivityLog";
-import { ChatPanel } from "./ChatPanel";
+import { TaskTimeline } from "./TaskTimeline";
+import { TaskChecks } from "./TaskChecks";
 import { SubtaskList } from "./SubtaskList";
 import { AssignDropdown } from "./AssignDropdown";
 
@@ -27,7 +27,7 @@ interface TaskDetailProps {
 
 const PRIORITIES = ["urgent", "high", "medium", "low"] as const;
 
-type Tab = "details" | "chat";
+type Tab = "details" | "checks";
 
 export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDetailProps) {
   const { data: session } = useSession();
@@ -36,14 +36,14 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
   const [repositories, setRepositories] = useState<{ id: string; name: string }[]>([]);
   const [depTitles, setDepTitles] = useState<Record<string, string>>({});
   const [activeTab, setActiveTab] = useState<Tab>("details");
-  const [initialMessages, setInitialMessages] = useState<any[]>([]);
-  const { messages: sseMessages } = useSSE({ taskId, enabled: true });
+  const [initialComments, setInitialComments] = useState<any[]>([]);
+  const { logs: sseLogs, comments: sseComments } = useSSE({ taskId, enabled: true });
 
   const reload = () => api.tasks.get(taskId).then(setTask);
 
   useEffect(() => {
     reload().finally(() => setLoading(false));
-    api.messages.list(taskId).then(setInitialMessages).catch(() => {});
+    api.comments.list(taskId).then(setInitialComments).catch(() => {});
   }, [taskId]);
 
   useEffect(() => {
@@ -99,7 +99,6 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
   }
 
   const dependsOn: string[] = task.depends_on || [];
-  const hasAgent = !!task.assigned_to;
 
   return (
     <Panel>
@@ -145,33 +144,31 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
       </div>
 
       {/* Tabs */}
-      {hasAgent && (
-        <div className="flex border-b border-border">
-          <button
-            onClick={() => setActiveTab("details")}
-            className={`px-5 py-2.5 text-sm font-medium transition-colors ${
-              activeTab === "details"
-                ? "text-content-primary border-b-2 border-accent"
-                : "text-content-tertiary hover:text-content-secondary"
-            }`}
-          >
-            Details
-          </button>
-          <button
-            onClick={() => setActiveTab("chat")}
-            className={`px-5 py-2.5 text-sm font-medium transition-colors ${
-              activeTab === "chat"
-                ? "text-accent border-b-2 border-accent"
-                : "text-content-tertiary hover:text-content-secondary"
-            }`}
-          >
-            Chat
-          </button>
-        </div>
-      )}
+      <div className="flex border-b border-border">
+        <button
+          onClick={() => setActiveTab("details")}
+          className={`px-5 py-2.5 text-sm font-medium transition-colors ${
+            activeTab === "details"
+              ? "text-content-primary border-b-2 border-accent"
+              : "text-content-tertiary hover:text-content-secondary"
+          }`}
+        >
+          Details
+        </button>
+        <button
+          onClick={() => setActiveTab("checks")}
+          className={`px-5 py-2.5 text-sm font-medium transition-colors ${
+            activeTab === "checks"
+              ? "text-accent border-b-2 border-accent"
+              : "text-content-tertiary hover:text-content-secondary"
+          }`}
+        >
+          Checks
+        </button>
+      </div>
 
       {/* Tab content */}
-      {(activeTab === "details" || !hasAgent) && (
+      {activeTab === "details" && (
         <div className="p-5 space-y-4">
           {/* Status row */}
           <div className="grid grid-cols-3 gap-4">
@@ -267,13 +264,17 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
 
           <hr className="border-border" />
 
-          {/* Activity Log */}
+          {/* Timeline */}
           <div>
-            <FieldLabel>Activity</FieldLabel>
-            <ActivityLog
+            <FieldLabel>Timeline</FieldLabel>
+            <TaskTimeline
               taskId={taskId}
               initialLogs={task.logs || []}
-              assigned={!!task.assigned_to}
+              initialComments={initialComments}
+              sseLogs={sseLogs}
+              sseComments={sseComments}
+              userId={session?.user?.id || null}
+              taskDone={task.status === "done" || task.status === "cancelled"}
             />
           </div>
 
@@ -289,16 +290,9 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
         </div>
       )}
 
-      {activeTab === "chat" && hasAgent && (
-        <div className="flex flex-col h-[calc(100%-8rem)] p-5">
-          <ChatPanel
-            taskId={taskId}
-            agentId={task.assigned_to}
-            userId={session?.user?.id || null}
-            taskDone={task.status === "done"}
-            initialMessages={initialMessages}
-            sseMessages={sseMessages}
-          />
+      {activeTab === "checks" && (
+        <div className="p-5">
+          <TaskChecks taskId={taskId} />
         </div>
       )}
     </Panel>

--- a/apps/web/src/components/TaskTimeline.tsx
+++ b/apps/web/src/components/TaskTimeline.tsx
@@ -1,0 +1,180 @@
+import { useState, useRef, useEffect } from "react";
+import { api } from "../lib/api";
+import { formatRelative } from "./TaskDetailFields";
+
+interface TimelineEntry {
+  id: string;
+  type: "action" | "comment";
+  created_at: string;
+  data: any;
+}
+
+interface TaskTimelineProps {
+  taskId: string;
+  initialLogs: any[];
+  initialComments: any[];
+  sseLogs: any[];
+  sseComments: any[];
+  userId: string | null;
+  taskDone: boolean;
+}
+
+const actionStyles: Record<string, string> = {
+  claimed: "text-accent",
+  assigned: "text-accent",
+  completed: "text-success",
+  released: "text-warning",
+  timed_out: "text-error",
+  cancelled: "text-error",
+  review_requested: "text-accent",
+};
+
+const actionLabels: Record<string, string> = {
+  claimed: "Claimed",
+  assigned: "Assigned",
+  completed: "Completed",
+  created: "Created",
+  released: "Released",
+  timed_out: "Timed out",
+  moved: "Moved",
+  cancelled: "Cancelled",
+  review_requested: "Moved to review",
+};
+
+function dedup<T extends { id: string }>(items: T[]): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const item of items) {
+    if (!seen.has(item.id)) {
+      seen.add(item.id);
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+function highlightMentions(text: string): (string | JSX.Element)[] {
+  const parts = text.split(/(@[a-z][a-z0-9_-]{1,30})/g);
+  return parts.map((part, i) =>
+    part.startsWith("@")
+      ? <span key={i} className="text-accent font-medium">{part}</span>
+      : part
+  );
+}
+
+export function TaskTimeline({ taskId, initialLogs, initialComments, sseLogs, sseComments, userId, taskDone }: TaskTimelineProps) {
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const allLogs = dedup([...initialLogs, ...sseLogs]);
+  const allComments = dedup([...initialComments, ...sseComments]);
+
+  const entries: TimelineEntry[] = [
+    ...allLogs.filter((l) => l.action !== "commented").map((l) => ({ id: l.id, type: "action" as const, created_at: l.created_at, data: l })),
+    ...allComments.map((c) => ({ id: c.id, type: "comment" as const, created_at: c.created_at, data: c })),
+  ].sort((a, b) => a.created_at.localeCompare(b.created_at));
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [entries.length]);
+
+  async function handleSend() {
+    if (!input.trim()) return;
+    setSending(true);
+    try {
+      await api.comments.create(taskId, { content: input.trim() });
+      setInput("");
+    } catch { /* ignore */ }
+    setSending(false);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div
+        ref={containerRef}
+        className="space-y-0 max-h-96 overflow-y-auto"
+      >
+        {entries.length === 0 && (
+          <p className="text-sm text-content-tertiary py-2">No activity yet.</p>
+        )}
+        {entries.map((entry) => (
+          <div key={entry.id}>
+            {entry.type === "action" ? (
+              <ActionRow log={entry.data} />
+            ) : (
+              <CommentRow comment={entry.data} />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {!taskDone && (
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Leave a comment... Use @username to mention"
+            disabled={sending}
+            className="flex-1 bg-surface-primary border border-border rounded-md px-3 py-2 text-sm text-content-primary placeholder:text-content-tertiary focus:outline-none focus:ring-1 focus:ring-accent"
+          />
+          <button
+            onClick={handleSend}
+            disabled={!input.trim() || sending}
+            className="px-4 py-2 bg-accent text-surface-primary rounded-md text-sm font-medium disabled:opacity-50 hover:opacity-90 transition-opacity"
+          >
+            {sending ? "..." : "Send"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ActionRow({ log }: { log: any }) {
+  return (
+    <div className="flex gap-3 py-1.5 border-l-2 pl-4 ml-1 border-border">
+      <span className="font-mono text-[11px] text-content-tertiary whitespace-nowrap min-w-[50px]">
+        {formatRelative(log.created_at)}
+      </span>
+      <span className={`text-[13px] text-content-secondary`}>
+        <span className={actionStyles[log.action] || ""}>{actionLabels[log.action] || log.action}</span>
+        {log.detail ? <span className="text-content-tertiary"> — {log.detail}</span> : null}
+      </span>
+    </div>
+  );
+}
+
+function CommentRow({ comment }: { comment: any }) {
+  const isAgent = comment.author_type === "agent";
+  return (
+    <div className={`flex gap-3 py-2 border-l-2 pl-4 ml-1 ${isAgent ? "border-accent" : "border-border"}`}>
+      <span className="font-mono text-[11px] text-content-tertiary whitespace-nowrap min-w-[50px]">
+        {formatRelative(comment.created_at)}
+      </span>
+      <div className="flex-1 min-w-0">
+        <span className={`text-[11px] font-mono uppercase tracking-wider ${
+          isAgent ? "text-accent" : "text-content-tertiary"
+        }`}>
+          {comment.author_type}
+        </span>
+        <p className={`text-[13px] mt-0.5 whitespace-pre-wrap break-words ${
+          isAgent ? "font-mono text-xs text-content-secondary" : "text-content-primary"
+        }`}>
+          {highlightMentions(comment.content)}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useAgents.ts
+++ b/apps/web/src/hooks/useAgents.ts
@@ -4,16 +4,23 @@ import { api } from "../lib/api";
 export function useAgents() {
   const [agents, setAgents] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
+      setError(null);
       const result = await api.agents.list();
       setAgents(result);
-    } catch { /* ignore */ }
-    finally { setLoading(false); }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to load agents";
+      setError(message);
+      console.error("[useAgents] fetch failed:", message);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => { load(); }, [load]);
 
-  return { agents, loading, refresh: load };
+  return { agents, loading, error, refresh: load };
 }

--- a/apps/web/src/hooks/useSSE.ts
+++ b/apps/web/src/hooks/useSSE.ts
@@ -79,7 +79,9 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
       if (logsRes.ok) setLogs(await logsRes.json());
       if (msgsRes.ok) setMessages(await msgsRes.json());
       if (commentsRes.ok) setComments(await commentsRes.json());
-    } catch { /* ignore polling errors */ }
+    } catch (err) {
+      console.error("[useSSE] polling failed:", err instanceof Error ? err.message : err);
+    }
   }, [taskId, token]);
 
   useEffect(() => {

--- a/apps/web/src/hooks/useSSE.ts
+++ b/apps/web/src/hooks/useSSE.ts
@@ -9,6 +9,7 @@ interface UseSSEOptions {
 export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
   const [logs, setLogs] = useState<any[]>([]);
   const [messages, setMessages] = useState<any[]>([]);
+  const [comments, setComments] = useState<any[]>([]);
   const [connected, setConnected] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
   const failCount = useRef(0);
@@ -42,6 +43,12 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
       setMessages((prev) => [...prev, msg]);
     });
 
+    es.addEventListener("comment", (e: MessageEvent) => {
+      const comment = JSON.parse(e.data);
+      lastEventId.current = e.lastEventId;
+      setComments((prev) => [...prev, comment]);
+    });
+
     es.onerror = () => {
       es.close();
       setConnected(false);
@@ -63,12 +70,15 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
   const poll = useCallback(async () => {
     if (!token) return;
     try {
-      const [logsRes, msgsRes] = await Promise.all([
-        fetch(`/api/tasks/${taskId}/logs`, { headers: { Authorization: `Bearer ${token}` } }),
-        fetch(`/api/tasks/${taskId}/messages`, { headers: { Authorization: `Bearer ${token}` } }),
+      const headers = { Authorization: `Bearer ${token}` };
+      const [logsRes, msgsRes, commentsRes] = await Promise.all([
+        fetch(`/api/tasks/${taskId}/logs`, { headers }),
+        fetch(`/api/tasks/${taskId}/messages`, { headers }),
+        fetch(`/api/tasks/${taskId}/comments`, { headers }),
       ]);
       if (logsRes.ok) setLogs(await logsRes.json());
       if (msgsRes.ok) setMessages(await msgsRes.json());
+      if (commentsRes.ok) setComments(await commentsRes.json());
     } catch { /* ignore polling errors */ }
   }, [taskId, token]);
 
@@ -94,5 +104,5 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
     }
   }, [reconnecting, poll]);
 
-  return { logs, messages, connected, reconnecting };
+  return { logs, messages, comments, connected, reconnecting };
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -76,6 +76,9 @@ export const api = {
     verify: (taskId: string, checkId: string, passed: boolean, agentId?: string) =>
       request<any>("POST", `/tasks/${taskId}/checks/${checkId}/verify`, { passed, agent_id: agentId }),
   },
+  sessions: {
+    get: (sessionId: string) => request<any>("GET", `/sessions/${sessionId}`),
+  },
   agents: {
     list: () => request<any[]>("GET", "/agents"),
     get: (id: string) => request<any>("GET", `/agents/${id}`),

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -57,10 +57,29 @@ export const api = {
     create: (taskId: string, body: { sender_type: string; sender_id: string; content: string }) =>
       request<any>("POST", `/tasks/${taskId}/messages`, body),
   },
+  comments: {
+    list: (taskId: string, since?: string) => {
+      const qs = since ? `?since=${encodeURIComponent(since)}` : "";
+      return request<any[]>("GET", `/tasks/${taskId}/comments${qs}`);
+    },
+    create: (taskId: string, body: { content: string; author_type?: string; author_id?: string }) =>
+      request<any>("POST", `/tasks/${taskId}/comments`, body),
+  },
+  checks: {
+    list: (taskId: string) => request<any[]>("GET", `/tasks/${taskId}/checks`),
+    create: (taskId: string, description: string) =>
+      request<any>("POST", `/tasks/${taskId}/checks`, { description }),
+    update: (taskId: string, checkId: string, body: { description?: string }) =>
+      request<any>("PATCH", `/tasks/${taskId}/checks/${checkId}`, body),
+    delete: (taskId: string, checkId: string) =>
+      request<void>("DELETE", `/tasks/${taskId}/checks/${checkId}`),
+    verify: (taskId: string, checkId: string, passed: boolean, agentId?: string) =>
+      request<any>("POST", `/tasks/${taskId}/checks/${checkId}/verify`, { passed, agent_id: agentId }),
+  },
   agents: {
     list: () => request<any[]>("GET", "/agents"),
     get: (id: string) => request<any>("GET", `/agents/${id}`),
-    create: (input: { name: string; bio?: string; soul?: string; role?: string; handoff_to?: string[]; runtime?: string; model?: string; skills?: string[] }) =>
+    create: (input: { username: string; name: string; bio?: string; soul?: string; role?: string; handoff_to?: string[]; runtime?: string; model?: string; skills?: string[] }) =>
       request<any>("POST", "/agents", input),
     update: (id: string, body: Record<string, unknown>) => request<any>("PATCH", `/agents/${id}`, body),
     delete: (id: string) => request<void>("DELETE", `/agents/${id}`),

--- a/apps/web/src/routes/AgentDetailPage.tsx
+++ b/apps/web/src/routes/AgentDetailPage.tsx
@@ -289,7 +289,7 @@ function SessionsTab({ sessions, color }: { sessions: any[]; color: string }) {
       {sessions.map((s: any) => {
         const isActive = s.status === "active";
         return (
-          <div key={s.id} className="relative flex items-center gap-4 py-2.5 pl-7">
+          <Link key={s.id} to={`/sessions/${s.id}`} className="relative flex items-center gap-4 py-2.5 pl-7 hover:bg-surface-tertiary/30 rounded-r transition-colors">
             <div
               className={`absolute left-0 w-[7px] h-[7px] rounded-full ${isActive ? "animate-pulse-glow" : ""}`}
               style={{ backgroundColor: isActive ? color : "#3f3f46" }}
@@ -306,7 +306,7 @@ function SessionsTab({ sessions, color }: { sessions: any[]; color: string }) {
             {s.machine_name && (
               <span className="text-[11px] text-content-tertiary font-mono ml-auto">{s.machine_name}</span>
             )}
-          </div>
+          </Link>
         );
       })}
     </div>

--- a/apps/web/src/routes/SessionDetailPage.tsx
+++ b/apps/web/src/routes/SessionDetailPage.tsx
@@ -1,0 +1,187 @@
+import { useState, useEffect, useRef } from "react";
+import { useParams, Link } from "react-router-dom";
+import { Header } from "../components/Header";
+import { AgentIdenticon } from "../components/AgentIdenticon";
+import { api } from "../lib/api";
+import { agentColor, agentColorRgb } from "../lib/agentIdentity";
+import { formatRelative } from "../components/TaskDetailFields";
+
+function formatTokens(n: number): string {
+  if (!n) return "0";
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatCost(microUsd: number): string {
+  if (!microUsd) return "$0.00";
+  return `$${(microUsd / 1_000_000).toFixed(2)}`;
+}
+
+export function SessionDetailPage() {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const [session, setSession] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    api.sessions.get(sessionId).then(setSession).finally(() => setLoading(false));
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [session?.messages?.length]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-surface-primary">
+        <Header />
+        <div className="max-w-4xl mx-auto px-8 py-10">
+          <div className="h-80 bg-surface-secondary rounded-lg animate-pulse" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="min-h-screen bg-surface-primary">
+        <Header />
+        <div className="max-w-4xl mx-auto px-8 py-10">
+          <p className="text-sm text-content-tertiary">Session not found.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const color = session.agent_public_key ? agentColor(session.agent_public_key) : "#22D3EE";
+  const rgb = session.agent_public_key ? agentColorRgb(session.agent_public_key) : "34, 211, 238";
+  const isActive = session.status === "active";
+  const messages = session.messages || [];
+
+  return (
+    <div className="min-h-screen bg-surface-primary">
+      <Header />
+      <div className="max-w-4xl mx-auto px-8 py-10">
+        <Link to={`/agents/${session.agent_id}`} className="text-xs text-content-tertiary hover:text-content-secondary transition-colors">
+          &larr; {session.agent_name}
+        </Link>
+
+        {/* Session Header */}
+        <div
+          className="mt-6 rounded-lg overflow-hidden"
+          style={{
+            background: "var(--bg-secondary)",
+            boxShadow: `0 0 0 1px ${isActive ? `rgba(${rgb}, 0.2)` : "var(--border)"}`,
+          }}
+        >
+          <div className="h-1" style={{ background: isActive ? color : "#3f3f46" }} />
+
+          <div className="px-6 py-6">
+            <div className="flex items-center gap-4">
+              <AgentIdenticon publicKey={session.agent_public_key} size={48} glow={isActive} />
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center gap-2">
+                  <h1 className="font-mono text-lg font-bold" style={{ color }}>
+                    {session.agent_name}
+                  </h1>
+                  <span className={`text-[10px] font-mono rounded px-1.5 py-0.5 ${
+                    isActive ? "text-accent bg-accent/10" : "text-content-tertiary bg-surface-tertiary"
+                  }`}>
+                    {session.status}
+                  </span>
+                </div>
+                <div className="flex items-center gap-3 mt-1">
+                  <code className="font-mono text-[11px] text-content-tertiary">{session.id}</code>
+                  {session.machine_name && (
+                    <span className="text-[10px] font-mono text-content-tertiary bg-surface-tertiary rounded-full px-2 py-0.5">
+                      {session.machine_name}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* Usage strip */}
+          <div className="border-t border-border/50 grid grid-cols-5 divide-x divide-border/50">
+            {[
+              { label: "INPUT", value: formatTokens(session.input_tokens || 0) },
+              { label: "OUTPUT", value: formatTokens(session.output_tokens || 0) },
+              { label: "CACHE", value: formatTokens(session.cache_read_tokens || 0) },
+              { label: "COST", value: formatCost(session.cost_micro_usd || 0) },
+              { label: "STARTED", value: formatRelative(session.created_at) },
+            ].map((stat) => (
+              <div key={stat.label} className="py-2.5 px-4 text-center">
+                <div className="text-[9px] font-mono text-content-tertiary uppercase tracking-wider">{stat.label}</div>
+                <div className="font-mono text-sm text-content-primary mt-0.5">{stat.value}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Task link */}
+        {session.task && (
+          <Link
+            to={`/boards/${session.task.board_id}`}
+            className="mt-4 flex items-center gap-3 bg-surface-secondary rounded-lg px-5 py-3 hover:bg-surface-tertiary/60 transition-colors"
+            style={{ boxShadow: "0 0 0 1px var(--border)" }}
+          >
+            <span className="text-[10px] font-mono uppercase text-content-tertiary">TASK</span>
+            <span className="text-sm text-content-primary flex-1 truncate">{session.task.title}</span>
+            <span className={`text-[10px] font-mono uppercase px-2 py-0.5 rounded ${
+              session.task.status === "done" ? "bg-green-500/15 text-green-500"
+                : session.task.status === "in_progress" ? "bg-accent/15 text-accent"
+                : "bg-zinc-500/15 text-content-tertiary"
+            }`}>
+              {session.task.status.replace("_", " ")}
+            </span>
+          </Link>
+        )}
+
+        {/* Messages */}
+        <div className="mt-8">
+          <h2 className="text-xs font-mono text-content-tertiary uppercase tracking-wider mb-4">
+            Chat History
+            <span className="ml-2 text-content-tertiary">{messages.length}</span>
+          </h2>
+
+          <div ref={containerRef} className="space-y-1">
+            {messages.length === 0 && (
+              <p className="text-sm text-content-tertiary py-8 text-center">No messages in this session.</p>
+            )}
+            {messages.map((msg: any) => (
+              <div
+                key={msg.id}
+                className={`flex gap-3 py-2.5 border-l-2 pl-4 ml-1 ${
+                  msg.sender_type === "agent" ? "border-accent" : "border-border"
+                }`}
+              >
+                <span className="font-mono text-[11px] text-content-tertiary whitespace-nowrap min-w-[50px]">
+                  {formatRelative(msg.created_at)}
+                </span>
+                <div className="flex-1 min-w-0">
+                  <span className={`text-[11px] font-mono uppercase tracking-wider ${
+                    msg.sender_type === "agent" ? "text-accent" : "text-content-tertiary"
+                  }`}>
+                    {msg.sender_type === "agent" ? session.agent_name : "human"}
+                  </span>
+                  <p className={`text-[13px] mt-0.5 whitespace-pre-wrap break-words ${
+                    msg.sender_type === "agent"
+                      ? "font-mono text-xs text-content-secondary"
+                      : "text-content-primary"
+                  }`}>
+                    {msg.content}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -91,7 +91,7 @@ export abstract class ApiClient {
     return this.request("DELETE", `/api/agents/${agentId}/sessions/${sessionId}`);
   }
   listAgents() { return this.request("GET", "/api/agents"); }
-  createAgent(input: { name: string; bio?: string; soul?: string; role?: string; handoff_to?: string[]; runtime?: string; model?: string; skills?: string[] }) {
+  createAgent(input: { username: string; name: string; bio?: string; soul?: string; role?: string; handoff_to?: string[]; runtime?: string; model?: string; skills?: string[] }) {
     return this.request("POST", "/api/agents", input);
   }
 

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -127,6 +127,11 @@ export abstract class ApiClient {
     const qs = since ? `?since=${encodeURIComponent(since)}` : "";
     return this.request<any[]>("GET", `/api/tasks/${taskId}/messages${qs}`);
   }
+
+  // Task Checks
+  getChecks(taskId: string) {
+    return this.request<any[]>("GET", `/api/tasks/${taskId}/checks`);
+  }
 }
 
 export class MachineClient extends ApiClient {

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -231,6 +231,11 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
 
       await pm.spawnAgent(task.id, sessionId, repoDir, taskContext, agentClient, agentEnv, systemPromptFile);
 
+      // Check for in_review tasks needing a reviewer agent
+      if (pm.activeCount < opts.maxConcurrent) {
+        await pollReviewTasks(client, pm, opts);
+      }
+
       backoffMs = baseInterval;
       schedulePoll(baseInterval);
 
@@ -355,6 +360,132 @@ function cloneAndLink(repo: any): void {
 function removePidFile() {
   try { unlinkSync(PID_FILE); } catch { /* ignore */ }
 }
+
+// ─── Reviewer Agent ───
+
+const activeReviewTasks = new Set<string>();
+
+async function pollReviewTasks(
+  client: MachineClient,
+  pm: ProcessManager,
+  opts: DaemonOptions,
+): Promise<void> {
+  const tasks = await client.listTasks({ status: "in_review", has_checks: "true" }) as any[];
+
+  for (const task of tasks) {
+    if (pm.hasTask(task.id) || activeReviewTasks.has(task.id)) continue;
+    if (!task.repository_id) continue;
+
+    const repoDir = findPathForRepository(task.repository_id);
+    if (!repoDir) continue;
+
+    // Check review_rounds vs board max
+    const board = await client.getBoard(task.board_id) as any;
+    const maxRounds = board?.max_review_rounds ?? 3;
+    if (task.review_rounds >= maxRounds) continue;
+
+    // Find a reviewer agent (role="reviewer")
+    const agents = await client.listAgents() as any[];
+    const reviewer = agents.find((a: any) => a.role === "reviewer");
+    if (!reviewer) continue;
+
+    activeReviewTasks.add(task.id);
+
+    // Create session for reviewer
+    const sessionId = randomUUID();
+    const { publicKey, privateKey } = await crypto.subtle.generateKey(
+      { name: "Ed25519" } as any, true, ["sign", "verify"],
+    );
+    const pubKeyJwk = await crypto.subtle.exportKey("jwk", publicKey);
+    const privKeyJwk = await crypto.subtle.exportKey("jwk", privateKey);
+
+    try {
+      await client.createSession(reviewer.id, sessionId, pubKeyJwk.x!);
+    } catch {
+      activeReviewTasks.delete(task.id);
+      continue;
+    }
+
+    console.log(`[INFO] Spawning reviewer (session=${sessionId.slice(0, 8)}) for task ${task.id}`);
+
+    const agentClient = new AgentClient(
+      getConfigValue("api-url")!,
+      reviewer.id,
+      sessionId,
+      privateKey,
+    );
+
+    const agentEnv = {
+      AK_AGENT_ID: reviewer.id,
+      AK_SESSION_ID: sessionId,
+      AK_AGENT_KEY: JSON.stringify(privKeyJwk),
+      AK_API_URL: getConfigValue("api-url")!,
+    };
+
+    // Build review-specific task context
+    const checks = await client.getChecks(task.id) as any[];
+    const checkDescriptions = Array.isArray(checks) && checks.length > 0
+      ? checks.map((c: any, i: number) => `${i + 1}. [${c.id}] ${c.description}`).join("\n")
+      : "No checks found.";
+
+    const reviewPrompt = generateReviewerSystemPrompt(reviewer);
+    const systemPromptFile = writePromptFile(sessionId, reviewPrompt);
+
+    const taskContext = [
+      `Task ID: ${task.id}`,
+      `Title: ${task.title}`,
+      task.description ? `Description: ${task.description}` : null,
+      task.pr_url ? `PR URL: ${task.pr_url}` : null,
+      `Review Round: ${task.review_rounds + 1}/${maxRounds}`,
+      ``,
+      `Verification Checks:`,
+      checkDescriptions,
+    ].filter((s) => s !== null).join("\n");
+
+    await pm.spawnAgent(task.id, sessionId, repoDir, taskContext, agentClient, agentEnv, systemPromptFile);
+
+    // Clean up tracking when process exits
+    const checkCleanup = setInterval(() => {
+      if (!pm.hasTask(task.id)) {
+        activeReviewTasks.delete(task.id);
+        clearInterval(checkCleanup);
+      }
+    }, 5000);
+
+    if (pm.activeCount >= opts.maxConcurrent) break;
+  }
+}
+
+function generateReviewerSystemPrompt(agent: { name: string; role: string | null; soul: string | null }): string {
+  return `# Reviewer Agent Protocol
+
+You are a code reviewer on the Agent Kanban platform.
+You verify tasks by checking each verification item against the actual code changes.
+
+## Review Process
+
+1. **Claim** the task: \`ak task claim <task-id>\`
+2. **Inspect** the PR: check out the branch, review the diff
+3. **Verify** each check item using: \`ak task verify <task-id> <check-id> --passed\` or \`ak task verify <task-id> <check-id> --failed\`
+4. If all checks pass, the task auto-completes
+5. If any check fails, the task bounces back to the original agent with feedback
+
+## Rules
+
+- Always claim before reviewing.
+- Verify every check item — do not skip any.
+- Be thorough but fair. Only fail checks that genuinely do not pass.
+- Log your findings: \`ak task log <task-id> "message"\`
+
+# Your Identity
+
+Name: ${agent.name}
+Role: ${agent.role ?? "reviewer"}
+
+${agent.soul ?? ""}
+`.trim() + "\n";
+}
+
 
 function detectRuntimes(): string[] {
   const commands: [string, string][] = [

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -193,6 +193,7 @@ agentCmd
   .command("create")
   .description("Create a new agent (from template or manual)")
   .option("--template <slug>", "Agent template slug (e.g. fullstack-developer, feature-planner)")
+  .option("--username <username>", "Agent username (lowercase, for @mentions)")
   .option("--name <name>", "Agent name")
   .option("--bio <bio>", "Agent bio")
   .option("--role <role>", "Agent role")
@@ -206,7 +207,9 @@ agentCmd
 
     if (opts.template) {
       const template = await fetchTemplate(opts.template);
+      const username = opts.username || template.role || template.name.toLowerCase().replace(/[^a-z0-9_-]/g, "-");
       body = {
+        username,
         name: opts.name || template.name,
         bio: template.bio,
         soul: template.soul,
@@ -221,7 +224,11 @@ agentCmd
         console.error("Either --template or --name is required");
         process.exit(1);
       }
-      body = { name: opts.name };
+      if (!opts.username) {
+        console.error("--username is required");
+        process.exit(1);
+      }
+      body = { username: opts.username, name: opts.name };
       if (opts.bio) body.bio = opts.bio;
       if (opts.role) body.role = opts.role;
       if (opts.runtime) body.runtime = opts.runtime;

--- a/packages/cli/src/processManager.ts
+++ b/packages/cli/src/processManager.ts
@@ -16,6 +16,8 @@ export interface AgentProcess {
   process: ChildProcess;
   agentClient: AgentClient;
   timeoutTimer?: ReturnType<typeof setTimeout>;
+  lastMessageSeen?: string;
+  messagePollTimer?: ReturnType<typeof setTimeout>;
 }
 
 export class ProcessManager {
@@ -24,12 +26,14 @@ export class ProcessManager {
   private agentCli: string;
   private onSlotFreed: () => void;
   private taskTimeoutMs: number;
+  private messagePollIntervalMs: number;
 
-  constructor(client: ApiClient, agentCli: string, onSlotFreed: () => void, taskTimeoutMs = 2 * 60 * 60 * 1000) {
+  constructor(client: ApiClient, agentCli: string, onSlotFreed: () => void, taskTimeoutMs = 2 * 60 * 60 * 1000, messagePollIntervalMs = 5000) {
     this.client = client;
     this.agentCli = agentCli;
     this.onSlotFreed = onSlotFreed;
     this.taskTimeoutMs = taskTimeoutMs;
+    this.messagePollIntervalMs = messagePollIntervalMs;
   }
 
   get activeCount(): number {
@@ -97,7 +101,7 @@ export class ProcessManager {
         message: { role: "user", content: taskContext },
       });
       proc.stdin?.write(payload + "\n");
-      proc.stdin?.end();
+      this.startMessagePolling(agent);
     });
 
     let stdoutBuffer = "";
@@ -122,6 +126,7 @@ export class ProcessManager {
 
     proc.on("close", async (code) => {
       if (agent.timeoutTimer) clearTimeout(agent.timeoutTimer);
+      if (agent.messagePollTimer) clearTimeout(agent.messagePollTimer);
       cleanupPromptFile(sessionId);
 
       if (stdoutBuffer.trim()) {
@@ -150,6 +155,7 @@ export class ProcessManager {
     proc.on("error", async (err) => {
       console.error(`[ERROR] Agent process error for task ${taskId}: ${err.message}`);
       if (agent.timeoutTimer) clearTimeout(agent.timeoutTimer);
+      if (agent.messagePollTimer) clearTimeout(agent.messagePollTimer);
       this.agents.delete(taskId);
       await this.releaseTask(taskId);
       this.onSlotFreed();
@@ -163,9 +169,39 @@ export class ProcessManager {
     for (const [taskId, agent] of entries) {
       console.log(`[INFO] Killing agent for task ${taskId}`);
       if (agent.timeoutTimer) clearTimeout(agent.timeoutTimer);
+      if (agent.messagePollTimer) clearTimeout(agent.messagePollTimer);
       agent.process.kill("SIGTERM");
       this.agents.delete(taskId);
       await this.releaseTask(taskId);
+    }
+  }
+
+  private startMessagePolling(agent: AgentProcess): void {
+    const poll = async () => {
+      if (!this.agents.has(agent.taskId)) return;
+      await this.pollMessages(agent);
+      if (this.agents.has(agent.taskId)) {
+        agent.messagePollTimer = setTimeout(poll, this.messagePollIntervalMs);
+      }
+    };
+    agent.messagePollTimer = setTimeout(poll, this.messagePollIntervalMs);
+  }
+
+  private async pollMessages(agent: AgentProcess): Promise<void> {
+    try {
+      const messages = await agent.agentClient.getMessages(agent.taskId, agent.lastMessageSeen) as any[];
+      const userMessages = messages.filter((m: any) => m.sender_type === "user");
+
+      for (const msg of userMessages) {
+        const payload = JSON.stringify({
+          type: "user",
+          message: { role: "user", content: msg.content },
+        });
+        agent.process.stdin?.write(payload + "\n");
+        agent.lastMessageSeen = msg.created_at;
+      }
+    } catch (err: any) {
+      console.error(`[WARN] Message poll failed for task ${agent.taskId}: ${err.message}`);
     }
   }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -5,6 +5,7 @@ export interface Board {
   owner_id: string;
   name: string;
   description: string | null;
+  max_review_rounds: number;
   created_at: string;
   updated_at: string;
 }
@@ -32,6 +33,7 @@ export interface Task {
   pr_url: string | null;
   input: string | null;
   created_from: string | null;
+  review_rounds: number;
   position: number;
   created_at: string;
   updated_at: string;
@@ -117,6 +119,7 @@ export type AgentStatus = "online" | "offline";
 export interface Agent {
   id: string;
   owner_id: string;
+  username: string;
   name: string;
   bio: string | null;
   soul: string | null;
@@ -190,6 +193,33 @@ export interface Message {
   created_at: string;
 }
 
+// ─── Comment ───
+
+export type AuthorType = "user" | "agent";
+
+export interface Comment {
+  id: string;
+  task_id: string;
+  author_type: AuthorType;
+  author_id: string;
+  content: string;
+  mentions: string | null;
+  created_at: string;
+}
+
+// ─── Task Check ───
+
+export interface TaskCheck {
+  id: string;
+  task_id: string;
+  description: string;
+  passed: number;
+  verified_by: string | null;
+  verified_at: string | null;
+  sort_order: number;
+  created_at: string;
+}
+
 // ─── API ───
 
 export interface ErrorEnvelope {
@@ -224,6 +254,7 @@ export interface CompleteTaskInput {
 }
 
 export interface CreateAgentInput {
+  username: string;
   name: string;
   bio?: string;
   soul?: string;

--- a/tests/agent-auth.test.ts
+++ b/tests/agent-auth.test.ts
@@ -84,7 +84,7 @@ describe("agent-auth bridge", () => {
 
   it("creates a persistent agent with keypair", async () => {
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
-    const agent = await createAgent(db, userId, { name: "Test Agent" });
+    const agent = await createAgent(db, userId, { username: "test-agent", name: "Test Agent" });
     agentId = agent.id;
 
     expect(agent.public_key).toBeTruthy();

--- a/tests/agent-redesign.test.ts
+++ b/tests/agent-redesign.test.ts
@@ -97,7 +97,7 @@ describe("agent CRUD", () => {
   it("setup user", async () => {
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
     userId = await seedUser(env.DB, "user-crud", "crud@test.com");
-    const agent = await createAgent(env.DB, userId, { name: "CrudAgent", bio: "test bio", soul: "be helpful", runtime: "claude", model: "opus" });
+    const agent = await createAgent(env.DB, userId, { username: "crudagent", name: "CrudAgent", bio: "test bio", soul: "be helpful", runtime: "claude", model: "opus" });
     agentId = agent.id;
     expect(agent.name).toBe("CrudAgent");
     expect(agent.bio).toBe("test bio");
@@ -114,7 +114,7 @@ describe("agent CRUD", () => {
 
   it("deletes agent", async () => {
     const { createAgent, deleteAgent } = await import("../apps/web/functions/api/agentRepo");
-    const temp = await createAgent(env.DB, userId, { name: "ToDelete" });
+    const temp = await createAgent(env.DB, userId, { username: "todelete", name: "ToDelete" });
     const deleted = await deleteAgent(env.DB, temp.id);
     expect(deleted).toBe(true);
     const row = await env.DB.prepare("SELECT id FROM agents WHERE id = ?").bind(temp.id).first();
@@ -155,7 +155,7 @@ describe("agent status computation", () => {
       forceAllowId: true,
     });
 
-    const agent = await createAgent(env.DB, userId, { name: "StatusAgent" });
+    const agent = await createAgent(env.DB, userId, { username: "statusagent", name: "StatusAgent" });
     agentId = agent.id;
   });
 
@@ -221,7 +221,7 @@ describe("session lifecycle", () => {
       forceAllowId: true,
     });
 
-    const agent = await createAgent(env.DB, userId, { name: "SessionAgent" });
+    const agent = await createAgent(env.DB, userId, { username: "sessionagent", name: "SessionAgent" });
     agentId = agent.id;
   });
 
@@ -280,7 +280,7 @@ describe("message sender model", () => {
     const { createBoard } = await import("../apps/web/functions/api/boardRepo");
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     userId = await seedUser(env.DB, "user-msg", "msg@test.com");
-    const agent = await createAgent(env.DB, userId, { name: "MsgAgent" });
+    const agent = await createAgent(env.DB, userId, { username: "msgagent", name: "MsgAgent" });
     agentId = agent.id;
     const board = await createBoard(env.DB, userId, "msg-board");
     const task = await createTask(env.DB, userId, { title: "Msg task", board_id: board.id });
@@ -365,7 +365,7 @@ describe("user assigns task to agent", () => {
     const { createBoard } = await import("../apps/web/functions/api/boardRepo");
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     userId = await seedUser(env.DB, "user-assign", "assign@test.com");
-    const agent = await createAgent(env.DB, userId, { name: "AssignAgent" });
+    const agent = await createAgent(env.DB, userId, { username: "assignagent", name: "AssignAgent" });
     agentId = agent.id;
     const board = await createBoard(env.DB, userId, "assign-board");
     const task = await createTask(env.DB, userId, { title: "Assign task", board_id: board.id });

--- a/tests/cli-agent-jwt.test.ts
+++ b/tests/cli-agent-jwt.test.ts
@@ -112,7 +112,7 @@ describe("CLI ApiClient agent JWT passthrough", () => {
 
     // Create persistent agent (user-only, use repo directly)
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
-    const agent = await createAgent(testEnv.DB, userId, { name: "JWT Test Agent", runtime: "claude" });
+    const agent = await createAgent(testEnv.DB, userId, { username: "jwt-test-agent", name: "JWT Test Agent", runtime: "claude" });
     agentId = agent.id;
 
     // Create session keypair (CSR — daemon generates locally)

--- a/tests/machine-agent-flow.test.ts
+++ b/tests/machine-agent-flow.test.ts
@@ -114,7 +114,7 @@ describe("machine → agent session flow", () => {
   it("user creates a persistent agent", async () => {
     // Create agent directly via repo (user-only route, no API key auth in test)
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
-    const agent = await createAgent(env.DB, userId, { name: "Test Agent", runtime: "Claude Code", model: "claude-sonnet-4-20250514" });
+    const agent = await createAgent(env.DB, userId, { username: "test-agent", name: "Test Agent", runtime: "Claude Code", model: "claude-sonnet-4-20250514" });
     agentId = agent.id;
     expect(agent.fingerprint).toBeTruthy();
     expect(agent.public_key).toBeTruthy();


### PR DESCRIPTION
## Summary
- Added missing `catch` block to `handleRelease` in `AssignDropdown.tsx`
- Without it, a failed release API call produced an unhandled Promise rejection and the UI silently failed
- Now matches the `handleAssign` error handling pattern (`catch (e: any) { alert(e.message) }`)

Blocker fix for PR #1 (`feat/phase2-daemon-review-session`).

## Test plan
- [ ] Trigger a release API failure (e.g., network error or invalid task state) and verify the error alert appears
- [ ] Verify successful release still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)