### PR TITLE
fix: return 400 when SSE Last-Event-ID cannot be resolved

### DIFF
--- a/apps/web/functions/api/sse.ts
+++ b/apps/web/functions/api/sse.ts
@@ -1,18 +1,19 @@
-import type { D1 } from "./db";
-import type { Env } from "./types";
-import { getTaskLogs } from "./taskRepo";
-import { listMessages } from "./messageRepo";
+import type { D1 } from './db';
+import type { Env } from './types';
+import { getTaskLogs } from './taskRepo';
+import { listMessages } from './messageRepo';
 
 interface SSEEvent {
   id: string;
-  type: "log" | "message";
+  type: 'log' | 'message';
   data: string;
   created_at: string;
 }
 
 function mergeByTime(logs: SSEEvent[], messages: SSEEvent[]): SSEEvent[] {
   const merged: SSEEvent[] = [];
-  let i = 0, j = 0;
+  let i = 0,
+    j = 0;
   while (i < logs.length && j < messages.length) {
     if (logs[i].created_at <= messages[j].created_at) merged.push(logs[i++]);
     else merged.push(messages[j++]);
@@ -29,6 +30,29 @@ export async function createSSEResponse(
 ): Promise<Response> {
   const db = env.DB;
 
+  // Resolve lastEventId before creating the stream
+  let since: string | undefined;
+  if (lastEventId) {
+    const ref = await db
+      .prepare(
+        'SELECT created_at FROM task_logs WHERE id = ? UNION SELECT created_at FROM messages WHERE id = ?',
+      )
+      .bind(lastEventId, lastEventId)
+      .first<{ created_at: string }>();
+    if (!ref) {
+      return Response.json(
+        {
+          error: {
+            code: 'INVALID_LAST_EVENT_ID',
+            message: 'Unknown event ID, reconnect without Last-Event-ID',
+          },
+        },
+        { status: 400 },
+      );
+    }
+    since = ref.created_at;
+  }
+
   const { readable, writable } = new TransformStream();
   const writer = writable.getWriter();
   const encoder = new TextEncoder();
@@ -41,33 +65,33 @@ export async function createSSEResponse(
   };
 
   const run = async () => {
-    // Resolve lastEventId to a timestamp for since-based filtering
-    let since: string | undefined;
-    if (lastEventId) {
-      const ref = await db.prepare(
-        "SELECT created_at FROM task_logs WHERE id = ? UNION SELECT created_at FROM messages WHERE id = ?",
-      ).bind(lastEventId, lastEventId).first<{ created_at: string }>();
-      since = ref?.created_at;
-    }
-
     const [initialLogs, initialMessages] = await Promise.all([
       getTaskLogs(db, taskId, since),
       listMessages(db, taskId, since),
     ]);
 
-    const logEvents: SSEEvent[] = (since ? initialLogs : initialLogs.slice(-50))
-      .map((l) => ({ id: l.id, type: "log" as const, data: JSON.stringify(l), created_at: l.created_at }));
-    const msgEvents: SSEEvent[] = (since ? initialMessages : initialMessages.slice(-50))
-      .map((m) => ({ id: m.id, type: "message" as const, data: JSON.stringify(m), created_at: m.created_at }));
+    const logEvents: SSEEvent[] = (since ? initialLogs : initialLogs.slice(-50)).map((l) => ({
+      id: l.id,
+      type: 'log' as const,
+      data: JSON.stringify(l),
+      created_at: l.created_at,
+    }));
+    const msgEvents: SSEEvent[] = (since ? initialMessages : initialMessages.slice(-50)).map(
+      (m) => ({
+        id: m.id,
+        type: 'message' as const,
+        data: JSON.stringify(m),
+        created_at: m.created_at,
+      }),
+    );
 
     const batch = mergeByTime(logEvents, msgEvents);
     for (const event of batch) {
       await write(event);
     }
 
-    let lastSeen = batch.length > 0
-      ? batch[batch.length - 1].created_at
-      : (since || new Date().toISOString());
+    let lastSeen =
+      batch.length > 0 ? batch[batch.length - 1].created_at : since || new Date().toISOString();
 
     // Poll every 2s for up to 25s (CF Workers 30s limit)
     const deadline = Date.now() + 25000;
@@ -79,8 +103,18 @@ export async function createSSEResponse(
         listMessages(db, taskId, lastSeen),
       ]);
 
-      const newLogEvents = newLogs.map((l) => ({ id: l.id, type: "log" as const, data: JSON.stringify(l), created_at: l.created_at }));
-      const newMsgEvents = newMessages.map((m) => ({ id: m.id, type: "message" as const, data: JSON.stringify(m), created_at: m.created_at }));
+      const newLogEvents = newLogs.map((l) => ({
+        id: l.id,
+        type: 'log' as const,
+        data: JSON.stringify(l),
+        created_at: l.created_at,
+      }));
+      const newMsgEvents = newMessages.map((m) => ({
+        id: m.id,
+        type: 'message' as const,
+        data: JSON.stringify(m),
+        created_at: m.created_at,
+      }));
       const merged = mergeByTime(newLogEvents, newMsgEvents);
 
       for (const event of merged) {
@@ -100,9 +134,9 @@ export async function createSSEResponse(
 
   return new Response(readable, {
     headers: {
-      "Content-Type": "text/event-stream",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
     },
   });
 }

--- a/tests/sse.test.ts
+++ b/tests/sse.test.ts
@@ -1,14 +1,14 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
-import { createTestEnv, setupMiniflare, seedUser } from "./helpers/db";
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { Miniflare } from 'miniflare';
+import { createTestEnv, setupMiniflare, seedUser } from './helpers/db';
 
 const env = createTestEnv();
 let mf: Miniflare;
 
 beforeAll(async () => {
   ({ mf, db: env.DB } = await setupMiniflare());
-  await seedUser(env.DB, "sse-user", "sse@test.com");
+  await seedUser(env.DB, 'sse-user', 'sse@test.com');
 });
 
 afterAll(async () => {
@@ -23,13 +23,13 @@ async function readSSEUntil(
 ): Promise<string> {
   const reader = body.getReader();
   const decoder = new TextDecoder();
-  let text = "";
+  let text = '';
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const result = await Promise.race([
       reader.read(),
       new Promise<{ done: true; value: undefined }>((resolve) =>
-        setTimeout(() => resolve({ done: true, value: undefined }), readTimeoutMs)
+        setTimeout(() => resolve({ done: true, value: undefined }), readTimeoutMs),
       ),
     ]);
     if (result.value) {
@@ -41,156 +41,178 @@ async function readSSEUntil(
   return text;
 }
 
-describe("createSSEResponse", () => {
+describe('createSSEResponse', () => {
   let boardId: string;
   let taskId: string;
 
   beforeAll(async () => {
-    const { createBoard } = await import("../apps/web/functions/api/boardRepo");
-    const board = await createBoard(env.DB, "sse-user", "SSE Board");
+    const { createBoard } = await import('../apps/web/functions/api/boardRepo');
+    const board = await createBoard(env.DB, 'sse-user', 'SSE Board');
     boardId = board.id;
 
-    const { createTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, "sse-user", { title: "SSE Task", board_id: boardId });
+    const { createTask } = await import('../apps/web/functions/api/taskRepo');
+    const task = await createTask(env.DB, 'sse-user', { title: 'SSE Task', board_id: boardId });
     taskId = task.id;
   });
 
-  it("returns a Response with correct SSE headers", async () => {
-    const { createSSEResponse } = await import("../apps/web/functions/api/sse");
+  it('returns a Response with correct SSE headers', async () => {
+    const { createSSEResponse } = await import('../apps/web/functions/api/sse');
     const response = await createSSEResponse(env as any, taskId, null);
     expect(response).toBeInstanceOf(Response);
-    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
-    expect(response.headers.get("Cache-Control")).toBe("no-cache");
-    expect(response.headers.get("Connection")).toBe("keep-alive");
+    expect(response.headers.get('Content-Type')).toBe('text/event-stream');
+    expect(response.headers.get('Cache-Control')).toBe('no-cache');
+    expect(response.headers.get('Connection')).toBe('keep-alive');
   });
 
-  it("streams initial logs as SSE events", async () => {
-    const { addTaskLog } = await import("../apps/web/functions/api/taskRepo");
-    await addTaskLog(env.DB, taskId, null, "commented", "Log entry 1");
-    await addTaskLog(env.DB, taskId, null, "commented", "Log entry 2");
+  it('streams initial logs as SSE events', async () => {
+    const { addTaskLog } = await import('../apps/web/functions/api/taskRepo');
+    await addTaskLog(env.DB, taskId, null, 'commented', 'Log entry 1');
+    await addTaskLog(env.DB, taskId, null, 'commented', 'Log entry 2');
 
-    const { createSSEResponse } = await import("../apps/web/functions/api/sse");
+    const { createSSEResponse } = await import('../apps/web/functions/api/sse');
     const response = await createSSEResponse(env as any, taskId, null);
-    const text = await readSSEUntil(response.body!, (t) => t.includes("Log entry 2"));
+    const text = await readSSEUntil(response.body!, (t) => t.includes('Log entry 2'));
 
-    expect(text).toContain("event: log");
-    expect(text).toContain("Log entry 1");
-    expect(text).toContain("Log entry 2");
-    expect(text).toContain("id: ");
-    expect(text).toContain("data: ");
+    expect(text).toContain('event: log');
+    expect(text).toContain('Log entry 1');
+    expect(text).toContain('Log entry 2');
+    expect(text).toContain('id: ');
+    expect(text).toContain('data: ');
   });
 
-  it("streams messages as SSE events", async () => {
-    const { createMessage } = await import("../apps/web/functions/api/messageRepo");
-    await createMessage(env.DB, taskId, "user", "sse-user", "Hello from user");
+  it('streams messages as SSE events', async () => {
+    const { createMessage } = await import('../apps/web/functions/api/messageRepo');
+    await createMessage(env.DB, taskId, 'user', 'sse-user', 'Hello from user');
 
-    const { createSSEResponse } = await import("../apps/web/functions/api/sse");
+    const { createSSEResponse } = await import('../apps/web/functions/api/sse');
     const response = await createSSEResponse(env as any, taskId, null);
-    const text = await readSSEUntil(response.body!, (t) => t.includes("event: message"));
+    const text = await readSSEUntil(response.body!, (t) => t.includes('event: message'));
 
-    expect(text).toContain("event: message");
-    expect(text).toContain("Hello from user");
+    expect(text).toContain('event: message');
+    expect(text).toContain('Hello from user');
   });
 
-  it("resumes from lastEventId", async () => {
-    const { addTaskLog, getTaskLogs } = await import("../apps/web/functions/api/taskRepo");
-    await addTaskLog(env.DB, taskId, null, "commented", "Before resume");
+  it('resumes from lastEventId', async () => {
+    const { addTaskLog, getTaskLogs } = await import('../apps/web/functions/api/taskRepo');
+    await addTaskLog(env.DB, taskId, null, 'commented', 'Before resume');
     const logsBeforeResume = await getTaskLogs(env.DB, taskId);
     const lastLogId = logsBeforeResume[logsBeforeResume.length - 1].id;
 
     // Small delay to ensure distinct timestamp in D1 (millisecond resolution)
     await new Promise((r) => setTimeout(r, 50));
-    await addTaskLog(env.DB, taskId, null, "commented", "After resume");
+    await addTaskLog(env.DB, taskId, null, 'commented', 'After resume');
 
-    const { createSSEResponse } = await import("../apps/web/functions/api/sse");
+    const { createSSEResponse } = await import('../apps/web/functions/api/sse');
     const response = await createSSEResponse(env as any, taskId, lastLogId);
-    const text = await readSSEUntil(response.body!, (t) => t.includes("After resume"));
+    const text = await readSSEUntil(response.body!, (t) => t.includes('After resume'));
 
-    expect(text).toContain("After resume");
+    expect(text).toContain('After resume');
   });
 
-  it("returns stream for task with only creation log", async () => {
-    const { createTask } = await import("../apps/web/functions/api/taskRepo");
-    const freshTask = await createTask(env.DB, "sse-user", { title: "Fresh SSE Task", board_id: boardId });
+  it('returns stream for task with only creation log', async () => {
+    const { createTask } = await import('../apps/web/functions/api/taskRepo');
+    const freshTask = await createTask(env.DB, 'sse-user', {
+      title: 'Fresh SSE Task',
+      board_id: boardId,
+    });
 
-    const { createSSEResponse } = await import("../apps/web/functions/api/sse");
+    const { createSSEResponse } = await import('../apps/web/functions/api/sse');
     const response = await createSSEResponse(env as any, freshTask.id, null);
     expect(response).toBeInstanceOf(Response);
-    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+    expect(response.headers.get('Content-Type')).toBe('text/event-stream');
 
-    const text = await readSSEUntil(response.body!, (t) => t.includes("event: log"));
+    const text = await readSSEUntil(response.body!, (t) => t.includes('event: log'));
 
-    expect(text).toContain("event: log");
+    expect(text).toContain('event: log');
     expect(text).toContain('"action":"created"');
   });
 
-  it("merges logs and messages by time order", async () => {
-    const { createTask, addTaskLog } = await import("../apps/web/functions/api/taskRepo");
-    const { createMessage } = await import("../apps/web/functions/api/messageRepo");
-    const mergeTask = await createTask(env.DB, "sse-user", { title: "Merge SSE Task", board_id: boardId });
+  it('merges logs and messages by time order', async () => {
+    const { createTask, addTaskLog } = await import('../apps/web/functions/api/taskRepo');
+    const { createMessage } = await import('../apps/web/functions/api/messageRepo');
+    const mergeTask = await createTask(env.DB, 'sse-user', {
+      title: 'Merge SSE Task',
+      board_id: boardId,
+    });
 
-    await createMessage(env.DB, mergeTask.id, "user", "sse-user", "Message first");
+    await createMessage(env.DB, mergeTask.id, 'user', 'sse-user', 'Message first');
     // Small delay to ensure distinct timestamp in D1 (millisecond resolution)
     await new Promise((r) => setTimeout(r, 50));
-    await addTaskLog(env.DB, mergeTask.id, null, "commented", "Log second");
+    await addTaskLog(env.DB, mergeTask.id, null, 'commented', 'Log second');
 
-    const { createSSEResponse } = await import("../apps/web/functions/api/sse");
+    const { createSSEResponse } = await import('../apps/web/functions/api/sse');
     const response = await createSSEResponse(env as any, mergeTask.id, null);
     const text = await readSSEUntil(
       response.body!,
-      (t) => t.includes("Message first") && t.includes("Log second"),
+      (t) => t.includes('Message first') && t.includes('Log second'),
     );
 
-    expect(text).toContain("event: message");
-    expect(text).toContain("event: log");
-    expect(text).toContain("Message first");
-    expect(text).toContain("Log second");
+    expect(text).toContain('event: message');
+    expect(text).toContain('event: log');
+    expect(text).toContain('Message first');
+    expect(text).toContain('Log second');
 
-    const msgPos = text.indexOf("Message first");
-    const logPos = text.indexOf("Log second");
+    const msgPos = text.indexOf('Message first');
+    const logPos = text.indexOf('Log second');
     expect(msgPos).toBeLessThan(logPos);
   });
 
-  it("poll loop picks up new events after initial batch", async () => {
-    const { createTask, addTaskLog } = await import("../apps/web/functions/api/taskRepo");
-    const pollTask = await createTask(env.DB, "sse-user", { title: "Poll SSE Task", board_id: boardId });
+  it('poll loop picks up new events after initial batch', async () => {
+    const { createTask, addTaskLog } = await import('../apps/web/functions/api/taskRepo');
+    const pollTask = await createTask(env.DB, 'sse-user', {
+      title: 'Poll SSE Task',
+      board_id: boardId,
+    });
 
     setTimeout(async () => {
-      await addTaskLog(env.DB, pollTask.id, null, "commented", "Polled event from loop");
+      await addTaskLog(env.DB, pollTask.id, null, 'commented', 'Polled event from loop');
     }, 500);
 
-    const { createSSEResponse } = await import("../apps/web/functions/api/sse");
+    const { createSSEResponse } = await import('../apps/web/functions/api/sse');
     const response = await createSSEResponse(env as any, pollTask.id, null);
     // Poll loop fires at 2s intervals — use a longer per-read timeout to avoid premature resolution
     const text = await readSSEUntil(
       response.body!,
-      (t) => t.includes("Polled event from loop"),
+      (t) => t.includes('Polled event from loop'),
       8000,
       3000,
     );
 
-    expect(text).toContain("Polled event from loop");
+    expect(text).toContain('Polled event from loop');
   }, 15000);
 
-  it("lastSeen defaults to current time when no batch and no since", async () => {
-    const { createSSEResponse } = await import("../apps/web/functions/api/sse");
-    const response = await createSSEResponse(env as any, "nonexistent-task-id", null);
-    expect(response).toBeInstanceOf(Response);
-    expect(response.headers.get("Content-Type")).toBe("text/event-stream");
-
-    const text = await readSSEUntil(response.body!, () => false, 500);
-    expect(text).toBe("");
+  it('returns 400 JSON error when lastEventId is not found in DB', async () => {
+    const { createSSEResponse } = await import('../apps/web/functions/api/sse');
+    const response = await createSSEResponse(env as any, taskId, 'nonexistent-event-id-xyz');
+    expect(response.status).toBe(400);
+    expect(response.headers.get('Content-Type')).toContain('application/json');
+    const body = (await response.json()) as any;
+    expect(body.error.code).toBe('INVALID_LAST_EVENT_ID');
+    expect(body.error.message).toBe('Unknown event ID, reconnect without Last-Event-ID');
   });
 
-  it("limits initial events to 50 per type", async () => {
-    const { createTask, addTaskLog } = await import("../apps/web/functions/api/taskRepo");
-    const bigTask = await createTask(env.DB, "sse-user", { title: "Big SSE Task", board_id: boardId });
+  it('lastSeen defaults to current time when no batch and no since', async () => {
+    const { createSSEResponse } = await import('../apps/web/functions/api/sse');
+    const response = await createSSEResponse(env as any, 'nonexistent-task-id', null);
+    expect(response).toBeInstanceOf(Response);
+    expect(response.headers.get('Content-Type')).toBe('text/event-stream');
+
+    const text = await readSSEUntil(response.body!, () => false, 500);
+    expect(text).toBe('');
+  });
+
+  it('limits initial events to 50 per type', async () => {
+    const { createTask, addTaskLog } = await import('../apps/web/functions/api/taskRepo');
+    const bigTask = await createTask(env.DB, 'sse-user', {
+      title: 'Big SSE Task',
+      board_id: boardId,
+    });
 
     for (let i = 0; i < 55; i++) {
-      await addTaskLog(env.DB, bigTask.id, null, "commented", `Bulk log ${i}`);
+      await addTaskLog(env.DB, bigTask.id, null, 'commented', `Bulk log ${i}`);
     }
 
-    const { createSSEResponse } = await import("../apps/web/functions/api/sse");
+    const { createSSEResponse } = await import('../apps/web/functions/api/sse');
     const response = await createSSEResponse(env as any, bigTask.id, null);
     const text = await readSSEUntil(
       response.body!,
@@ -199,7 +221,7 @@ describe("createSSEResponse", () => {
 
     const logEventCount = (text.match(/event: log/g) || []).length;
     expect(logEventCount).toBeLessThanOrEqual(50);
-    expect(text).not.toContain("Bulk log 0");
-    expect(text).toContain("Bulk log 54");
+    expect(text).not.toContain('Bulk log 0');
+    expect(text).toContain('Bulk log 54');
   });
 });


### PR DESCRIPTION
## Summary
- Validates `Last-Event-ID` before creating the SSE TransformStream
- Returns 400 JSON error (`INVALID_LAST_EVENT_ID`) when the ID is not found in `task_logs` or `messages` tables
- No behavior change when `Last-Event-ID` is absent or resolves successfully

## Test plan
- [x] New test: unknown Last-Event-ID returns 400 with correct error envelope
- [x] Existing tests pass: null ID → SSE stream, valid ID → resumed SSE stream
- [x] Full regression: 389/389 tests pass, build + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)