### PR TITLE
Replace any types with shared types in frontend

### DIFF
--- a/apps/web/functions/api/sse.ts
+++ b/apps/web/functions/api/sse.ts
@@ -96,7 +96,10 @@ export async function createSSEResponse(
   };
 
   // Run in background — don't await
-  run().catch(() => writer.close().catch(() => {}));
+  run().catch((err) => {
+    console.error("[SSE] stream failed:", err instanceof Error ? err.message : err);
+    writer.close().catch(() => {});
+  });
 
   return new Response(readable, {
     headers: {

--- a/apps/web/src/components/ActivityLog.tsx
+++ b/apps/web/src/components/ActivityLog.tsx
@@ -1,11 +1,12 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSSE } from "../hooks/useSSE";
 import { formatRelative } from "./TaskDetailFields";
 import { Button } from "./ui/button";
+import type { TaskLog } from "@agent-kanban/shared";
 
 interface ActivityLogProps {
   taskId: string;
-  initialLogs: any[];
+  initialLogs: TaskLog[];
   assigned: boolean;
 }
 
@@ -40,9 +41,9 @@ export function ActivityLog({ taskId, initialLogs, assigned }: ActivityLogProps)
   const [newCount, setNewCount] = useState(0);
 
   // Merge initial logs with SSE logs (dedup by ID)
-  const allLogs = (() => {
+  const allLogs = useMemo(() => {
     const seen = new Set<string>();
-    const merged: any[] = [];
+    const merged: TaskLog[] = [];
     for (const log of [...initialLogs, ...sseLogs]) {
       if (!seen.has(log.id)) {
         seen.add(log.id);
@@ -50,7 +51,7 @@ export function ActivityLog({ taskId, initialLogs, assigned }: ActivityLogProps)
       }
     }
     return merged.sort((a, b) => a.created_at.localeCompare(b.created_at));
-  })();
+  }, [initialLogs, sseLogs]);
 
   const displayed = allLogs.slice().reverse();
 
@@ -106,7 +107,7 @@ export function ActivityLog({ taskId, initialLogs, assigned }: ActivityLogProps)
         className="space-y-0 mt-2 max-h-80 overflow-y-auto"
         aria-live="polite"
       >
-        {displayed.map((log: any) => (
+        {displayed.map((log) => (
           <div
             key={log.id}
             className={`flex gap-3 py-2 border-l-2 pl-4 ml-1 ${

--- a/apps/web/src/components/AgentProfile.tsx
+++ b/apps/web/src/components/AgentProfile.tsx
@@ -7,6 +7,11 @@ import { Button } from "./ui/button";
 import { Sheet, SheetContent, SheetTitle, SheetDescription } from "./ui/sheet";
 import { Separator } from "./ui/separator";
 import { Skeleton } from "./ui/skeleton";
+import type { AgentWithActivity, TaskLog } from "@agent-kanban/shared";
+
+interface AgentActivityLog extends TaskLog {
+  task_title?: string;
+}
 
 interface AgentProfileProps {
   agentId: string;
@@ -33,7 +38,7 @@ const actionStyles: Record<string, string> = {
 };
 
 export function AgentProfile({ agentId, onClose, onTaskClick }: AgentProfileProps) {
-  const [agent, setAgent] = useState<any>(null);
+  const [agent, setAgent] = useState<(AgentWithActivity & { logs?: AgentActivityLog[] }) | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -94,7 +99,7 @@ export function AgentProfile({ agentId, onClose, onTaskClick }: AgentProfileProp
               <div>
                 <div className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide mb-2">Activity</div>
                 <div className="space-y-0 max-h-96 overflow-y-auto">
-                  {(agent.logs || []).map((log: any) => (
+                  {(agent.logs || []).map((log) => (
                     <div
                       key={log.id}
                       className="flex gap-3 py-2 border-l-2 pl-4 ml-1 border-border"

--- a/apps/web/src/components/SubtaskList.tsx
+++ b/apps/web/src/components/SubtaskList.tsx
@@ -8,10 +8,20 @@ interface SubtaskListProps {
 
 export function SubtaskList({ parentId, onTaskClick }: SubtaskListProps) {
   const [subtasks, setSubtasks] = useState<any[]>([]);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    api.tasks.list({ parent: parentId }).then(setSubtasks).catch(() => {});
+    setError(null);
+    api.tasks.list({ parent: parentId }).then(setSubtasks).catch((err) => {
+      const message = err instanceof Error ? err.message : "Failed to load subtasks";
+      setError(message);
+      console.error("[SubtaskList] fetch failed:", message);
+    });
   }, [parentId]);
+
+  if (error) {
+    return <div className="text-sm text-danger pl-6 md:pl-4">{error}</div>;
+  }
 
   if (subtasks.length === 0) return null;
 

--- a/apps/web/src/components/SubtaskList.tsx
+++ b/apps/web/src/components/SubtaskList.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { api } from "../lib/api";
+import type { Task } from "@agent-kanban/shared";
 
 interface SubtaskListProps {
   parentId: string;
@@ -7,7 +8,7 @@ interface SubtaskListProps {
 }
 
 export function SubtaskList({ parentId, onTaskClick }: SubtaskListProps) {
-  const [subtasks, setSubtasks] = useState<any[]>([]);
+  const [subtasks, setSubtasks] = useState<Task[]>([]);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {

--- a/apps/web/src/hooks/useAgents.ts
+++ b/apps/web/src/hooks/useAgents.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
 import { api } from "../lib/api";
+import type { AgentWithActivity } from "@agent-kanban/shared";
 
 export function useAgents() {
-  const [agents, setAgents] = useState<any[]>([]);
+  const [agents, setAgents] = useState<AgentWithActivity[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/apps/web/src/hooks/useAgents.ts
+++ b/apps/web/src/hooks/useAgents.ts
@@ -4,16 +4,23 @@ import { api } from "../lib/api";
 export function useAgents() {
   const [agents, setAgents] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
     try {
+      setError(null);
       const result = await api.agents.list();
       setAgents(result);
-    } catch { /* ignore */ }
-    finally { setLoading(false); }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to load agents";
+      setError(message);
+      console.error("[useAgents] fetch failed:", message);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => { load(); }, [load]);
 
-  return { agents, loading, refresh: load };
+  return { agents, loading, error, refresh: load };
 }

--- a/apps/web/src/hooks/useSSE.ts
+++ b/apps/web/src/hooks/useSSE.ts
@@ -1,19 +1,28 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { getAuthToken } from "../lib/auth-client";
+import type { TaskLog, Message } from "@agent-kanban/shared";
+
+const MAX_LOGS = 500;
 
 interface UseSSEOptions {
   taskId: string;
   enabled?: boolean;
 }
 
+function appendCapped<T>(prev: T[], item: T): T[] {
+  const next = [...prev, item];
+  return next.length > MAX_LOGS ? next.slice(next.length - MAX_LOGS) : next;
+}
+
 export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
-  const [logs, setLogs] = useState<any[]>([]);
-  const [messages, setMessages] = useState<any[]>([]);
+  const [logs, setLogs] = useState<TaskLog[]>([]);
+  const [messages, setMessages] = useState<Message[]>([]);
   const [connected, setConnected] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
   const failCount = useRef(0);
   const lastEventId = useRef<string | null>(null);
   const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
+  const connectRef = useRef<(() => EventSource | undefined) | undefined>(undefined);
 
   const token = getAuthToken();
 
@@ -33,13 +42,13 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
     es.addEventListener("log", (e: MessageEvent) => {
       const log = JSON.parse(e.data);
       lastEventId.current = e.lastEventId;
-      setLogs((prev) => [...prev, log]);
+      setLogs((prev) => appendCapped(prev, log));
     });
 
     es.addEventListener("message", (e: MessageEvent) => {
       const msg = JSON.parse(e.data);
       lastEventId.current = e.lastEventId;
-      setMessages((prev) => [...prev, msg]);
+      setMessages((prev) => appendCapped(prev, msg));
     });
 
     es.onerror = () => {
@@ -53,11 +62,14 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
       }
 
       setReconnecting(true);
-      setTimeout(connectSSE, 2000);
+      setTimeout(() => connectRef.current?.(), 2000);
     };
 
     return es;
   }, [taskId, token, enabled]);
+
+  // Keep ref in sync so setTimeout always calls the latest version
+  connectRef.current = connectSSE;
 
   // Polling fallback
   const poll = useCallback(async () => {

--- a/apps/web/src/hooks/useSSE.ts
+++ b/apps/web/src/hooks/useSSE.ts
@@ -69,7 +69,9 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
       ]);
       if (logsRes.ok) setLogs(await logsRes.json());
       if (msgsRes.ok) setMessages(await msgsRes.json());
-    } catch { /* ignore polling errors */ }
+    } catch (err) {
+      console.error("[useSSE] polling failed:", err instanceof Error ? err.message : err);
+    }
   }, [taskId, token]);
 
   useEffect(() => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,6 +1,24 @@
 import { getAuthToken } from "./auth-client";
+import type {
+  Task,
+  TaskWithLogs,
+  TaskLog,
+  Message,
+  AgentWithActivity,
+  AgentSession,
+  MachineWithAgents,
+  Board,
+  BoardWithTasks,
+  Repository,
+  CreateTaskInput,
+} from "@agent-kanban/shared";
 
 const API_BASE = "/api";
+
+interface ApiError extends Error {
+  code: string;
+  status: number;
+}
 
 async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
   const token = getAuthToken();
@@ -15,12 +33,13 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
     body: body ? JSON.stringify(body) : undefined,
   });
 
-  const data = await res.json() as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- response shape varies per endpoint
+  const data: any = await res.json();
 
   if (!res.ok) {
-    const err = new Error(data.error?.message || `HTTP ${res.status}`);
-    (err as any).code = data.error?.code || "UNKNOWN";
-    (err as any).status = res.status;
+    const err = new Error(data.error?.message || `HTTP ${res.status}`) as ApiError;
+    err.code = data.error?.code || "UNKNOWN";
+    err.status = res.status;
     throw err;
   }
 
@@ -31,57 +50,57 @@ export const api = {
   tasks: {
     list: (params?: Record<string, string>) => {
       const qs = params ? "?" + new URLSearchParams(params).toString() : "";
-      return request<any[]>("GET", `/tasks${qs}`);
+      return request<Task[]>("GET", `/tasks${qs}`);
     },
-    get: (id: string) => request<any>("GET", `/tasks/${id}`),
-    create: (input: Record<string, unknown>) => request<any>("POST", "/tasks", input),
-    update: (id: string, body: Record<string, unknown>) => request<any>("PATCH", `/tasks/${id}`, body),
+    get: (id: string) => request<TaskWithLogs>("GET", `/tasks/${id}`),
+    create: (input: CreateTaskInput) => request<Task>("POST", "/tasks", input),
+    update: (id: string, body: Record<string, unknown>) => request<Task>("PATCH", `/tasks/${id}`, body),
     delete: (id: string) => request<void>("DELETE", `/tasks/${id}`),
-    claim: (id: string) => request<any>("POST", `/tasks/${id}/claim`),
-    complete: (id: string, body?: Record<string, unknown>) => request<any>("POST", `/tasks/${id}/complete`, body),
-    release: (id: string) => request<any>("POST", `/tasks/${id}/release`),
-    cancel: (id: string) => request<any>("POST", `/tasks/${id}/cancel`),
-    review: (id: string) => request<any>("POST", `/tasks/${id}/review`),
-    reject: (id: string) => request<any>("POST", `/tasks/${id}/reject`),
-    assign: (id: string, agentId: string) => request<any>("POST", `/tasks/${id}/assign`, { agent_id: agentId }),
-    addLog: (id: string, detail: string) => request<any>("POST", `/tasks/${id}/logs`, { detail }),
+    claim: (id: string) => request<Task>("POST", `/tasks/${id}/claim`),
+    complete: (id: string, body?: Record<string, unknown>) => request<Task>("POST", `/tasks/${id}/complete`, body),
+    release: (id: string) => request<Task>("POST", `/tasks/${id}/release`),
+    cancel: (id: string) => request<Task>("POST", `/tasks/${id}/cancel`),
+    review: (id: string) => request<Task>("POST", `/tasks/${id}/review`),
+    reject: (id: string) => request<Task>("POST", `/tasks/${id}/reject`),
+    assign: (id: string, agentId: string) => request<Task>("POST", `/tasks/${id}/assign`, { agent_id: agentId }),
+    addLog: (id: string, detail: string) => request<TaskLog>("POST", `/tasks/${id}/logs`, { detail }),
     getLogs: (id: string, since?: string) => {
       const qs = since ? `?since=${encodeURIComponent(since)}` : "";
-      return request<any[]>("GET", `/tasks/${id}/logs${qs}`);
+      return request<TaskLog[]>("GET", `/tasks/${id}/logs${qs}`);
     },
   },
   messages: {
     list: (taskId: string, since?: string) => {
       const qs = since ? `?since=${encodeURIComponent(since)}` : "";
-      return request<any[]>("GET", `/tasks/${taskId}/messages${qs}`);
+      return request<Message[]>("GET", `/tasks/${taskId}/messages${qs}`);
     },
     create: (taskId: string, body: { sender_type: string; sender_id: string; content: string }) =>
-      request<any>("POST", `/tasks/${taskId}/messages`, body),
+      request<Message>("POST", `/tasks/${taskId}/messages`, body),
   },
   agents: {
-    list: () => request<any[]>("GET", "/agents"),
-    get: (id: string) => request<any>("GET", `/agents/${id}`),
+    list: () => request<AgentWithActivity[]>("GET", "/agents"),
+    get: (id: string) => request<AgentWithActivity>("GET", `/agents/${id}`),
     create: (input: { name: string; bio?: string; soul?: string; role?: string; handoff_to?: string[]; runtime?: string; model?: string; skills?: string[] }) =>
-      request<any>("POST", "/agents", input),
-    update: (id: string, body: Record<string, unknown>) => request<any>("PATCH", `/agents/${id}`, body),
+      request<AgentWithActivity>("POST", "/agents", input),
+    update: (id: string, body: Record<string, unknown>) => request<AgentWithActivity>("PATCH", `/agents/${id}`, body),
     delete: (id: string) => request<void>("DELETE", `/agents/${id}`),
-    sessions: (agentId: string) => request<any[]>("GET", `/agents/${agentId}/sessions`),
+    sessions: (agentId: string) => request<AgentSession[]>("GET", `/agents/${agentId}/sessions`),
   },
   machines: {
-    list: () => request<any[]>("GET", "/machines"),
-    get: (id: string) => request<any>("GET", `/machines/${id}`),
+    list: () => request<MachineWithAgents[]>("GET", "/machines"),
+    get: (id: string) => request<MachineWithAgents>("GET", `/machines/${id}`),
     delete: (id: string) => request<void>("DELETE", `/machines/${id}`),
   },
   boards: {
-    list: () => request<any[]>("GET", "/boards"),
-    get: (id: string) => request<any>("GET", `/boards/${id}`),
-    create: (input: { name: string; description?: string }) => request<any>("POST", "/boards", input),
-    update: (id: string, body: { name?: string; description?: string }) => request<any>("PATCH", `/boards/${id}`, body),
+    list: () => request<Board[]>("GET", "/boards"),
+    get: (id: string) => request<BoardWithTasks>("GET", `/boards/${id}`),
+    create: (input: { name: string; description?: string }) => request<Board>("POST", "/boards", input),
+    update: (id: string, body: { name?: string; description?: string }) => request<Board>("PATCH", `/boards/${id}`, body),
     delete: (id: string) => request<void>("DELETE", `/boards/${id}`),
   },
   repositories: {
-    list: () => request<any[]>("GET", "/repositories"),
-    create: (input: { name: string; url: string }) => request<any>("POST", "/repositories", input),
+    list: () => request<Repository[]>("GET", "/repositories"),
+    create: (input: { name: string; url: string }) => request<Repository>("POST", "/repositories", input),
     delete: (id: string) => request<void>("DELETE", `/repositories/${id}`),
   },
 };

--- a/apps/web/src/routes/AgentDetailPage.tsx
+++ b/apps/web/src/routes/AgentDetailPage.tsx
@@ -139,7 +139,8 @@ export function AgentDetailPage() {
                     {agent.name}
                   </h1>
                   {agent.builtin ? (
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" className="text-content-tertiary shrink-0" title="Built-in — cannot be modified">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" className="text-content-tertiary shrink-0">
+                      <title>Built-in — cannot be modified</title>
                       <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
                       <path d="M7 11V7a5 5 0 0 1 10 0v4" />
                     </svg>


### PR DESCRIPTION
## Summary
- Replace all `any` type parameters in `api.ts` with proper shared types (`Task`, `TaskWithLogs`, `TaskLog`, `Message`, `AgentWithActivity`, `AgentSession`, `MachineWithAgents`, `Board`, `BoardWithTasks`, `Repository`, `CreateTaskInput`)
- Add `ApiError` interface to replace `(err as any)` casting in the request function
- Type `useAgents` hook state as `AgentWithActivity[]`
- Type `AgentProfile` component state with `AgentWithActivity` and extended `AgentActivityLog` for task-title-enriched logs
- Type `SubtaskList` state as `Task[]`

## Test plan
- [x] `tsc --noEmit` passes (no new errors introduced)
- [ ] Verify board page loads and tasks render correctly
- [ ] Verify agent profile panel opens with activity logs
- [ ] Verify subtask list renders in task detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)