### PR TITLE
fix: useMemo, bounded logs, stale closure in SSE

### DIFF
--- a/apps/web/functions/api/sse.ts
+++ b/apps/web/functions/api/sse.ts
@@ -96,7 +96,10 @@ export async function createSSEResponse(
   };
 
   // Run in background — don't await
-  run().catch(() => writer.close().catch(() => {}));
+  run().catch((err) => {
+    console.error("[SSE] stream failed:", err instanceof Error ? err.message : err);
+    writer.close().catch(() => {});
+  });
 
   return new Response(readable, {
     headers: {

--- a/apps/web/src/components/ActivityLog.tsx
+++ b/apps/web/src/components/ActivityLog.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSSE } from "../hooks/useSSE";
 import { formatRelative } from "./TaskDetailFields";
 import { Button } from "./ui/button";
+import type { TaskLog } from "@agent-kanban/shared";
 
 interface ActivityLogProps {
   taskId: string;
-  initialLogs: any[];
+  initialLogs: TaskLog[];
   assigned: boolean;
 }
 
@@ -40,9 +41,9 @@ export function ActivityLog({ taskId, initialLogs, assigned }: ActivityLogProps)
   const [newCount, setNewCount] = useState(0);
 
   // Merge initial logs with SSE logs (dedup by ID)
-  const allLogs = (() => {
+  const allLogs = useMemo(() => {
     const seen = new Set<string>();
-    const merged: any[] = [];
+    const merged: TaskLog[] = [];
     for (const log of [...initialLogs, ...sseLogs]) {
       if (!seen.has(log.id)) {
         seen.add(log.id);
@@ -50,7 +51,7 @@ export function ActivityLog({ taskId, initialLogs, assigned }: ActivityLogProps)
       }
     }
     return merged.sort((a, b) => a.created_at.localeCompare(b.created_at));
-  })();
+  }, [initialLogs, sseLogs]);
 
   const displayed = allLogs.slice().reverse();
 
@@ -106,7 +107,7 @@ export function ActivityLog({ taskId, initialLogs, assigned }: ActivityLogProps)
         className="space-y-0 mt-2 max-h-80 overflow-y-auto"
         aria-live="polite"
       >
-        {displayed.map((log: any) => (
+        {displayed.map((log) => (
           <div
             key={log.id}
             className={`flex gap-3 py-2 border-l-2 pl-4 ml-1 ${

--- a/apps/web/src/components/SubtaskList.tsx
+++ b/apps/web/src/components/SubtaskList.tsx
@@ -8,10 +8,20 @@ interface SubtaskListProps {
 
 export function SubtaskList({ parentId, onTaskClick }: SubtaskListProps) {
   const [subtasks, setSubtasks] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    api.tasks.list({ parent: parentId }).then(setSubtasks).catch(() => {});
+    setError(null);
+    api.tasks.list({ parent: parentId }).then(setSubtasks).catch((err) => {
+      const message = err instanceof Error ? err.message : "Failed to load subtasks";
+      setError(message);
+      console.error("[SubtaskList] fetch failed:", message);
+    });
   }, [parentId]);
+
+  if (error) {
+    return <div className="text-sm text-danger pl-6 md:pl-4">{error}</div>;
+  }
 
   if (subtasks.length === 0) return null;
 

--- a/apps/web/src/hooks/useAgents.ts
+++ b/apps/web/src/hooks/useAgents.ts
@@ -4,16 +4,23 @@ import { api } from "../lib/api";
 export function useAgents() {
   const [agents, setAgents] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
+      setError(null);
       const result = await api.agents.list();
       setAgents(result);
-    } catch { /* ignore */ }
-    finally { setLoading(false); }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to load agents";
+      setError(message);
+      console.error("[useAgents] fetch failed:", message);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => { load(); }, [load]);
 
-  return { agents, loading, refresh: load };
+  return { agents, loading, error, refresh: load };
 }

--- a/apps/web/src/hooks/useSSE.ts
+++ b/apps/web/src/hooks/useSSE.ts
@@ -1,19 +1,28 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { getAuthToken } from "../lib/auth-client";
+import type { TaskLog, Message } from "@agent-kanban/shared";
+
+const MAX_LOGS = 500;
 
 interface UseSSEOptions {
   taskId: string;
   enabled?: boolean;
 }
 
+function appendCapped<T>(prev: T[], item: T): T[] {
+  const next = [...prev, item];
+  return next.length > MAX_LOGS ? next.slice(next.length - MAX_LOGS) : next;
+}
+
 export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
-  const [logs, setLogs] = useState<any[]>([]);
-  const [messages, setMessages] = useState<any[]>([]);
+  const [logs, setLogs] = useState<TaskLog[]>([]);
+  const [messages, setMessages] = useState<Message[]>([]);
   const [connected, setConnected] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
   const failCount = useRef(0);
   const lastEventId = useRef<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
+  const connectRef = useRef<(() => EventSource | undefined) | undefined>(undefined);
 
   const token = getAuthToken();
 
@@ -33,13 +42,13 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
     es.addEventListener("log", (e: MessageEvent) => {
       const log = JSON.parse(e.data);
       lastEventId.current = e.lastEventId;
-      setLogs((prev) => [...prev, log]);
+      setLogs((prev) => appendCapped(prev, log));
     });
 
     es.addEventListener("message", (e: MessageEvent) => {
       const msg = JSON.parse(e.data);
       lastEventId.current = e.lastEventId;
-      setMessages((prev) => [...prev, msg]);
+      setMessages((prev) => appendCapped(prev, msg));
     });
 
     es.onerror = () => {
@@ -53,11 +62,14 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
       }
 
       setReconnecting(true);
-      setTimeout(connectSSE, 2000);
+      setTimeout(() => connectRef.current?.(), 2000);
     };
 
     return es;
   }, [taskId, token, enabled]);
+
+  // Keep ref in sync so setTimeout always calls the latest version
+  connectRef.current = connectSSE;
 
   // Polling fallback
   const poll = useCallback(async () => {

--- a/apps/web/src/hooks/useSSE.ts
+++ b/apps/web/src/hooks/useSSE.ts
@@ -69,7 +69,9 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
       ]);
       if (logsRes.ok) setLogs(await logsRes.json());
       if (msgsRes.ok) setMessages(await msgsRes.json());
-    } catch { /* ignore polling errors */ }
+    } catch (err) {
+      console.error("[useSSE] polling failed:", err instanceof Error ? err.message : err);
+    }
   }, [taskId, token]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **ActivityLog.tsx**: Replace IIFE with `useMemo` for `allLogs` merge — avoids recomputing on unrelated renders
- **useSSE.ts**: Cap logs and messages at 500 entries via `appendCapped` helper to prevent unbounded memory growth
- **useSSE.ts**: Use `connectRef` so `setTimeout` in `onerror` always calls the latest `connectSSE`, fixing stale closure when `taskId` changes

## Test plan
- [ ] Open a task detail page with active agent — verify logs stream in correctly
- [ ] Let logs accumulate past 500 — verify oldest entries are dropped, no memory leak
- [ ] Switch between tasks rapidly — verify reconnect targets the correct task stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)