### PR TITLE
fix: resolve all Biome lint and format violations

### DIFF
--- a/apps/web/functions/api/agentRepo.ts
+++ b/apps/web/functions/api/agentRepo.ts
@@ -1,10 +1,20 @@
 import type { Agent, AgentWithActivity, CreateAgentInput } from "@agent-kanban/shared";
-import { generateKeypair, computeFingerprint, computeKeyId, BUILTIN_TEMPLATES } from "@agent-kanban/shared";
-import { parseJsonFields, type D1 } from "./db";
+import {
+  BUILTIN_TEMPLATES,
+  computeFingerprint,
+  computeKeyId,
+  generateKeypair,
+} from "@agent-kanban/shared";
+import { type D1, parseJsonFields } from "./db";
 
 const parseAgent = <T extends Agent>(row: T) => parseJsonFields(row, ["skills", "handoff_to"]);
 
-export async function createAgent(db: D1, ownerId: string, input: CreateAgentInput, builtin = false): Promise<Agent> {
+export async function createAgent(
+  db: D1,
+  ownerId: string,
+  input: CreateAgentInput,
+  builtin = false,
+): Promise<Agent> {
   const { publicKeyBase64, privateKeyJwk } = await generateKeypair();
   const fingerprint = await computeFingerprint(publicKeyBase64);
   const id = computeKeyId(fingerprint);
@@ -12,29 +22,55 @@ export async function createAgent(db: D1, ownerId: string, input: CreateAgentInp
   const skillsJson = input.skills ? JSON.stringify(input.skills) : null;
   const handoffJson = input.handoff_to ? JSON.stringify(input.handoff_to) : null;
 
-  await db.prepare(`
+  await db
+    .prepare(`
     INSERT INTO agents (id, owner_id, name, bio, soul, role, handoff_to, runtime, model, skills, public_key, private_key, fingerprint, builtin, created_at, updated_at)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).bind(
-    id, ownerId, input.name, input.bio ?? null, input.soul ?? null,
-    input.role ?? null, handoffJson,
-    input.runtime ?? null, input.model ?? null, skillsJson,
-    publicKeyBase64, JSON.stringify(privateKeyJwk), fingerprint, builtin ? 1 : 0, now, now,
-  ).run();
+  `)
+    .bind(
+      id,
+      ownerId,
+      input.name,
+      input.bio ?? null,
+      input.soul ?? null,
+      input.role ?? null,
+      handoffJson,
+      input.runtime ?? null,
+      input.model ?? null,
+      skillsJson,
+      publicKeyBase64,
+      JSON.stringify(privateKeyJwk),
+      fingerprint,
+      builtin ? 1 : 0,
+      now,
+      now,
+    )
+    .run();
 
   return {
-    id, owner_id: ownerId, name: input.name, bio: input.bio ?? null,
-    soul: input.soul ?? null, role: input.role ?? null, handoff_to: input.handoff_to ?? null,
-    runtime: input.runtime ?? null, model: input.model ?? null,
-    skills: input.skills ?? null, public_key: publicKeyBase64, fingerprint, builtin: builtin ? 1 : 0,
-    created_at: now, updated_at: now,
+    id,
+    owner_id: ownerId,
+    name: input.name,
+    bio: input.bio ?? null,
+    soul: input.soul ?? null,
+    role: input.role ?? null,
+    handoff_to: input.handoff_to ?? null,
+    runtime: input.runtime ?? null,
+    model: input.model ?? null,
+    skills: input.skills ?? null,
+    public_key: publicKeyBase64,
+    fingerprint,
+    builtin: builtin ? 1 : 0,
+    created_at: now,
+    updated_at: now,
   };
 }
 
 export async function seedBuiltinAgents(db: D1, ownerId: string): Promise<void> {
-  const existing = await db.prepare(
-    "SELECT role FROM agents WHERE owner_id = ? AND builtin = 1"
-  ).bind(ownerId).all<{ role: string }>();
+  const existing = await db
+    .prepare("SELECT role FROM agents WHERE owner_id = ? AND builtin = 1")
+    .bind(ownerId)
+    .all<{ role: string }>();
   const existingRoles = new Set(existing.results.map((a) => a.role));
 
   for (const tpl of BUILTIN_TEMPLATES) {
@@ -44,7 +80,8 @@ export async function seedBuiltinAgents(db: D1, ownerId: string): Promise<void> 
 }
 
 export async function listAgents(db: D1, ownerId: string): Promise<AgentWithActivity[]> {
-  const result = await db.prepare(`
+  const result = await db
+    .prepare(`
     SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.handoff_to, a.runtime, a.model, a.skills,
       a.public_key, a.fingerprint, a.builtin, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
@@ -58,12 +95,19 @@ export async function listAgents(db: D1, ownerId: string): Promise<AgentWithActi
     FROM agents a
     WHERE a.owner_id = ?
     ORDER BY a.created_at DESC
-  `).bind(ownerId).all<AgentWithActivity>();
+  `)
+    .bind(ownerId)
+    .all<AgentWithActivity>();
   return result.results.map(parseAgent);
 }
 
-export async function getAgent(db: D1, agentId: string, ownerId: string): Promise<AgentWithActivity | null> {
-  return db.prepare(`
+export async function getAgent(
+  db: D1,
+  agentId: string,
+  ownerId: string,
+): Promise<AgentWithActivity | null> {
+  return db
+    .prepare(`
     SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.handoff_to, a.runtime, a.model, a.skills,
       a.public_key, a.fingerprint, a.builtin, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
@@ -76,13 +120,18 @@ export async function getAgent(db: D1, agentId: string, ownerId: string): Promis
       COALESCE((SELECT SUM(s.cost_micro_usd) FROM agent_sessions s WHERE s.agent_id = a.id), 0) as cost_micro_usd
     FROM agents a
     WHERE a.id = ? AND a.owner_id = ?
-  `).bind(agentId, ownerId).first<AgentWithActivity>().then(r => r ? parseAgent(r) : null);
+  `)
+    .bind(agentId, ownerId)
+    .first<AgentWithActivity>()
+    .then((r) => (r ? parseAgent(r) : null));
 }
 
 export async function updateAgent(
   db: D1,
   agentId: string,
-  updates: Partial<Pick<Agent, "name" | "bio" | "soul" | "role" | "handoff_to" | "runtime" | "model" | "skills">>,
+  updates: Partial<
+    Pick<Agent, "name" | "bio" | "soul" | "role" | "handoff_to" | "runtime" | "model" | "skills">
+  >,
 ): Promise<Agent | null> {
   const agent = await db.prepare("SELECT * FROM agents WHERE id = ?").bind(agentId).first<Agent>();
   if (!agent) return null;
@@ -92,7 +141,16 @@ export async function updateAgent(
   const binds: unknown[] = [now];
 
   const jsonFields = new Set(["skills", "handoff_to"]);
-  const fields = ["name", "bio", "soul", "role", "handoff_to", "runtime", "model", "skills"] as const;
+  const fields = [
+    "name",
+    "bio",
+    "soul",
+    "role",
+    "handoff_to",
+    "runtime",
+    "model",
+    "skills",
+  ] as const;
   for (const field of fields) {
     if (field in updates && (updates as any)[field] !== undefined) {
       sets.push(`${field} = ?`);
@@ -102,7 +160,10 @@ export async function updateAgent(
   }
 
   binds.push(agentId);
-  await db.prepare(`UPDATE agents SET ${sets.join(", ")} WHERE id = ?`).bind(...binds).run();
+  await db
+    .prepare(`UPDATE agents SET ${sets.join(", ")} WHERE id = ?`)
+    .bind(...binds)
+    .run();
   return parseAgent({ ...agent, ...updates, updated_at: now });
 }
 
@@ -112,13 +173,19 @@ export async function deleteAgent(db: D1, agentId: string): Promise<boolean> {
 }
 
 export async function getAgentLogs(db: D1, agentId: string): Promise<any[]> {
-  const result = await db.prepare(
-    "SELECT tl.*, t.title as task_title FROM task_logs tl JOIN tasks t ON tl.task_id = t.id WHERE tl.agent_id = ? ORDER BY tl.created_at DESC LIMIT 100"
-  ).bind(agentId).all();
+  const result = await db
+    .prepare(
+      "SELECT tl.*, t.title as task_title FROM task_logs tl JOIN tasks t ON tl.task_id = t.id WHERE tl.agent_id = ? ORDER BY tl.created_at DESC LIMIT 100",
+    )
+    .bind(agentId)
+    .all();
   return result.results;
 }
 
 export async function getAgentPrivateKey(db: D1, agentId: string): Promise<JsonWebKey | null> {
-  const row = await db.prepare("SELECT private_key FROM agents WHERE id = ?").bind(agentId).first<{ private_key: string }>();
+  const row = await db
+    .prepare("SELECT private_key FROM agents WHERE id = ?")
+    .bind(agentId)
+    .first<{ private_key: string }>();
   return row ? JSON.parse(row.private_key) : null;
 }

--- a/apps/web/functions/api/agentSessionRepo.ts
+++ b/apps/web/functions/api/agentSessionRepo.ts
@@ -1,8 +1,12 @@
-import type { AgentSession, AgentSessionWithMachine, SessionUsageInput } from "@agent-kanban/shared";
+import type {
+  AgentSession,
+  AgentSessionWithMachine,
+  SessionUsageInput,
+} from "@agent-kanban/shared";
 import { signDelegation } from "@agent-kanban/shared";
-import type { D1 } from "./db";
 import { getAgentPrivateKey } from "./agentRepo";
 import { createAuth } from "./betterAuth";
+import type { D1 } from "./db";
 import type { Env } from "./types";
 
 export async function createSession(
@@ -20,23 +24,34 @@ export async function createSession(
   const delegationProof = await signDelegation(agentPrivateKey, sessionPublicKey);
   const now = new Date().toISOString();
 
-  await db.prepare(`
+  await db
+    .prepare(`
     INSERT INTO agent_sessions (id, agent_id, machine_id, status, public_key, delegation_proof, created_at)
     VALUES (?, ?, ?, 'active', ?, ?, ?)
-  `).bind(sessionId, agentId, machineId, sessionPublicKey, delegationProof, now).run();
+  `)
+    .bind(sessionId, agentId, machineId, sessionPublicKey, delegationProof, now)
+    .run();
 
   // Register in Better Auth agent table for JWT verification
   const auth = createAuth(env);
   const authCtx = await auth.$context;
 
   // Ensure agentHost exists for this machine
-  const existingHost = await authCtx.adapter.findOne({ model: "agentHost", where: [{ field: "id", value: machineId }] });
+  const existingHost = await authCtx.adapter.findOne({
+    model: "agentHost",
+    where: [{ field: "id", value: machineId }],
+  });
   if (!existingHost) {
     await authCtx.adapter.create({
       model: "agentHost",
       data: {
-        id: machineId, name: `machine-${machineId.slice(0, 8)}`, userId: ownerId,
-        status: "active", activatedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+        id: machineId,
+        name: `machine-${machineId.slice(0, 8)}`,
+        userId: ownerId,
+        status: "active",
+        activatedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
       },
       forceAllowId: true,
     });
@@ -46,9 +61,16 @@ export async function createSession(
   await authCtx.adapter.create({
     model: "agent",
     data: {
-      id: sessionId, name: `session-${sessionId.slice(0, 8)}`, userId: ownerId,
-      hostId: machineId, status: "active", mode: "autonomous", publicKey: jwk,
-      activatedAt: new Date(), createdAt: new Date(), updatedAt: new Date(),
+      id: sessionId,
+      name: `session-${sessionId.slice(0, 8)}`,
+      userId: ownerId,
+      hostId: machineId,
+      status: "active",
+      mode: "autonomous",
+      publicKey: jwk,
+      activatedAt: new Date(),
+      createdAt: new Date(),
+      updatedAt: new Date(),
     },
     forceAllowId: true,
   });
@@ -58,9 +80,16 @@ export async function createSession(
     await authCtx.adapter.create({
       model: "agentCapabilityGrant",
       data: {
-        agentId: sessionId, capability: cap, grantedBy: ownerId, deniedBy: null,
-        expiresAt: null, status: "active", reason: null, constraints: null,
-        createdAt: new Date(), updatedAt: new Date(),
+        agentId: sessionId,
+        capability: cap,
+        grantedBy: ownerId,
+        deniedBy: null,
+        expiresAt: null,
+        status: "active",
+        reason: null,
+        constraints: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
       },
     });
   }
@@ -69,23 +98,37 @@ export async function createSession(
 }
 
 export async function getSession(db: D1, sessionId: string): Promise<AgentSession | null> {
-  return db.prepare("SELECT * FROM agent_sessions WHERE id = ?").bind(sessionId).first<AgentSession>();
+  return db
+    .prepare("SELECT * FROM agent_sessions WHERE id = ?")
+    .bind(sessionId)
+    .first<AgentSession>();
 }
 
 export async function closeSession(db: D1, sessionId: string): Promise<void> {
   const now = new Date().toISOString();
-  await db.prepare("UPDATE agent_sessions SET status = 'closed', closed_at = ? WHERE id = ?").bind(now, sessionId).run();
+  await db
+    .prepare("UPDATE agent_sessions SET status = 'closed', closed_at = ? WHERE id = ?")
+    .bind(now, sessionId)
+    .run();
 }
 
 export async function reopenSession(db: D1, sessionId: string): Promise<void> {
-  const result = await db.prepare(
-    "UPDATE agent_sessions SET status = 'active', closed_at = NULL WHERE id = ? AND status = 'closed'",
-  ).bind(sessionId).run();
+  const result = await db
+    .prepare(
+      "UPDATE agent_sessions SET status = 'active', closed_at = NULL WHERE id = ? AND status = 'closed'",
+    )
+    .bind(sessionId)
+    .run();
   if (!result.meta.changes) throw new Error(`Session ${sessionId} not found or not closed`);
 }
 
-export async function updateSessionUsage(db: D1, sessionId: string, usage: SessionUsageInput): Promise<void> {
-  await db.prepare(`
+export async function updateSessionUsage(
+  db: D1,
+  sessionId: string,
+  usage: SessionUsageInput,
+): Promise<void> {
+  await db
+    .prepare(`
     UPDATE agent_sessions SET
       input_tokens = input_tokens + ?,
       output_tokens = output_tokens + ?,
@@ -93,20 +136,28 @@ export async function updateSessionUsage(db: D1, sessionId: string, usage: Sessi
       cache_creation_tokens = cache_creation_tokens + ?,
       cost_micro_usd = cost_micro_usd + ?
     WHERE id = ?
-  `).bind(
-    usage.input_tokens, usage.output_tokens,
-    usage.cache_read_tokens, usage.cache_creation_tokens,
-    usage.cost_micro_usd, sessionId,
-  ).run();
+  `)
+    .bind(
+      usage.input_tokens,
+      usage.output_tokens,
+      usage.cache_read_tokens,
+      usage.cache_creation_tokens,
+      usage.cost_micro_usd,
+      sessionId,
+    )
+    .run();
 }
 
 export async function listSessions(db: D1, agentId: string): Promise<AgentSessionWithMachine[]> {
-  const result = await db.prepare(`
+  const result = await db
+    .prepare(`
     SELECT s.*, m.name as machine_name
     FROM agent_sessions s
     JOIN machines m ON s.machine_id = m.id
     WHERE s.agent_id = ?
     ORDER BY s.created_at DESC
-  `).bind(agentId).all<AgentSessionWithMachine>();
+  `)
+    .bind(agentId)
+    .all<AgentSessionWithMachine>();
   return result.results;
 }

--- a/apps/web/functions/api/auth.ts
+++ b/apps/web/functions/api/auth.ts
@@ -1,6 +1,6 @@
 import type { Context, Next } from "hono";
-import type { Env } from "./types";
 import { createAuth } from "./betterAuth";
+import type { Env } from "./types";
 
 type IdentityType = "user" | "machine" | "agent";
 
@@ -24,17 +24,49 @@ const ROUTE_RULES: { method: string; pattern: RegExp; rule: RouteRule }[] = [
 
   // Agent Sessions — machine creates/closes, agent reports usage
   { method: "POST", pattern: /^\/api\/agents\/[^/]+\/sessions$/, rule: { allow: ["machine"] } },
-  { method: "DELETE", pattern: /^\/api\/agents\/[^/]+\/sessions\/[^/]+$/, rule: { allow: ["machine"] } },
-  { method: "PATCH", pattern: /^\/api\/agents\/[^/]+\/sessions\/[^/]+\/usage$/, rule: { allow: ["agent"], capability: "agent:usage" } },
+  {
+    method: "DELETE",
+    pattern: /^\/api\/agents\/[^/]+\/sessions\/[^/]+$/,
+    rule: { allow: ["machine"] },
+  },
+  {
+    method: "PATCH",
+    pattern: /^\/api\/agents\/[^/]+\/sessions\/[^/]+\/usage$/,
+    rule: { allow: ["agent"], capability: "agent:usage" },
+  },
 
   // Task lifecycle
-  { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/claim$/, rule: { allow: ["agent"], capability: "task:claim" } },
-  { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/review$/, rule: { allow: ["agent"], capability: "task:review" } },
-  { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/assign$/, rule: { allow: ["user", "machine"] } },
+  {
+    method: "POST",
+    pattern: /^\/api\/tasks\/[^/]+\/claim$/,
+    rule: { allow: ["agent"], capability: "task:claim" },
+  },
+  {
+    method: "POST",
+    pattern: /^\/api\/tasks\/[^/]+\/review$/,
+    rule: { allow: ["agent"], capability: "task:review" },
+  },
+  {
+    method: "POST",
+    pattern: /^\/api\/tasks\/[^/]+\/assign$/,
+    rule: { allow: ["user", "machine"] },
+  },
   { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/release$/, rule: { allow: ["machine"] } },
-  { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/complete$/, rule: { allow: ["user", "machine"] } },
-  { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/cancel$/, rule: { allow: ["user", "machine"] } },
-  { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/reject$/, rule: { allow: ["user", "machine"] } },
+  {
+    method: "POST",
+    pattern: /^\/api\/tasks\/[^/]+\/complete$/,
+    rule: { allow: ["user", "machine"] },
+  },
+  {
+    method: "POST",
+    pattern: /^\/api\/tasks\/[^/]+\/cancel$/,
+    rule: { allow: ["user", "machine"] },
+  },
+  {
+    method: "POST",
+    pattern: /^\/api\/tasks\/[^/]+\/reject$/,
+    rule: { allow: ["user", "machine"] },
+  },
 ];
 
 function matchRouteRule(method: string, path: string): RouteRule | null {
@@ -51,7 +83,9 @@ function detectTokenType(token: string): "apikey" | "agent" | "user" {
     try {
       const header = JSON.parse(atob(parts[0]));
       if (header.typ === "agent+jwt") return "agent";
-    } catch { /* not a valid JWT header */ }
+    } catch {
+      /* not a valid JWT header */
+    }
   }
   return "user";
 }
@@ -103,18 +137,31 @@ async function handleApiKey(c: Context<{ Bindings: Env }>, auth: any, token: str
   try {
     result = await auth.api.verifyApiKey({ body: { key: token } });
   } catch (err: any) {
-    return c.json({ error: { code: "UNAUTHORIZED", message: err?.message || "Invalid API key" } }, 401);
+    return c.json(
+      { error: { code: "UNAUTHORIZED", message: err?.message || "Invalid API key" } },
+      401,
+    );
   }
   if (!result?.valid) {
     if (result?.error?.code === "RATE_LIMITED") {
-      const retryAfter = result.error.details?.tryAgainIn ? Math.ceil(result.error.details.tryAgainIn / 1000) : 60;
+      const retryAfter = result.error.details?.tryAgainIn
+        ? Math.ceil(result.error.details.tryAgainIn / 1000)
+        : 60;
       console.log(`[rate-limit] retry_after=${retryAfter}s path=${c.req.path}`);
       return c.json(
-        { error: { code: "RATE_LIMITED", message: `Rate limit exceeded. Retry after ${retryAfter}s` } },
+        {
+          error: {
+            code: "RATE_LIMITED",
+            message: `Rate limit exceeded. Retry after ${retryAfter}s`,
+          },
+        },
         { status: 429, headers: { "Retry-After": String(retryAfter) } },
       );
     }
-    return c.json({ error: result?.error || { code: "UNAUTHORIZED", message: "Invalid API key" } }, 401);
+    return c.json(
+      { error: result?.error || { code: "UNAUTHORIZED", message: "Invalid API key" } },
+      401,
+    );
   }
 
   c.set("ownerId", result.key.referenceId);
@@ -126,12 +173,20 @@ async function handleApiKey(c: Context<{ Bindings: Env }>, auth: any, token: str
   const key = result.key;
   if (key?.rateLimitMax != null) {
     c.header("X-RateLimit-Limit", String(key.rateLimitMax));
-    c.header("X-RateLimit-Remaining", String(Math.max(0, key.rateLimitMax - (key.requestCount || 0))));
+    c.header(
+      "X-RateLimit-Remaining",
+      String(Math.max(0, key.rateLimitMax - (key.requestCount || 0))),
+    );
   }
   return enforceRouteRule(c, next);
 }
 
-function handleAgentIdentity(c: Context<{ Bindings: Env }>, identity: any, persistentAgentId: string | null, next: Next) {
+function handleAgentIdentity(
+  c: Context<{ Bindings: Env }>,
+  identity: any,
+  persistentAgentId: string | null,
+  next: Next,
+) {
   c.set("ownerId", identity.host?.userId || identity.user?.id);
   c.set("identityType", "agent");
   c.set("sessionId", identity.agent.id);
@@ -148,7 +203,9 @@ function decodeJwtClaim(token: string, claim: string): string | null {
   try {
     const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
     return payload[claim] || null;
-  } catch { return null; }
+  } catch {
+    return null;
+  }
 }
 
 function enforceRouteRule(c: Context<{ Bindings: Env }>, next: Next) {
@@ -157,16 +214,21 @@ function enforceRouteRule(c: Context<{ Bindings: Env }>, next: Next) {
 
   const identity = c.get("identityType") as IdentityType;
   if (!rule.allow.includes(identity)) {
-    return c.json({ error: { code: "FORBIDDEN", message: `${rule.allow.join(" or ")} required` } }, 403);
+    return c.json(
+      { error: { code: "FORBIDDEN", message: `${rule.allow.join(" or ")} required` } },
+      403,
+    );
   }
 
   if (rule.capability && identity === "agent") {
     const caps: string[] = c.get("agentCapabilities") || [];
     if (!caps.includes(rule.capability)) {
-      return c.json({ error: { code: "FORBIDDEN", message: `Missing capability: ${rule.capability}` } }, 403);
+      return c.json(
+        { error: { code: "FORBIDDEN", message: `Missing capability: ${rule.capability}` } },
+        403,
+      );
     }
   }
 
   return next();
 }
-

--- a/apps/web/functions/api/betterAuth.ts
+++ b/apps/web/functions/api/betterAuth.ts
@@ -1,7 +1,7 @@
+import { agentAuth } from "@better-auth/agent-auth";
+import { apiKey } from "@better-auth/api-key";
 import { betterAuth } from "better-auth";
 import { bearer } from "better-auth/plugins";
-import { apiKey } from "@better-auth/api-key";
-import { agentAuth } from "@better-auth/agent-auth";
 import { Kysely } from "kysely";
 import { D1Dialect } from "kysely-d1";
 import type { Env } from "./types";

--- a/apps/web/functions/api/boardRepo.ts
+++ b/apps/web/functions/api/boardRepo.ts
@@ -1,44 +1,64 @@
 import type { Board, BoardWithTasks, Task } from "@agent-kanban/shared";
-import { newId, parseJsonFields, type D1 } from "./db";
-import { computeBlocked } from "./taskDeps";
 import { seedBuiltinAgents } from "./agentRepo";
+import { type D1, newId, parseJsonFields } from "./db";
+import { computeBlocked } from "./taskDeps";
 
-export async function createBoard(db: D1, ownerId: string, name: string, description?: string): Promise<Board> {
+export async function createBoard(
+  db: D1,
+  ownerId: string,
+  name: string,
+  description?: string,
+): Promise<Board> {
   const id = newId();
   const now = new Date().toISOString();
-  await db.prepare(
-    "INSERT INTO boards (id, owner_id, name, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)"
-  ).bind(id, ownerId, name, description || null, now, now).run();
+  await db
+    .prepare(
+      "INSERT INTO boards (id, owner_id, name, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(id, ownerId, name, description || null, now, now)
+    .run();
 
   await seedBuiltinAgents(db, ownerId);
 
-  return { id, owner_id: ownerId, name, description: description || null, created_at: now, updated_at: now };
+  return {
+    id,
+    owner_id: ownerId,
+    name,
+    description: description || null,
+    created_at: now,
+    updated_at: now,
+  };
 }
 
 export async function listBoards(db: D1, ownerId: string): Promise<Board[]> {
-  const result = await db.prepare(
-    "SELECT * FROM boards WHERE owner_id = ? ORDER BY created_at DESC"
-  ).bind(ownerId).all<Board>();
+  const result = await db
+    .prepare("SELECT * FROM boards WHERE owner_id = ? ORDER BY created_at DESC")
+    .bind(ownerId)
+    .all<Board>();
   return result.results;
 }
 
 export async function getBoardByName(db: D1, ownerId: string, name: string): Promise<Board | null> {
-  return db.prepare(
-    "SELECT * FROM boards WHERE owner_id = ? AND name = ?"
-  ).bind(ownerId, name).first<Board>();
+  return db
+    .prepare("SELECT * FROM boards WHERE owner_id = ? AND name = ?")
+    .bind(ownerId, name)
+    .first<Board>();
 }
 
 export async function getBoard(db: D1, boardId: string): Promise<BoardWithTasks | null> {
   const board = await db.prepare("SELECT * FROM boards WHERE id = ?").bind(boardId).first<Board>();
   if (!board) return null;
 
-  const tasks = await db.prepare(`
+  const tasks = await db
+    .prepare(`
     SELECT t.*, a.name as agent_name, a.public_key as agent_public_key, r.name as repository_name FROM tasks t
     LEFT JOIN agents a ON t.assigned_to = a.id
     LEFT JOIN repositories r ON t.repository_id = r.id
     WHERE t.board_id = ?
     ORDER BY t.position
-  `).bind(boardId).all<Task>();
+  `)
+    .bind(boardId)
+    .all<Task>();
 
   const taskIds = tasks.results.map((t: Task) => t.id);
   if (taskIds.length > 0) {
@@ -48,27 +68,42 @@ export async function getBoard(db: D1, boardId: string): Promise<BoardWithTasks 
     }
   }
 
-  return { ...board, tasks: tasks.results.map(t => parseJsonFields(t, ["labels", "input"])) };
+  return { ...board, tasks: tasks.results.map((t) => parseJsonFields(t, ["labels", "input"])) };
 }
 
 export async function getDefaultBoard(db: D1, ownerId: string): Promise<Board | null> {
-  return db.prepare(
-    "SELECT * FROM boards WHERE owner_id = ? ORDER BY created_at ASC LIMIT 1"
-  ).bind(ownerId).first<Board>();
+  return db
+    .prepare("SELECT * FROM boards WHERE owner_id = ? ORDER BY created_at ASC LIMIT 1")
+    .bind(ownerId)
+    .first<Board>();
 }
 
-export async function updateBoard(db: D1, boardId: string, updates: { name?: string; description?: string }): Promise<Board | null> {
+export async function updateBoard(
+  db: D1,
+  boardId: string,
+  updates: { name?: string; description?: string },
+): Promise<Board | null> {
   const sets: string[] = [];
   const values: unknown[] = [];
-  if (updates.name !== undefined) { sets.push("name = ?"); values.push(updates.name); }
-  if (updates.description !== undefined) { sets.push("description = ?"); values.push(updates.description || null); }
-  if (sets.length === 0) return db.prepare("SELECT * FROM boards WHERE id = ?").bind(boardId).first<Board>();
+  if (updates.name !== undefined) {
+    sets.push("name = ?");
+    values.push(updates.name);
+  }
+  if (updates.description !== undefined) {
+    sets.push("description = ?");
+    values.push(updates.description || null);
+  }
+  if (sets.length === 0)
+    return db.prepare("SELECT * FROM boards WHERE id = ?").bind(boardId).first<Board>();
 
   sets.push("updated_at = ?");
   values.push(new Date().toISOString());
   values.push(boardId);
 
-  await db.prepare(`UPDATE boards SET ${sets.join(", ")} WHERE id = ?`).bind(...values).run();
+  await db
+    .prepare(`UPDATE boards SET ${sets.join(", ")} WHERE id = ?`)
+    .bind(...values)
+    .run();
   return db.prepare("SELECT * FROM boards WHERE id = ?").bind(boardId).first<Board>();
 }
 

--- a/apps/web/functions/api/machineRepo.ts
+++ b/apps/web/functions/api/machineRepo.ts
@@ -1,6 +1,6 @@
 import type { Machine, MachineWithAgents, UsageInfo } from "@agent-kanban/shared";
 import { MACHINE_STALE_TIMEOUT_MS } from "@agent-kanban/shared";
-import { newId, parseJsonFields, type D1 } from "./db";
+import { type D1, newId, parseJsonFields } from "./db";
 
 export interface CreateMachineInfo {
   name: string;
@@ -15,17 +15,38 @@ export interface HeartbeatInfo {
   usage_info?: UsageInfo | null;
 }
 
-export async function createMachine(db: D1, ownerId: string, info: CreateMachineInfo): Promise<Machine> {
+export async function createMachine(
+  db: D1,
+  ownerId: string,
+  info: CreateMachineInfo,
+): Promise<Machine> {
   const id = newId();
   const now = new Date().toISOString();
-  await db.prepare(
-    "INSERT INTO machines (id, owner_id, name, os, version, runtimes, status, created_at) VALUES (?, ?, ?, ?, ?, ?, 'offline', ?)"
-  ).bind(id, ownerId, info.name, info.os, info.version, JSON.stringify(info.runtimes), now).run();
-  return { id, owner_id: ownerId, name: info.name, status: "offline", os: info.os, version: info.version, runtimes: info.runtimes, usage_info: null, last_heartbeat_at: null, created_at: now };
+  await db
+    .prepare(
+      "INSERT INTO machines (id, owner_id, name, os, version, runtimes, status, created_at) VALUES (?, ?, ?, ?, ?, ?, 'offline', ?)",
+    )
+    .bind(id, ownerId, info.name, info.os, info.version, JSON.stringify(info.runtimes), now)
+    .run();
+  return {
+    id,
+    owner_id: ownerId,
+    name: info.name,
+    status: "offline",
+    os: info.os,
+    version: info.version,
+    runtimes: info.runtimes,
+    usage_info: null,
+    last_heartbeat_at: null,
+    created_at: now,
+  };
 }
 
 export async function deleteMachine(db: D1, machineId: string, ownerId: string): Promise<boolean> {
-  const result = await db.prepare("DELETE FROM machines WHERE id = ? AND owner_id = ?").bind(machineId, ownerId).run();
+  const result = await db
+    .prepare("DELETE FROM machines WHERE id = ? AND owner_id = ?")
+    .bind(machineId, ownerId)
+    .run();
   return result.meta.changes > 0;
 }
 
@@ -39,45 +60,71 @@ export async function updateMachine(
   const sets: string[] = ["status = 'online'", "last_heartbeat_at = ?"];
   const binds: any[] = [now];
 
-  if (info.version) { sets.push("version = ?"); binds.push(info.version); }
-  if (info.runtimes) { sets.push("runtimes = ?"); binds.push(JSON.stringify(info.runtimes)); }
-  if (info.usage_info) { sets.push("usage_info = ?"); binds.push(JSON.stringify(info.usage_info)); }
+  if (info.version) {
+    sets.push("version = ?");
+    binds.push(info.version);
+  }
+  if (info.runtimes) {
+    sets.push("runtimes = ?");
+    binds.push(JSON.stringify(info.runtimes));
+  }
+  if (info.usage_info) {
+    sets.push("usage_info = ?");
+    binds.push(JSON.stringify(info.usage_info));
+  }
 
   binds.push(machineId, ownerId);
-  const result = await db.prepare(`UPDATE machines SET ${sets.join(", ")} WHERE id = ? AND owner_id = ?`).bind(...binds).run();
+  const result = await db
+    .prepare(`UPDATE machines SET ${sets.join(", ")} WHERE id = ? AND owner_id = ?`)
+    .bind(...binds)
+    .run();
   if (result.meta.changes === 0) return null;
 
-  const row = await db.prepare("SELECT * FROM machines WHERE id = ?").bind(machineId).first<Machine>();
+  const row = await db
+    .prepare("SELECT * FROM machines WHERE id = ?")
+    .bind(machineId)
+    .first<Machine>();
   return parseMachine(row!);
 }
 
 export async function listMachines(db: D1, ownerId: string): Promise<MachineWithAgents[]> {
   await detectStaleMachines(db);
 
-  const result = await db.prepare(`
+  const result = await db
+    .prepare(`
     SELECT m.*,
       (SELECT COUNT(*) FROM agent_sessions s WHERE s.machine_id = m.id) as session_count,
       (SELECT COUNT(*) FROM agent_sessions s WHERE s.machine_id = m.id AND s.status = 'active') as active_session_count
     FROM machines m
     WHERE m.owner_id = ?
     ORDER BY m.last_heartbeat_at DESC
-  `).bind(ownerId).all<MachineWithAgents>();
+  `)
+    .bind(ownerId)
+    .all<MachineWithAgents>();
   return result.results.map(parseMachine);
 }
 
-export async function getMachine(db: D1, machineId: string, ownerId: string): Promise<(MachineWithAgents & { agents: any[] }) | null> {
+export async function getMachine(
+  db: D1,
+  machineId: string,
+  ownerId: string,
+): Promise<(MachineWithAgents & { agents: any[] }) | null> {
   await detectStaleMachines(db);
 
-  const machine = await db.prepare(`
+  const machine = await db
+    .prepare(`
     SELECT m.*,
       (SELECT COUNT(*) FROM agent_sessions s WHERE s.machine_id = m.id) as session_count,
       (SELECT COUNT(*) FROM agent_sessions s WHERE s.machine_id = m.id AND s.status = 'active') as active_session_count
     FROM machines m WHERE m.id = ? AND m.owner_id = ?
-  `).bind(machineId, ownerId).first<MachineWithAgents>();
+  `)
+    .bind(machineId, ownerId)
+    .first<MachineWithAgents>();
 
   if (!machine) return null;
 
-  const agents = await db.prepare(`
+  const agents = await db
+    .prepare(`
     SELECT a.id, a.name,
       CASE WHEN SUM(s.status = 'active') > 0 THEN 'working' ELSE 'idle' END as status,
       MAX(s.created_at) as last_active_at
@@ -86,16 +133,22 @@ export async function getMachine(db: D1, machineId: string, ownerId: string): Pr
     WHERE s.machine_id = ?
     GROUP BY a.id
     ORDER BY last_active_at DESC
-  `).bind(machineId).all();
+  `)
+    .bind(machineId)
+    .all();
 
   return { ...parseMachine(machine), agents: agents.results };
 }
 
-const parseMachine = <T extends Machine>(row: T) => parseJsonFields(row, ["runtimes", "usage_info"]);
+const parseMachine = <T extends Machine>(row: T) =>
+  parseJsonFields(row, ["runtimes", "usage_info"]);
 
 async function detectStaleMachines(db: D1): Promise<void> {
   const cutoff = new Date(Date.now() - MACHINE_STALE_TIMEOUT_MS).toISOString();
-  await db.prepare(
-    "UPDATE machines SET status = 'offline' WHERE status = 'online' AND last_heartbeat_at < ?"
-  ).bind(cutoff).run();
+  await db
+    .prepare(
+      "UPDATE machines SET status = 'offline' WHERE status = 'online' AND last_heartbeat_at < ?",
+    )
+    .bind(cutoff)
+    .run();
 }

--- a/apps/web/functions/api/messageRepo.ts
+++ b/apps/web/functions/api/messageRepo.ts
@@ -1,5 +1,5 @@
 import type { Message, SenderType } from "@agent-kanban/shared";
-import { newLongId, type D1 } from "./db";
+import { type D1, newLongId } from "./db";
 
 export async function createMessage(
   db: D1,
@@ -10,20 +10,30 @@ export async function createMessage(
 ): Promise<Message> {
   const id = newLongId();
   const now = new Date().toISOString();
-  await db.prepare(
-    "INSERT INTO messages (id, task_id, sender_type, sender_id, content, created_at) VALUES (?, ?, ?, ?, ?, ?)",
-  ).bind(id, taskId, senderType, senderId, content, now).run();
+  await db
+    .prepare(
+      "INSERT INTO messages (id, task_id, sender_type, sender_id, content, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+    )
+    .bind(id, taskId, senderType, senderId, content, now)
+    .run();
 
-  return { id, task_id: taskId, sender_type: senderType, sender_id: senderId, content, created_at: now };
+  return {
+    id,
+    task_id: taskId,
+    sender_type: senderType,
+    sender_id: senderId,
+    content,
+    created_at: now,
+  };
 }
 
-export async function listMessages(
-  db: D1,
-  taskId: string,
-  since?: string,
-): Promise<Message[]> {
+export async function listMessages(db: D1, taskId: string, since?: string): Promise<Message[]> {
   const query = since
-    ? db.prepare("SELECT * FROM messages WHERE task_id = ? AND created_at > ? ORDER BY created_at ASC").bind(taskId, since)
+    ? db
+        .prepare(
+          "SELECT * FROM messages WHERE task_id = ? AND created_at > ? ORDER BY created_at ASC",
+        )
+        .bind(taskId, since)
     : db.prepare("SELECT * FROM messages WHERE task_id = ? ORDER BY created_at ASC").bind(taskId);
   const result = await query.all<Message>();
   return result.results;

--- a/apps/web/functions/api/repositoryRepo.ts
+++ b/apps/web/functions/api/repositoryRepo.ts
@@ -1,5 +1,5 @@
-import type { Repository, CreateRepositoryInput } from "@agent-kanban/shared";
-import { newId, type D1 } from "./db";
+import type { CreateRepositoryInput, Repository } from "@agent-kanban/shared";
+import { type D1, newId } from "./db";
 
 /** Normalize git URL to canonical HTTPS form without .git suffix */
 export function normalizeGitUrl(url: string): string {
@@ -18,31 +18,47 @@ function withFullName<T extends { url: string }>(repo: T): T & { full_name: stri
   return { ...repo, full_name: extractFullName(repo.url) };
 }
 
-export async function createRepository(db: D1, ownerId: string, input: CreateRepositoryInput): Promise<Repository> {
+export async function createRepository(
+  db: D1,
+  ownerId: string,
+  input: CreateRepositoryInput,
+): Promise<Repository> {
   const id = newId();
   const now = new Date().toISOString();
   const url = normalizeGitUrl(input.url);
 
-  await db.prepare(
-    "INSERT INTO repositories (id, owner_id, name, url, created_at) VALUES (?, ?, ?, ?, ?)"
-  ).bind(id, ownerId, input.name, url, now).run();
+  await db
+    .prepare(
+      "INSERT INTO repositories (id, owner_id, name, url, created_at) VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(id, ownerId, input.name, url, now)
+    .run();
 
   return withFullName({ id, owner_id: ownerId, name: input.name, url, created_at: now });
 }
 
-export async function findOrCreateRepository(db: D1, ownerId: string, input: CreateRepositoryInput): Promise<Repository> {
+export async function findOrCreateRepository(
+  db: D1,
+  ownerId: string,
+  input: CreateRepositoryInput,
+): Promise<Repository> {
   try {
     return await createRepository(db, ownerId, input);
   } catch {
-    const existing = await db.prepare(
-      "SELECT * FROM repositories WHERE owner_id = ? AND url = ?"
-    ).bind(ownerId, normalizeGitUrl(input.url)).first<Repository>();
+    const existing = await db
+      .prepare("SELECT * FROM repositories WHERE owner_id = ? AND url = ?")
+      .bind(ownerId, normalizeGitUrl(input.url))
+      .first<Repository>();
     if (existing) return existing;
     throw new Error("Failed to create or find repository");
   }
 }
 
-export async function listRepositories(db: D1, ownerId: string, filters?: { url?: string }): Promise<Repository[]> {
+export async function listRepositories(
+  db: D1,
+  ownerId: string,
+  filters?: { url?: string },
+): Promise<Repository[]> {
   let query = `
     SELECT r.*, COUNT(t.id) as task_count
     FROM repositories r
@@ -56,7 +72,10 @@ export async function listRepositories(db: D1, ownerId: string, filters?: { url?
   }
 
   query += " GROUP BY r.id ORDER BY r.created_at DESC";
-  const result = await db.prepare(query).bind(...binds).all<Repository>();
+  const result = await db
+    .prepare(query)
+    .bind(...binds)
+    .all<Repository>();
   return result.results.map(withFullName);
 }
 

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -1,18 +1,59 @@
+import { RESERVED_ROLES } from "@agent-kanban/shared";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import type { Env } from "./types";
+import {
+  createAgent,
+  deleteAgent,
+  getAgent,
+  getAgentLogs,
+  listAgents,
+  updateAgent,
+} from "./agentRepo";
+import {
+  closeSession,
+  createSession,
+  listSessions,
+  reopenSession,
+  updateSessionUsage,
+} from "./agentSessionRepo";
 import { authMiddleware } from "./auth";
-import { getBoard, listBoards, createBoard, getBoardByName, updateBoard, deleteBoard } from "./boardRepo";
-import { createRepository, listRepositories, deleteRepository } from "./repositoryRepo";
-import { createTask, listTasks, getTask, updateTask, deleteTask, claimTask, completeTask, releaseTask, assignTask, cancelTask, reviewTask, rejectTask, addTaskLog, getTaskLogs } from "./taskRepo";
-import { createAgent, listAgents, getAgent, getAgentLogs, updateAgent, deleteAgent } from "./agentRepo";
-import { RESERVED_ROLES } from "@agent-kanban/shared";
-import { createSession, closeSession, reopenSession, updateSessionUsage, listSessions } from "./agentSessionRepo";
-import { detectAndReleaseStale } from "./taskStale";
-import { createSSEResponse } from "./sse";
-import { createMessage, listMessages } from "./messageRepo";
-import { updateMachine, listMachines, getMachine, createMachine, deleteMachine } from "./machineRepo";
 import { createAuth } from "./betterAuth";
+import {
+  createBoard,
+  deleteBoard,
+  getBoard,
+  getBoardByName,
+  listBoards,
+  updateBoard,
+} from "./boardRepo";
+import {
+  createMachine,
+  deleteMachine,
+  getMachine,
+  listMachines,
+  updateMachine,
+} from "./machineRepo";
+import { createMessage, listMessages } from "./messageRepo";
+import { createRepository, deleteRepository, listRepositories } from "./repositoryRepo";
+import { createSSEResponse } from "./sse";
+import {
+  addTaskLog,
+  assignTask,
+  cancelTask,
+  claimTask,
+  completeTask,
+  createTask,
+  deleteTask,
+  getTask,
+  getTaskLogs,
+  listTasks,
+  rejectTask,
+  releaseTask,
+  reviewTask,
+  updateTask,
+} from "./taskRepo";
+import { detectAndReleaseStale } from "./taskStale";
+import type { Env } from "./types";
 
 const api = new Hono<{ Bindings: Env }>();
 
@@ -32,7 +73,10 @@ api.onError((err, c) => {
     return c.json({ error: { code: err.message, message: err.message } }, err.status);
   }
   console.error(`${c.req.method} ${c.req.path} 500 ${err.message}`);
-  return c.json({ error: { code: "INTERNAL_ERROR", message: err.message || "Internal server error" } }, 500);
+  return c.json(
+    { error: { code: "INTERNAL_ERROR", message: err.message || "Internal server error" } },
+    500,
+  );
 });
 
 // Better Auth handler — must be before auth middleware
@@ -73,8 +117,12 @@ api.get("/api/machines/:id", async (c) => {
 });
 
 api.post("/api/machines", async (c) => {
-
-  const body = await c.req.json<{ name: string; os: string; version: string; runtimes: string[] }>();
+  const body = await c.req.json<{
+    name: string;
+    os: string;
+    version: string;
+    runtimes: string[];
+  }>();
   if (!body.name || !body.os || !body.version || !body.runtimes) {
     throw new HTTPException(400, { message: "name, os, version, and runtimes are required" });
   }
@@ -107,7 +155,6 @@ api.post("/api/machines", async (c) => {
 });
 
 api.delete("/api/machines/:id", async (c) => {
-
   const machineId = c.req.param("id");
   const deleted = await deleteMachine(c.env.DB, machineId, c.get("ownerId"));
   if (!deleted) throw new HTTPException(404, { message: "Machine not found" });
@@ -135,29 +182,46 @@ api.get("/api/agents/:id", async (c) => {
 });
 
 api.post("/api/agents", async (c) => {
-  const body = await c.req.json<{ name: string; bio?: string; soul?: string; role?: string; handoff_to?: string[]; runtime?: string; model?: string; skills?: string[] }>();
+  const body = await c.req.json<{
+    name: string;
+    bio?: string;
+    soul?: string;
+    role?: string;
+    handoff_to?: string[];
+    runtime?: string;
+    model?: string;
+    skills?: string[];
+  }>();
   if (!body.name) throw new HTTPException(400, { message: "name is required" });
   if (body.role && RESERVED_ROLES.has(body.role)) {
-    throw new HTTPException(403, { message: `Role "${body.role}" is reserved for built-in agents` });
+    throw new HTTPException(403, {
+      message: `Role "${body.role}" is reserved for built-in agents`,
+    });
   }
   const agent = await createAgent(c.env.DB, c.get("ownerId"), body);
   return c.json(agent, 201);
 });
 
 api.patch("/api/agents/:id", async (c) => {
-  const existing = await c.env.DB.prepare("SELECT builtin FROM agents WHERE id = ?").bind(c.req.param("id")).first<{ builtin: number }>();
+  const existing = await c.env.DB.prepare("SELECT builtin FROM agents WHERE id = ?")
+    .bind(c.req.param("id"))
+    .first<{ builtin: number }>();
   if (!existing) throw new HTTPException(404, { message: "Agent not found" });
-  if (existing.builtin) throw new HTTPException(403, { message: "Built-in agents cannot be modified" });
+  if (existing.builtin)
+    throw new HTTPException(403, { message: "Built-in agents cannot be modified" });
   const body = await c.req.json();
   const agent = await updateAgent(c.env.DB, c.req.param("id"), body);
   return c.json(agent);
 });
 
 api.delete("/api/agents/:id", async (c) => {
-  const existing = await c.env.DB.prepare("SELECT builtin FROM agents WHERE id = ?").bind(c.req.param("id")).first<{ builtin: number }>();
+  const existing = await c.env.DB.prepare("SELECT builtin FROM agents WHERE id = ?")
+    .bind(c.req.param("id"))
+    .first<{ builtin: number }>();
   if (!existing) throw new HTTPException(404, { message: "Agent not found" });
-  if (existing.builtin) throw new HTTPException(403, { message: "Built-in agents cannot be deleted" });
-  const deleted = await deleteAgent(c.env.DB, c.req.param("id"));
+  if (existing.builtin)
+    throw new HTTPException(403, { message: "Built-in agents cannot be deleted" });
+  const _deleted = await deleteAgent(c.env.DB, c.req.param("id"));
   return c.json({ ok: true });
 });
 
@@ -172,8 +236,13 @@ api.post("/api/agents/:agentId/sessions", async (c) => {
   if (!machineId) throw new HTTPException(400, { message: "Machine not registered" });
 
   const result = await createSession(
-    c.env.DB, c.env, c.req.param("agentId"), machineId,
-    body.session_id, body.session_public_key, c.get("ownerId"),
+    c.env.DB,
+    c.env,
+    c.req.param("agentId"),
+    machineId,
+    body.session_id,
+    body.session_public_key,
+    c.get("ownerId"),
   );
   return c.json(result, 201);
 });
@@ -215,7 +284,14 @@ api.post("/api/tasks", async (c) => {
 
 api.get("/api/tasks", async (c) => {
   const { repository_id, status, label, board_id, parent, assigned_to } = c.req.query();
-  const tasks = await listTasks(c.env.DB, { repository_id, status, label, board_id, parent, assigned_to });
+  const tasks = await listTasks(c.env.DB, {
+    repository_id,
+    status,
+    label,
+    board_id,
+    parent,
+    assigned_to,
+  });
   return c.json(tasks);
 });
 
@@ -246,8 +322,7 @@ api.delete("/api/tasks/:id", async (c) => {
 // ─── Task Lifecycle ───
 
 api.post("/api/tasks/:id/claim", async (c) => {
-
-  const body = await c.req.json().catch(() => ({})) as { agent_id?: string };
+  const body = (await c.req.json().catch(() => ({}))) as { agent_id?: string };
   const agentId = c.get("agentId") || body.agent_id;
   if (!agentId) throw new HTTPException(400, { message: "agent_id is required" });
 
@@ -256,10 +331,21 @@ api.post("/api/tasks/:id/claim", async (c) => {
 });
 
 api.post("/api/tasks/:id/complete", async (c) => {
-  const body = await c.req.json().catch(() => ({})) as { result?: string; pr_url?: string; agent_id?: string };
+  const body = (await c.req.json().catch(() => ({}))) as {
+    result?: string;
+    pr_url?: string;
+    agent_id?: string;
+  };
   const agentId = c.get("agentId") || body.agent_id;
 
-  const task = await completeTask(c.env.DB, c.req.param("id"), agentId || null, body.result || null, body.pr_url || null, c.get("identityType"));
+  const task = await completeTask(
+    c.env.DB,
+    c.req.param("id"),
+    agentId || null,
+    body.result || null,
+    body.pr_url || null,
+    c.get("identityType"),
+  );
   return c.json(task);
 });
 
@@ -270,13 +356,13 @@ api.post("/api/tasks/:id/release", async (c) => {
 });
 
 api.post("/api/tasks/:id/assign", async (c) => {
-
   const body = await c.req.json<{ agent_id: string }>();
   const agentId = c.get("agentId") || body.agent_id;
   if (!agentId) throw new HTTPException(400, { message: "agent_id is required" });
 
   const existing = await c.env.DB.prepare("SELECT board_id FROM tasks WHERE id = ?")
-    .bind(c.req.param("id")).first<{ board_id: string }>();
+    .bind(c.req.param("id"))
+    .first<{ board_id: string }>();
   if (existing) {
     await detectAndReleaseStale(c.env.DB, existing.board_id);
   }
@@ -286,28 +372,46 @@ api.post("/api/tasks/:id/assign", async (c) => {
 });
 
 api.post("/api/tasks/:id/cancel", async (c) => {
-  const body = await c.req.json().catch(() => ({})) as { agent_id?: string };
+  const body = (await c.req.json().catch(() => ({}))) as { agent_id?: string };
   const agentId = c.get("agentId") || body.agent_id;
 
-  const task = await cancelTask(c.env.DB, c.req.param("id"), agentId || null, c.get("identityType"));
+  const task = await cancelTask(
+    c.env.DB,
+    c.req.param("id"),
+    agentId || null,
+    c.get("identityType"),
+  );
   return c.json(task);
 });
 
 api.post("/api/tasks/:id/review", async (c) => {
-  const body = await c.req.json().catch(() => ({})) as { agent_id?: string; pr_url?: string };
+  const body = (await c.req.json().catch(() => ({}))) as { agent_id?: string; pr_url?: string };
   const agentId = c.get("agentId") || body.agent_id;
 
   const existing = await c.env.DB.prepare("SELECT assigned_to FROM tasks WHERE id = ?")
-    .bind(c.req.param("id")).first<{ assigned_to: string | null }>();
+    .bind(c.req.param("id"))
+    .first<{ assigned_to: string | null }>();
 
-  const task = await reviewTask(c.env.DB, c.req.param("id"), agentId || existing?.assigned_to || null, body.pr_url || null, c.get("identityType"));
+  const task = await reviewTask(
+    c.env.DB,
+    c.req.param("id"),
+    agentId || existing?.assigned_to || null,
+    body.pr_url || null,
+    c.get("identityType"),
+  );
   return c.json(task);
 });
 
 api.post("/api/tasks/:id/reject", async (c) => {
   const agentId = c.get("agentId") || null;
-  const body = await c.req.json<{ reason?: string }>().catch(() => ({} as { reason?: string }));
-  const task = await rejectTask(c.env.DB, c.req.param("id"), agentId, c.get("identityType"), body.reason);
+  const body = await c.req.json<{ reason?: string }>().catch(() => ({}) as { reason?: string });
+  const task = await rejectTask(
+    c.env.DB,
+    c.req.param("id"),
+    agentId,
+    c.get("identityType"),
+    body.reason,
+  );
   return c.json(task);
 });
 
@@ -318,17 +422,25 @@ api.post("/api/tasks/:id/logs", async (c) => {
   if (!body.detail) throw new HTTPException(400, { message: "detail is required" });
 
   const task = await c.env.DB.prepare("SELECT id FROM tasks WHERE id = ?")
-    .bind(c.req.param("id")).first();
+    .bind(c.req.param("id"))
+    .first();
   if (!task) throw new HTTPException(404, { message: "Task not found" });
 
   const agentId = c.get("agentId") || body.agent_id;
-  const log = await addTaskLog(c.env.DB, c.req.param("id"), agentId || null, "commented", body.detail);
+  const log = await addTaskLog(
+    c.env.DB,
+    c.req.param("id"),
+    agentId || null,
+    "commented",
+    body.detail,
+  );
   return c.json(log, 201);
 });
 
 api.get("/api/tasks/:id/logs", async (c) => {
   const task = await c.env.DB.prepare("SELECT id FROM tasks WHERE id = ?")
-    .bind(c.req.param("id")).first();
+    .bind(c.req.param("id"))
+    .first();
   if (!task) throw new HTTPException(404, { message: "Task not found" });
 
   const since = c.req.query("since");
@@ -347,20 +459,29 @@ api.post("/api/tasks/:id/messages", async (c) => {
     throw new HTTPException(400, { message: "sender_type must be 'user' or 'agent'" });
   }
 
-  const senderId = body.sender_id || (body.sender_type === "agent" ? c.get("agentId") : c.get("ownerId"));
+  const senderId =
+    body.sender_id || (body.sender_type === "agent" ? c.get("agentId") : c.get("ownerId"));
   if (!senderId) throw new HTTPException(400, { message: "sender_id is required" });
 
   const task = await c.env.DB.prepare("SELECT id FROM tasks WHERE id = ?")
-    .bind(c.req.param("id")).first();
+    .bind(c.req.param("id"))
+    .first();
   if (!task) throw new HTTPException(404, { message: "Task not found" });
 
-  const message = await createMessage(c.env.DB, c.req.param("id"), body.sender_type, senderId, body.content);
+  const message = await createMessage(
+    c.env.DB,
+    c.req.param("id"),
+    body.sender_type,
+    senderId,
+    body.content,
+  );
   return c.json(message, 201);
 });
 
 api.get("/api/tasks/:id/messages", async (c) => {
   const task = await c.env.DB.prepare("SELECT id FROM tasks WHERE id = ?")
-    .bind(c.req.param("id")).first();
+    .bind(c.req.param("id"))
+    .first();
   if (!task) throw new HTTPException(404, { message: "Task not found" });
 
   const since = c.req.query("since");
@@ -435,7 +556,9 @@ api.get("/api/repositories", async (c) => {
 
 api.delete("/api/repositories/:id", async (c) => {
   const ownerId = c.get("ownerId");
-  const repo = await c.env.DB.prepare("SELECT owner_id FROM repositories WHERE id = ?").bind(c.req.param("id")).first<{ owner_id: string }>();
+  const repo = await c.env.DB.prepare("SELECT owner_id FROM repositories WHERE id = ?")
+    .bind(c.req.param("id"))
+    .first<{ owner_id: string }>();
   if (!repo) throw new HTTPException(404, { message: "Repository not found" });
   if (repo.owner_id !== ownerId) throw new HTTPException(403, { message: "Forbidden" });
   await deleteRepository(c.env.DB, c.req.param("id"));

--- a/apps/web/functions/api/sse.ts
+++ b/apps/web/functions/api/sse.ts
@@ -1,7 +1,6 @@
-import type { D1 } from "./db";
-import type { Env } from "./types";
-import { getTaskLogs } from "./taskRepo";
 import { listMessages } from "./messageRepo";
+import { getTaskLogs } from "./taskRepo";
+import type { Env } from "./types";
 
 interface SSEEvent {
   id: string;
@@ -12,7 +11,8 @@ interface SSEEvent {
 
 function mergeByTime(logs: SSEEvent[], messages: SSEEvent[]): SSEEvent[] {
   const merged: SSEEvent[] = [];
-  let i = 0, j = 0;
+  let i = 0,
+    j = 0;
   while (i < logs.length && j < messages.length) {
     if (logs[i].created_at <= messages[j].created_at) merged.push(logs[i++]);
     else merged.push(messages[j++]);
@@ -44,9 +44,12 @@ export async function createSSEResponse(
     // Resolve lastEventId to a timestamp for since-based filtering
     let since: string | undefined;
     if (lastEventId) {
-      const ref = await db.prepare(
-        "SELECT created_at FROM task_logs WHERE id = ? UNION SELECT created_at FROM messages WHERE id = ?",
-      ).bind(lastEventId, lastEventId).first<{ created_at: string }>();
+      const ref = await db
+        .prepare(
+          "SELECT created_at FROM task_logs WHERE id = ? UNION SELECT created_at FROM messages WHERE id = ?",
+        )
+        .bind(lastEventId, lastEventId)
+        .first<{ created_at: string }>();
       since = ref?.created_at;
     }
 
@@ -55,19 +58,28 @@ export async function createSSEResponse(
       listMessages(db, taskId, since),
     ]);
 
-    const logEvents: SSEEvent[] = (since ? initialLogs : initialLogs.slice(-50))
-      .map((l) => ({ id: l.id, type: "log" as const, data: JSON.stringify(l), created_at: l.created_at }));
-    const msgEvents: SSEEvent[] = (since ? initialMessages : initialMessages.slice(-50))
-      .map((m) => ({ id: m.id, type: "message" as const, data: JSON.stringify(m), created_at: m.created_at }));
+    const logEvents: SSEEvent[] = (since ? initialLogs : initialLogs.slice(-50)).map((l) => ({
+      id: l.id,
+      type: "log" as const,
+      data: JSON.stringify(l),
+      created_at: l.created_at,
+    }));
+    const msgEvents: SSEEvent[] = (since ? initialMessages : initialMessages.slice(-50)).map(
+      (m) => ({
+        id: m.id,
+        type: "message" as const,
+        data: JSON.stringify(m),
+        created_at: m.created_at,
+      }),
+    );
 
     const batch = mergeByTime(logEvents, msgEvents);
     for (const event of batch) {
       await write(event);
     }
 
-    let lastSeen = batch.length > 0
-      ? batch[batch.length - 1].created_at
-      : (since || new Date().toISOString());
+    let lastSeen =
+      batch.length > 0 ? batch[batch.length - 1].created_at : since || new Date().toISOString();
 
     // Poll every 2s for up to 25s (CF Workers 30s limit)
     const deadline = Date.now() + 25000;
@@ -79,8 +91,18 @@ export async function createSSEResponse(
         listMessages(db, taskId, lastSeen),
       ]);
 
-      const newLogEvents = newLogs.map((l) => ({ id: l.id, type: "log" as const, data: JSON.stringify(l), created_at: l.created_at }));
-      const newMsgEvents = newMessages.map((m) => ({ id: m.id, type: "message" as const, data: JSON.stringify(m), created_at: m.created_at }));
+      const newLogEvents = newLogs.map((l) => ({
+        id: l.id,
+        type: "log" as const,
+        data: JSON.stringify(l),
+        created_at: l.created_at,
+      }));
+      const newMsgEvents = newMessages.map((m) => ({
+        id: m.id,
+        type: "message" as const,
+        data: JSON.stringify(m),
+        created_at: m.created_at,
+      }));
       const merged = mergeByTime(newLogEvents, newMsgEvents);
 
       for (const event of merged) {

--- a/apps/web/functions/api/taskDeps.ts
+++ b/apps/web/functions/api/taskDeps.ts
@@ -4,7 +4,8 @@ export async function detectCycle(db: D1, taskId: string, dependsOn: string[]): 
   if (dependsOn.includes(taskId)) return true;
 
   for (const depId of dependsOn) {
-    const result = await db.prepare(`
+    const result = await db
+      .prepare(`
       WITH RECURSIVE dep_chain(tid) AS (
         SELECT ?
         UNION
@@ -12,7 +13,9 @@ export async function detectCycle(db: D1, taskId: string, dependsOn: string[]): 
         JOIN task_dependencies td ON td.task_id = dc.tid
       )
       SELECT 1 FROM dep_chain WHERE tid = ? LIMIT 1
-    `).bind(depId, taskId).first();
+    `)
+      .bind(depId, taskId)
+      .first();
 
     if (result) return true;
   }
@@ -24,19 +27,23 @@ export async function computeBlocked(db: D1, taskIds: string[]): Promise<Set<str
   if (taskIds.length === 0) return new Set();
 
   const placeholders = taskIds.map(() => "?").join(",");
-  const result = await db.prepare(`
+  const result = await db
+    .prepare(`
     SELECT DISTINCT td.task_id FROM task_dependencies td
     JOIN tasks dep ON dep.id = td.depends_on
     WHERE td.task_id IN (${placeholders}) AND dep.status NOT IN ('done', 'cancelled')
-  `).bind(...taskIds).all<{ task_id: string }>();
+  `)
+    .bind(...taskIds)
+    .all<{ task_id: string }>();
 
   return new Set(result.results.map((r: { task_id: string }) => r.task_id));
 }
 
 export async function getDependencies(db: D1, taskId: string): Promise<string[]> {
-  const result = await db.prepare(
-    "SELECT depends_on FROM task_dependencies WHERE task_id = ?"
-  ).bind(taskId).all<{ depends_on: string }>();
+  const result = await db
+    .prepare("SELECT depends_on FROM task_dependencies WHERE task_id = ?")
+    .bind(taskId)
+    .all<{ depends_on: string }>();
   return result.results.map((r: { depends_on: string }) => r.depends_on);
 }
 
@@ -44,7 +51,9 @@ export async function setDependencies(db: D1, taskId: string, deps: string[]): P
   const stmts = [
     db.prepare("DELETE FROM task_dependencies WHERE task_id = ?").bind(taskId),
     ...deps.map((depId) =>
-      db.prepare("INSERT INTO task_dependencies (task_id, depends_on) VALUES (?, ?)").bind(taskId, depId)
+      db
+        .prepare("INSERT INTO task_dependencies (task_id, depends_on) VALUES (?, ?)")
+        .bind(taskId, depId),
     ),
   ];
   await db.batch(stmts);

--- a/apps/web/functions/api/taskRepo.ts
+++ b/apps/web/functions/api/taskRepo.ts
@@ -1,13 +1,25 @@
-import type { Task, TaskLog, TaskWithLogs, CreateTaskInput, TaskStatus, IdentityType, TaskTransition } from "@agent-kanban/shared";
+import type {
+  CreateTaskInput,
+  IdentityType,
+  Task,
+  TaskLog,
+  TaskStatus,
+  TaskTransition,
+  TaskWithLogs,
+} from "@agent-kanban/shared";
 import { validateTransition } from "@agent-kanban/shared";
 import { HTTPException } from "hono/http-exception";
-import { newLongId, parseJsonFields, type D1 } from "./db";
 import { getDefaultBoard } from "./boardRepo";
-import { detectCycle, computeBlocked, getDependencies, setDependencies } from "./taskDeps";
+import { type D1, newLongId, parseJsonFields } from "./db";
+import { computeBlocked, detectCycle, getDependencies, setDependencies } from "./taskDeps";
 
 const parseTask = <T extends Task>(row: T) => parseJsonFields(row, ["labels", "input"]);
 
-function enforceTransition(action: TaskTransition, currentStatus: TaskStatus, identity: IdentityType): void {
+function enforceTransition(
+  action: TaskTransition,
+  currentStatus: TaskStatus,
+  identity: IdentityType,
+): void {
   const error = validateTransition(action, currentStatus, identity);
   if (error) {
     const status = error.code === "FORBIDDEN" ? 403 : 409;
@@ -15,16 +27,21 @@ function enforceTransition(action: TaskTransition, currentStatus: TaskStatus, id
   }
 }
 
-export async function createTask(db: D1, ownerId: string, input: CreateTaskInput & { agentId?: string; assigned_to?: string }): Promise<Task> {
-  const board = input.board_id
-    ? { id: input.board_id }
-    : await getDefaultBoard(db, ownerId);
+export async function createTask(
+  db: D1,
+  ownerId: string,
+  input: CreateTaskInput & { agentId?: string; assigned_to?: string },
+): Promise<Task> {
+  const board = input.board_id ? { id: input.board_id } : await getDefaultBoard(db, ownerId);
 
   if (!board) throw new HTTPException(400, { message: "No board exists. Create a board first." });
 
-  const maxPos = await db.prepare(
-    "SELECT COALESCE(MAX(position), -1) as max_pos FROM tasks WHERE board_id = ? AND status = 'todo'"
-  ).bind(board.id).first<{ max_pos: number }>();
+  const maxPos = await db
+    .prepare(
+      "SELECT COALESCE(MAX(position), -1) as max_pos FROM tasks WHERE board_id = ? AND status = 'todo'",
+    )
+    .bind(board.id)
+    .first<{ max_pos: number }>();
 
   const taskId = newLongId();
   const logId = newLongId();
@@ -39,50 +56,89 @@ export async function createTask(db: D1, ownerId: string, input: CreateTaskInput
   }
 
   if (input.created_from) {
-    const parent = await db.prepare("SELECT id FROM tasks WHERE id = ?").bind(input.created_from).first();
+    const parent = await db
+      .prepare("SELECT id FROM tasks WHERE id = ?")
+      .bind(input.created_from)
+      .first();
     if (!parent) throw new HTTPException(400, { message: "Parent task not found" });
   }
 
   const stmts = [
-    db.prepare(`
+    db
+      .prepare(`
       INSERT INTO tasks (id, board_id, status, title, description, repository_id, labels, priority, created_by, assigned_to, result, pr_url, input, created_from, position, created_at, updated_at)
       VALUES (?, ?, 'todo', ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?, ?)
-    `).bind(
-      taskId, board.id, input.title, input.description || null,
-      input.repository_id || null, labelsJson, input.priority || null,
-      input.agentId || "human", input.assigned_to || null,
-      inputJson, input.created_from || null,
-      position, now, now,
-    ),
-    db.prepare(
-      "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'created', NULL, ?)"
-    ).bind(logId, taskId, input.agentId || null, null, now),
-    ...(input.assigned_to ? [
-      db.prepare(
-        "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)"
-      ).bind(newLongId(), taskId, input.assigned_to, null, now),
-    ] : []),
+    `)
+      .bind(
+        taskId,
+        board.id,
+        input.title,
+        input.description || null,
+        input.repository_id || null,
+        labelsJson,
+        input.priority || null,
+        input.agentId || "human",
+        input.assigned_to || null,
+        inputJson,
+        input.created_from || null,
+        position,
+        now,
+        now,
+      ),
+    db
+      .prepare(
+        "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'created', NULL, ?)",
+      )
+      .bind(logId, taskId, input.agentId || null, null, now),
+    ...(input.assigned_to
+      ? [
+          db
+            .prepare(
+              "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)",
+            )
+            .bind(newLongId(), taskId, input.assigned_to, null, now),
+        ]
+      : []),
     ...(input.depends_on || []).map((depId) =>
-      db.prepare("INSERT INTO task_dependencies (task_id, depends_on) VALUES (?, ?)").bind(taskId, depId)
+      db
+        .prepare("INSERT INTO task_dependencies (task_id, depends_on) VALUES (?, ?)")
+        .bind(taskId, depId),
     ),
   ];
 
   await db.batch(stmts);
 
   return {
-    id: taskId, board_id: board.id, status: "todo" as const, title: input.title,
-    description: input.description || null, repository_id: input.repository_id || null,
-    labels: input.labels || null, priority: input.priority || null,
-    created_by: input.agentId || "human", assigned_to: input.assigned_to || null,
-    result: null, pr_url: null, input: input.input || null,
+    id: taskId,
+    board_id: board.id,
+    status: "todo" as const,
+    title: input.title,
+    description: input.description || null,
+    repository_id: input.repository_id || null,
+    labels: input.labels || null,
+    priority: input.priority || null,
+    created_by: input.agentId || "human",
+    assigned_to: input.assigned_to || null,
+    result: null,
+    pr_url: null,
+    input: input.input || null,
     created_from: input.created_from || null,
-    position, created_at: now, updated_at: now,
+    position,
+    created_at: now,
+    updated_at: now,
   };
 }
 
 export async function listTasks(
   db: D1,
-  filters: { repository_id?: string; status?: string; label?: string; board_id?: string; parent?: string; assigned_to?: string },
+  filters: {
+    repository_id?: string;
+    status?: string;
+    label?: string;
+    board_id?: string;
+    parent?: string;
+    assigned_to?: string;
+  },
 ): Promise<Task[]> {
   let query = `
     SELECT t.*, r.name as repository_name FROM tasks t
@@ -126,9 +182,12 @@ export async function listTasks(
   if (taskIds.length > 0) {
     const blockedSet = await computeBlocked(db, taskIds);
     const placeholders = taskIds.map(() => "?").join(",");
-    const depsResult = await db.prepare(
-      `SELECT task_id, depends_on FROM task_dependencies WHERE task_id IN (${placeholders})`
-    ).bind(...taskIds).all<{ task_id: string; depends_on: string }>();
+    const depsResult = await db
+      .prepare(
+        `SELECT task_id, depends_on FROM task_dependencies WHERE task_id IN (${placeholders})`,
+      )
+      .bind(...taskIds)
+      .all<{ task_id: string; depends_on: string }>();
     const depsMap = new Map<string, string[]>();
     for (const row of depsResult.results) {
       const arr = depsMap.get(row.task_id) || [];
@@ -145,7 +204,8 @@ export async function listTasks(
 }
 
 export async function getTask(db: D1, taskId: string): Promise<TaskWithLogs | null> {
-  const task = await db.prepare(`
+  const task = await db
+    .prepare(`
     SELECT t.*, a.name as agent_name, a.public_key as agent_public_key, a.fingerprint as agent_fingerprint,
       r.name as repository_name,
       (SELECT COUNT(*) FROM tasks sub WHERE sub.created_from = t.id) as subtask_count
@@ -153,12 +213,17 @@ export async function getTask(db: D1, taskId: string): Promise<TaskWithLogs | nu
     LEFT JOIN agents a ON t.assigned_to = a.id
     LEFT JOIN repositories r ON t.repository_id = r.id
     WHERE t.id = ?
-  `).bind(taskId).first<Task & { subtask_count: number }>();
+  `)
+    .bind(taskId)
+    .first<Task & { subtask_count: number }>();
   if (!task) return null;
   parseTask(task);
 
   const [logs, deps, blockedSet] = await Promise.all([
-    db.prepare("SELECT * FROM task_logs WHERE task_id = ? ORDER BY created_at ASC").bind(taskId).all<TaskLog>(),
+    db
+      .prepare("SELECT * FROM task_logs WHERE task_id = ? ORDER BY created_at ASC")
+      .bind(taskId)
+      .all<TaskLog>(),
     getDependencies(db, taskId),
     computeBlocked(db, [taskId]),
   ]);
@@ -166,10 +231,33 @@ export async function getTask(db: D1, taskId: string): Promise<TaskWithLogs | nu
   const duration = computeDuration(logs.results);
   task.blocked = blockedSet.has(taskId);
 
-  return { ...task, logs: logs.results, duration_minutes: duration, depends_on: deps, subtask_count: task.subtask_count };
+  return {
+    ...task,
+    logs: logs.results,
+    duration_minutes: duration,
+    depends_on: deps,
+    subtask_count: task.subtask_count,
+  };
 }
 
-export async function updateTask(db: D1, taskId: string, updates: Partial<Pick<Task, "title" | "description" | "repository_id" | "labels" | "priority" | "result" | "pr_url" | "input" | "position">> & { depends_on?: string[] }): Promise<Task | null> {
+export async function updateTask(
+  db: D1,
+  taskId: string,
+  updates: Partial<
+    Pick<
+      Task,
+      | "title"
+      | "description"
+      | "repository_id"
+      | "labels"
+      | "priority"
+      | "result"
+      | "pr_url"
+      | "input"
+      | "position"
+    >
+  > & { depends_on?: string[] },
+): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
 
@@ -186,7 +274,17 @@ export async function updateTask(db: D1, taskId: string, updates: Partial<Pick<T
   const binds: unknown[] = [now];
 
   const jsonFields = new Set(["labels", "input"]);
-  const allowedFields = ["title", "description", "repository_id", "labels", "priority", "result", "pr_url", "input", "position"] as const;
+  const allowedFields = [
+    "title",
+    "description",
+    "repository_id",
+    "labels",
+    "priority",
+    "result",
+    "pr_url",
+    "input",
+    "position",
+  ] as const;
   for (const field of allowedFields) {
     if (field in updates && (updates as any)[field] !== undefined) {
       sets.push(`${field} = ?`);
@@ -196,40 +294,56 @@ export async function updateTask(db: D1, taskId: string, updates: Partial<Pick<T
   }
 
   binds.push(taskId);
-  await db.prepare(`UPDATE tasks SET ${sets.join(", ")} WHERE id = ?`).bind(...binds).run();
+  await db
+    .prepare(`UPDATE tasks SET ${sets.join(", ")} WHERE id = ?`)
+    .bind(...binds)
+    .run();
 
   return parseTask({ ...task, ...updates, updated_at: now } as Task);
 }
 
 export async function deleteTask(db: D1, taskId: string): Promise<boolean> {
-  const task = await db.prepare("SELECT status, assigned_to FROM tasks WHERE id = ?").bind(taskId).first<{ status: string; assigned_to: string | null }>();
+  const task = await db
+    .prepare("SELECT status, assigned_to FROM tasks WHERE id = ?")
+    .bind(taskId)
+    .first<{ status: string; assigned_to: string | null }>();
   if (!task) return false;
 
   const canDelete = (task.status === "todo" && !task.assigned_to) || task.status === "cancelled";
   if (!canDelete) {
-    throw new HTTPException(409, { message: `Cannot delete task in ${task.status}${task.assigned_to ? " (assigned)" : ""} status` });
+    throw new HTTPException(409, {
+      message: `Cannot delete task in ${task.status}${task.assigned_to ? " (assigned)" : ""} status`,
+    });
   }
 
   const result = await db.prepare("DELETE FROM tasks WHERE id = ?").bind(taskId).run();
   return result.meta.changes > 0;
 }
 
-export async function claimTask(db: D1, taskId: string, agentId: string, identity: IdentityType): Promise<Task | null> {
+export async function claimTask(
+  db: D1,
+  taskId: string,
+  agentId: string,
+  identity: IdentityType,
+): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
-  if (task.assigned_to !== agentId) throw new HTTPException(409, { message: "Task is not assigned to this agent" });
+  if (task.assigned_to !== agentId)
+    throw new HTTPException(409, { message: "Task is not assigned to this agent" });
   enforceTransition("claim", task.status as TaskStatus, identity);
 
   const now = new Date().toISOString();
   const logId = newLongId();
 
   await db.batch([
-    db.prepare(
-      "UPDATE tasks SET status = 'in_progress', updated_at = ? WHERE id = ?"
-    ).bind(now, taskId),
-    db.prepare(
-      "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'claimed', NULL, ?)"
-    ).bind(logId, taskId, agentId, null, now),
+    db
+      .prepare("UPDATE tasks SET status = 'in_progress', updated_at = ? WHERE id = ?")
+      .bind(now, taskId),
+    db
+      .prepare(
+        "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'claimed', NULL, ?)",
+      )
+      .bind(logId, taskId, agentId, null, now),
   ]);
 
   return parseTask({ ...task, status: "in_progress" as const, updated_at: now });
@@ -238,28 +352,41 @@ export async function claimTask(db: D1, taskId: string, agentId: string, identit
 export async function assignTask(db: D1, taskId: string, agentId: string): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
-  if (task.status !== "todo") throw new HTTPException(409, { message: "Can only assign tasks in todo status" });
+  if (task.status !== "todo")
+    throw new HTTPException(409, { message: "Can only assign tasks in todo status" });
   if (task.assigned_to) throw new HTTPException(409, { message: "Task is already assigned" });
 
   const blockedSet = await computeBlocked(db, [taskId]);
-  if (blockedSet.has(taskId)) throw new HTTPException(409, { message: "Task is blocked by unfinished dependencies" });
+  if (blockedSet.has(taskId))
+    throw new HTTPException(409, { message: "Task is blocked by unfinished dependencies" });
 
   const now = new Date().toISOString();
   const logId = newLongId();
 
   await db.batch([
-    db.prepare(
-      "UPDATE tasks SET assigned_to = ?, updated_at = ? WHERE id = ? AND assigned_to IS NULL"
-    ).bind(agentId, now, taskId),
-    db.prepare(
-      "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)"
-    ).bind(logId, taskId, agentId, null, now),
+    db
+      .prepare(
+        "UPDATE tasks SET assigned_to = ?, updated_at = ? WHERE id = ? AND assigned_to IS NULL",
+      )
+      .bind(agentId, now, taskId),
+    db
+      .prepare(
+        "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)",
+      )
+      .bind(logId, taskId, agentId, null, now),
   ]);
 
   return parseTask({ ...task, assigned_to: agentId, updated_at: now } as Task);
 }
 
-export async function completeTask(db: D1, taskId: string, agentId: string | null, result: string | null, prUrl: string | null, identity: IdentityType): Promise<Task | null> {
+export async function completeTask(
+  db: D1,
+  taskId: string,
+  agentId: string | null,
+  result: string | null,
+  prUrl: string | null,
+  identity: IdentityType,
+): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
   enforceTransition("complete", task.status as TaskStatus, identity);
@@ -268,18 +395,27 @@ export async function completeTask(db: D1, taskId: string, agentId: string | nul
   const logId = newLongId();
 
   await db.batch([
-    db.prepare(
-      "UPDATE tasks SET status = 'done', result = ?, pr_url = ?, updated_at = ? WHERE id = ?"
-    ).bind(result, prUrl, now, taskId),
-    db.prepare(
-      "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'completed', ?, ?)"
-    ).bind(logId, taskId, agentId, null, result, now),
+    db
+      .prepare(
+        "UPDATE tasks SET status = 'done', result = ?, pr_url = ?, updated_at = ? WHERE id = ?",
+      )
+      .bind(result, prUrl, now, taskId),
+    db
+      .prepare(
+        "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'completed', ?, ?)",
+      )
+      .bind(logId, taskId, agentId, null, result, now),
   ]);
 
   return parseTask({ ...task, status: "done" as const, result, pr_url: prUrl, updated_at: now });
 }
 
-export async function cancelTask(db: D1, taskId: string, agentId: string | null, identity: IdentityType): Promise<Task | null> {
+export async function cancelTask(
+  db: D1,
+  taskId: string,
+  agentId: string | null,
+  identity: IdentityType,
+): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
   enforceTransition("cancel", task.status as TaskStatus, identity);
@@ -288,18 +424,28 @@ export async function cancelTask(db: D1, taskId: string, agentId: string | null,
   const logId = newLongId();
 
   await db.batch([
-    db.prepare(
-      "UPDATE tasks SET status = 'cancelled', assigned_to = NULL, updated_at = ? WHERE id = ?"
-    ).bind(now, taskId),
-    db.prepare(
-      "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'cancelled', NULL, ?)"
-    ).bind(logId, taskId, agentId, null, now),
+    db
+      .prepare(
+        "UPDATE tasks SET status = 'cancelled', assigned_to = NULL, updated_at = ? WHERE id = ?",
+      )
+      .bind(now, taskId),
+    db
+      .prepare(
+        "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'cancelled', NULL, ?)",
+      )
+      .bind(logId, taskId, agentId, null, now),
   ]);
 
   return parseTask({ ...task, status: "cancelled" as const, assigned_to: null, updated_at: now });
 }
 
-export async function reviewTask(db: D1, taskId: string, agentId: string | null, prUrl: string | null, identity: IdentityType): Promise<Task | null> {
+export async function reviewTask(
+  db: D1,
+  taskId: string,
+  agentId: string | null,
+  prUrl: string | null,
+  identity: IdentityType,
+): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
   enforceTransition("review", task.status as TaskStatus, identity);
@@ -308,18 +454,33 @@ export async function reviewTask(db: D1, taskId: string, agentId: string | null,
   const logId = newLongId();
 
   await db.batch([
-    db.prepare(
-      "UPDATE tasks SET status = 'in_review', pr_url = COALESCE(?, pr_url), updated_at = ? WHERE id = ?"
-    ).bind(prUrl, now, taskId),
-    db.prepare(
-      "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'review_requested', NULL, ?)"
-    ).bind(logId, taskId, agentId, null, now),
+    db
+      .prepare(
+        "UPDATE tasks SET status = 'in_review', pr_url = COALESCE(?, pr_url), updated_at = ? WHERE id = ?",
+      )
+      .bind(prUrl, now, taskId),
+    db
+      .prepare(
+        "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'review_requested', NULL, ?)",
+      )
+      .bind(logId, taskId, agentId, null, now),
   ]);
 
-  return parseTask({ ...task, status: "in_review" as const, pr_url: prUrl || task.pr_url, updated_at: now });
+  return parseTask({
+    ...task,
+    status: "in_review" as const,
+    pr_url: prUrl || task.pr_url,
+    updated_at: now,
+  });
 }
 
-export async function releaseTask(db: D1, taskId: string, agentId: string | null, identity: IdentityType, action: "released" | "timed_out" = "released"): Promise<Task | null> {
+export async function releaseTask(
+  db: D1,
+  taskId: string,
+  agentId: string | null,
+  identity: IdentityType,
+  action: "released" | "timed_out" = "released",
+): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
   enforceTransition("release", task.status as TaskStatus, identity);
@@ -328,18 +489,24 @@ export async function releaseTask(db: D1, taskId: string, agentId: string | null
   const logId = newLongId();
 
   await db.batch([
-    db.prepare(
-      "UPDATE tasks SET status = 'todo', updated_at = ? WHERE id = ?"
-    ).bind(now, taskId),
-    db.prepare(
-      "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, NULL, ?)"
-    ).bind(logId, taskId, agentId, null, action, now),
+    db.prepare("UPDATE tasks SET status = 'todo', updated_at = ? WHERE id = ?").bind(now, taskId),
+    db
+      .prepare(
+        "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, NULL, ?)",
+      )
+      .bind(logId, taskId, agentId, null, action, now),
   ]);
 
   return parseTask({ ...task, status: "todo" as const, updated_at: now });
 }
 
-export async function rejectTask(db: D1, taskId: string, agentId: string | null, identity: IdentityType, reason?: string): Promise<Task | null> {
+export async function rejectTask(
+  db: D1,
+  taskId: string,
+  agentId: string | null,
+  identity: IdentityType,
+  reason?: string,
+): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
   enforceTransition("reject", task.status as TaskStatus, identity);
@@ -348,12 +515,14 @@ export async function rejectTask(db: D1, taskId: string, agentId: string | null,
   const logId = newLongId();
 
   await db.batch([
-    db.prepare(
-      "UPDATE tasks SET status = 'in_progress', updated_at = ? WHERE id = ?"
-    ).bind(now, taskId),
-    db.prepare(
-      "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'rejected', ?, ?)"
-    ).bind(logId, taskId, agentId, null, reason || null, now),
+    db
+      .prepare("UPDATE tasks SET status = 'in_progress', updated_at = ? WHERE id = ?")
+      .bind(now, taskId),
+    db
+      .prepare(
+        "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'rejected', ?, ?)",
+      )
+      .bind(logId, taskId, agentId, null, reason || null, now),
   ]);
 
   return parseTask({ ...task, status: "in_progress" as const, updated_at: now });
@@ -369,11 +538,22 @@ export async function addTaskLog(
   const logId = newLongId();
   const now = new Date().toISOString();
 
-  await db.prepare(
-    "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
-  ).bind(logId, taskId, agentId, null, action, detail, now).run();
+  await db
+    .prepare(
+      "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(logId, taskId, agentId, null, action, detail, now)
+    .run();
 
-  return { id: logId, task_id: taskId, agent_id: agentId, session_id: null, action: action as any, detail, created_at: now };
+  return {
+    id: logId,
+    task_id: taskId,
+    agent_id: agentId,
+    session_id: null,
+    action: action as any,
+    detail,
+    created_at: now,
+  };
 }
 
 export async function getTaskLogs(db: D1, taskId: string, since?: string): Promise<TaskLog[]> {
@@ -387,7 +567,10 @@ export async function getTaskLogs(db: D1, taskId: string, since?: string): Promi
 
   query += " ORDER BY created_at ASC";
 
-  const result = await db.prepare(query).bind(...binds).all<TaskLog>();
+  const result = await db
+    .prepare(query)
+    .bind(...binds)
+    .all<TaskLog>();
   return result.results;
 }
 

--- a/apps/web/functions/api/taskStale.ts
+++ b/apps/web/functions/api/taskStale.ts
@@ -5,13 +5,16 @@ import { releaseTask } from "./taskRepo";
 export async function detectAndReleaseStale(db: D1, boardId: string): Promise<void> {
   const cutoff = new Date(Date.now() - STALE_TIMEOUT_MS).toISOString();
 
-  const staleTasks = await db.prepare(`
+  const staleTasks = await db
+    .prepare(`
     SELECT t.id, t.assigned_to FROM tasks t
     WHERE t.board_id = ? AND t.status IN ('in_progress', 'in_review') AND t.assigned_to IS NOT NULL
     AND (
       SELECT MAX(tl.created_at) FROM task_logs tl WHERE tl.task_id = t.id
     ) < ?
-  `).bind(boardId, cutoff).all<{ id: string; assigned_to: string }>();
+  `)
+    .bind(boardId, cutoff)
+    .all<{ id: string; assigned_to: string }>();
 
   for (const stale of staleTasks.results) {
     await releaseTask(db, stale.id, stale.assigned_to, "machine", "timed_out");

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,16 +1,16 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
-import { BoardPage } from "./routes/BoardPage";
-import { AccountSettingsPage } from "./routes/AccountSettingsPage";
-import { MachinesPage } from "./routes/MachinesPage";
-import { MachineDetailPage } from "./routes/MachineDetailPage";
-import { AgentsPage } from "./routes/AgentsPage";
-import { AgentNewPage } from "./routes/AgentNewPage";
-import { AgentDetailPage } from "./routes/AgentDetailPage";
-import { RepositoriesPage } from "./routes/RepositoriesPage";
-import { AuthPage } from "./routes/AuthPage";
-import { AuthCallbackPage } from "./routes/AuthCallbackPage";
-import { BoardRedirect } from "./routes/BoardRedirect";
+import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import { useSession } from "./lib/auth-client";
+import { AccountSettingsPage } from "./routes/AccountSettingsPage";
+import { AgentDetailPage } from "./routes/AgentDetailPage";
+import { AgentNewPage } from "./routes/AgentNewPage";
+import { AgentsPage } from "./routes/AgentsPage";
+import { AuthCallbackPage } from "./routes/AuthCallbackPage";
+import { AuthPage } from "./routes/AuthPage";
+import { BoardPage } from "./routes/BoardPage";
+import { BoardRedirect } from "./routes/BoardRedirect";
+import { MachineDetailPage } from "./routes/MachineDetailPage";
+import { MachinesPage } from "./routes/MachinesPage";
+import { RepositoriesPage } from "./routes/RepositoriesPage";
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { data: session, isPending } = useSession();
@@ -26,15 +26,78 @@ export function App() {
       <Routes>
         <Route path="/auth" element={<AuthPage />} />
         <Route path="/auth/callback" element={<AuthCallbackPage />} />
-        <Route path="/" element={<ProtectedRoute><BoardRedirect /></ProtectedRoute>} />
-        <Route path="/boards/:boardId" element={<ProtectedRoute><BoardPage /></ProtectedRoute>} />
-        <Route path="/machines" element={<ProtectedRoute><MachinesPage /></ProtectedRoute>} />
-        <Route path="/machines/:id" element={<ProtectedRoute><MachineDetailPage /></ProtectedRoute>} />
-        <Route path="/agents" element={<ProtectedRoute><AgentsPage /></ProtectedRoute>} />
-        <Route path="/agents/new" element={<ProtectedRoute><AgentNewPage /></ProtectedRoute>} />
-        <Route path="/agents/:id" element={<ProtectedRoute><AgentDetailPage /></ProtectedRoute>} />
-        <Route path="/repositories" element={<ProtectedRoute><RepositoriesPage /></ProtectedRoute>} />
-        <Route path="/settings" element={<ProtectedRoute><AccountSettingsPage /></ProtectedRoute>} />
+        <Route
+          path="/"
+          element={
+            <ProtectedRoute>
+              <BoardRedirect />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/boards/:boardId"
+          element={
+            <ProtectedRoute>
+              <BoardPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/machines"
+          element={
+            <ProtectedRoute>
+              <MachinesPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/machines/:id"
+          element={
+            <ProtectedRoute>
+              <MachineDetailPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/agents"
+          element={
+            <ProtectedRoute>
+              <AgentsPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/agents/new"
+          element={
+            <ProtectedRoute>
+              <AgentNewPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/agents/:id"
+          element={
+            <ProtectedRoute>
+              <AgentDetailPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/repositories"
+          element={
+            <ProtectedRoute>
+              <RepositoriesPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/settings"
+          element={
+            <ProtectedRoute>
+              <AccountSettingsPage />
+            </ProtectedRoute>
+          }
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/apps/web/src/components/ActivityLog.tsx
+++ b/apps/web/src/components/ActivityLog.tsx
@@ -78,17 +78,13 @@ export function ActivityLog({ taskId, initialLogs, assigned }: ActivityLogProps)
 
   if (displayed.length === 0) {
     return (
-      <p className="text-sm text-content-tertiary">
-        No activity yet. Assign an agent to see logs.
-      </p>
+      <p className="text-sm text-content-tertiary">No activity yet. Assign an agent to see logs.</p>
     );
   }
 
   return (
     <div className="relative">
-      {reconnecting && (
-        <div className="text-[10px] text-warning mb-1">Reconnecting...</div>
-      )}
+      {reconnecting && <div className="text-[10px] text-warning mb-1">Reconnecting...</div>}
 
       {newCount > 0 && !autoScroll && (
         <Button
@@ -116,15 +112,21 @@ export function ActivityLog({ taskId, initialLogs, assigned }: ActivityLogProps)
             <span className="font-mono text-[11px] text-content-tertiary whitespace-nowrap min-w-[50px]">
               {formatRelative(log.created_at)}
             </span>
-            <span className={`text-[13px] ${
-              log.action === "commented"
-                ? "font-mono text-xs text-content-secondary bg-surface-primary px-1.5 py-0.5 rounded"
-                : "text-content-secondary"
-            }`}>
-              {log.action === "commented"
-                ? log.detail
-                : <span className={actionStyles[log.action] || ""}>{actionLabels[log.action] || log.action}{log.detail ? `: ${log.detail}` : ""}</span>
-              }
+            <span
+              className={`text-[13px] ${
+                log.action === "commented"
+                  ? "font-mono text-xs text-content-secondary bg-surface-primary px-1.5 py-0.5 rounded"
+                  : "text-content-secondary"
+              }`}
+            >
+              {log.action === "commented" ? (
+                log.detail
+              ) : (
+                <span className={actionStyles[log.action] || ""}>
+                  {actionLabels[log.action] || log.action}
+                  {log.detail ? `: ${log.detail}` : ""}
+                </span>
+              )}
             </span>
           </div>
         ))}

--- a/apps/web/src/components/AddMachineSteps.tsx
+++ b/apps/web/src/components/AddMachineSteps.tsx
@@ -1,7 +1,7 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import { Button } from "./ui/button";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../lib/api";
 import { getAuthToken } from "../lib/auth-client";
+import { Button } from "./ui/button";
 
 interface AddMachineStepsProps {
   apiKey: string;
@@ -29,7 +29,7 @@ export function AddMachineSteps({ apiKey, apiKeyId, onDone, onConnected }: AddMa
         headers: { Authorization: `Bearer ${getAuthToken()}` },
       });
       if (!res.ok) return;
-      const keyData = await res.json() as any;
+      const keyData = (await res.json()) as any;
       const machineId = keyData?.metadata?.machineId;
       if (!machineId) return;
       const m = await api.machines.get(machineId);
@@ -56,7 +56,9 @@ export function AddMachineSteps({ apiKey, apiKeyId, onDone, onConnected }: AddMa
             <span className="font-mono text-sm text-content-primary">{connectedMachine.name}</span>
           </div>
           <div className="flex items-center justify-between">
-            <span className="text-[11px] text-content-tertiary uppercase tracking-wide">Status</span>
+            <span className="text-[11px] text-content-tertiary uppercase tracking-wide">
+              Status
+            </span>
             <div className="flex items-center gap-1.5">
               <span className="w-1.5 h-1.5 rounded-full bg-success" />
               <span className="text-xs text-success">Online</span>
@@ -65,15 +67,24 @@ export function AddMachineSteps({ apiKey, apiKeyId, onDone, onConnected }: AddMa
           {connectedMachine.os && (
             <div className="flex items-center justify-between">
               <span className="text-[11px] text-content-tertiary uppercase tracking-wide">OS</span>
-              <span className="font-mono text-[11px] text-content-primary">{connectedMachine.os}</span>
+              <span className="font-mono text-[11px] text-content-primary">
+                {connectedMachine.os}
+              </span>
             </div>
           )}
           {connectedMachine.runtimes && (
             <div className="flex items-center justify-between">
-              <span className="text-[11px] text-content-tertiary uppercase tracking-wide">Runtimes</span>
+              <span className="text-[11px] text-content-tertiary uppercase tracking-wide">
+                Runtimes
+              </span>
               <div className="flex gap-1">
                 {connectedMachine.runtimes.map((r: string) => (
-                  <span key={r} className="text-[10px] font-mono text-accent bg-accent-soft px-1.5 py-0.5 rounded">{r}</span>
+                  <span
+                    key={r}
+                    className="text-[10px] font-mono text-accent bg-accent-soft px-1.5 py-0.5 rounded"
+                  >
+                    {r}
+                  </span>
                 ))}
               </div>
             </div>
@@ -108,9 +119,11 @@ export function AddMachineSteps({ apiKey, apiKeyId, onDone, onConnected }: AddMa
       <Button
         variant="outline"
         className="w-full"
-        onClick={() => navigator.clipboard.writeText(
-          `npx agent-kanban start --api-url ${apiUrl} --api-key ${apiKey}`
-        )}
+        onClick={() =>
+          navigator.clipboard.writeText(
+            `npx agent-kanban start --api-url ${apiUrl} --api-key ${apiKey}`,
+          )
+        }
       >
         Copy to clipboard
       </Button>

--- a/apps/web/src/components/AgentIdenticon.tsx
+++ b/apps/web/src/components/AgentIdenticon.tsx
@@ -1,4 +1,4 @@
-import { agentIdenticon, agentColor } from "../lib/agentIdentity";
+import { agentColor, agentIdenticon } from "../lib/agentIdentity";
 
 interface AgentIdenticonProps {
   publicKey: string;
@@ -17,12 +17,7 @@ export function AgentIdenticon({ publicKey, size = 40, glow, crystallize }: Agen
   let cellIndex = 0;
 
   return (
-    <svg
-      width={size}
-      height={size}
-      viewBox={`0 0 ${size} ${size}`}
-      className="shrink-0"
-    >
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} className="shrink-0">
       {glow && (
         <defs>
           <filter id={`glow-${publicKey.slice(0, 8)}`} x="-50%" y="-50%" width="200%" height="200%">
@@ -50,6 +45,7 @@ export function AgentIdenticon({ publicKey, size = 40, glow, crystallize }: Agen
             const idx = cellIndex++;
             return (
               <rect
+                // biome-ignore lint/suspicious/noArrayIndexKey: grid position (y,x) is the stable identity for each cell
                 key={`${y}-${x}`}
                 x={padding + x * cellSize + gap}
                 y={padding + y * cellSize + gap}
@@ -58,10 +54,14 @@ export function AgentIdenticon({ publicKey, size = 40, glow, crystallize }: Agen
                 rx={cellSize * 0.2}
                 fill={color}
                 opacity={crystallize ? 0 : 0.9}
-                style={crystallize ? {
-                  animation: `cell-in 0.4s ease-out ${idx * 60}ms forwards`,
-                  transformOrigin: `${padding + x * cellSize + cellSize / 2}px ${padding + y * cellSize + cellSize / 2}px`,
-                } : undefined}
+                style={
+                  crystallize
+                    ? {
+                        animation: `cell-in 0.4s ease-out ${idx * 60}ms forwards`,
+                        transformOrigin: `${padding + x * cellSize + cellSize / 2}px ${padding + y * cellSize + cellSize / 2}px`,
+                      }
+                    : undefined
+                }
               />
             );
           }),

--- a/apps/web/src/components/AgentProfile.tsx
+++ b/apps/web/src/components/AgentProfile.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from "react";
-import { api } from "../lib/api";
+import { useEffect, useState } from "react";
 import { agentFingerprint } from "../lib/agentIdentity";
+import { api } from "../lib/api";
 import { AgentIdenticon } from "./AgentIdenticon";
 import { formatRelative } from "./TaskDetailFields";
 import { Button } from "./ui/button";
-import { Sheet, SheetContent, SheetTitle, SheetDescription } from "./ui/sheet";
 import { Separator } from "./ui/separator";
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from "./ui/sheet";
 import { Skeleton } from "./ui/skeleton";
 
 interface AgentProfileProps {
@@ -37,11 +37,19 @@ export function AgentProfile({ agentId, onClose, onTaskClick }: AgentProfileProp
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    api.agents.get(agentId).then(setAgent).finally(() => setLoading(false));
+    api.agents
+      .get(agentId)
+      .then(setAgent)
+      .finally(() => setLoading(false));
   }, [agentId]);
 
   return (
-    <Sheet open onOpenChange={(open) => { if (!open) onClose(); }}>
+    <Sheet
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
       <SheetContent showCloseButton={false} className="overflow-y-auto p-0 gap-0">
         <SheetTitle className="sr-only">Agent profile</SheetTitle>
         <SheetDescription className="sr-only">Agent details and activity</SheetDescription>
@@ -64,7 +72,9 @@ export function AgentProfile({ agentId, onClose, onTaskClick }: AgentProfileProp
                   <h2 className="font-mono text-lg text-accent font-semibold">{agent.name}</h2>
                   <div className="flex items-center gap-1.5 mt-0.5">
                     <span className={`w-1.5 h-1.5 rounded-full ${statusDotColors[agent.status]}`} />
-                    <span className="text-xs text-content-secondary">{statusLabels[agent.status] || agent.status}</span>
+                    <span className="text-xs text-content-secondary">
+                      {statusLabels[agent.status] || agent.status}
+                    </span>
                   </div>
                   {agent.fingerprint && (
                     <span className="font-mono text-[10px] text-content-tertiary">
@@ -78,11 +88,15 @@ export function AgentProfile({ agentId, onClose, onTaskClick }: AgentProfileProp
             <div className="p-5 space-y-4">
               <div className="grid grid-cols-2 gap-4 text-sm">
                 <div>
-                  <div className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide mb-1">Tasks</div>
+                  <div className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide mb-1">
+                    Tasks
+                  </div>
                   <span className="font-mono text-content-primary">{agent.task_count}</span>
                 </div>
                 <div>
-                  <div className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide mb-1">Last Active</div>
+                  <div className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide mb-1">
+                    Last Active
+                  </div>
                   <span className="font-mono text-content-primary text-[13px]">
                     {agent.last_active_at ? formatRelative(agent.last_active_at) : "—"}
                   </span>
@@ -92,7 +106,9 @@ export function AgentProfile({ agentId, onClose, onTaskClick }: AgentProfileProp
               <Separator />
 
               <div>
-                <div className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide mb-2">Activity</div>
+                <div className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide mb-2">
+                  Activity
+                </div>
                 <div className="space-y-0 max-h-96 overflow-y-auto">
                   {(agent.logs || []).map((log: any) => (
                     <div
@@ -102,7 +118,9 @@ export function AgentProfile({ agentId, onClose, onTaskClick }: AgentProfileProp
                       <span className="font-mono text-[11px] text-content-tertiary whitespace-nowrap min-w-[50px]">
                         {formatRelative(log.created_at)}
                       </span>
-                      <span className={`text-[13px] ${actionStyles[log.action] || "text-content-secondary"}`}>
+                      <span
+                        className={`text-[13px] ${actionStyles[log.action] || "text-content-secondary"}`}
+                      >
                         {log.action}
                       </span>
                       {log.task_title && (

--- a/apps/web/src/components/BoardSwitcher.tsx
+++ b/apps/web/src/components/BoardSwitcher.tsx
@@ -1,6 +1,6 @@
-import { useState, useRef } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "./ui/dialog";
+import { useRef, useState } from "react";
 import { Button } from "./ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "./ui/dialog";
 import { Input } from "./ui/input";
 
 interface Board {
@@ -17,7 +17,13 @@ interface BoardSwitcherProps {
   onClose: () => void;
 }
 
-export function BoardSwitcher({ boards, activeBoardId, onSelect, onCreate, onClose }: BoardSwitcherProps) {
+export function BoardSwitcher({
+  boards,
+  activeBoardId,
+  onSelect,
+  onCreate,
+  onClose,
+}: BoardSwitcherProps) {
   const [newName, setNewName] = useState("");
   const [creating, setCreating] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -31,7 +37,12 @@ export function BoardSwitcher({ boards, activeBoardId, onSelect, onCreate, onClo
   }
 
   return (
-    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
       <DialogContent className="sm:max-w-md" showCloseButton={false}>
         <DialogHeader>
           <DialogTitle className="text-[11px] font-mono font-medium text-content-tertiary uppercase tracking-[0.08em]">
@@ -46,22 +57,28 @@ export function BoardSwitcher({ boards, activeBoardId, onSelect, onCreate, onClo
             const isActive = b.id === activeBoardId;
             return (
               <button
+                type="button"
                 key={b.id}
-                onClick={() => { onSelect(b.id); onClose(); }}
+                onClick={() => {
+                  onSelect(b.id);
+                  onClose();
+                }}
                 className={`w-full text-left px-3.5 py-3 rounded-lg transition-colors group ${
-                  isActive
-                    ? "bg-accent-soft"
-                    : "hover:bg-surface-tertiary"
+                  isActive ? "bg-accent-soft" : "hover:bg-surface-tertiary"
                 }`}
               >
                 <div className="flex items-center gap-3">
-                  <div className={`w-1.5 h-1.5 rounded-full shrink-0 ${
-                    isActive ? "bg-accent" : "bg-transparent"
-                  }`} />
+                  <div
+                    className={`w-1.5 h-1.5 rounded-full shrink-0 ${
+                      isActive ? "bg-accent" : "bg-transparent"
+                    }`}
+                  />
                   <div className="min-w-0 flex-1">
-                    <div className={`text-sm font-medium truncate ${
-                      isActive ? "text-accent" : "text-content-primary"
-                    }`}>
+                    <div
+                      className={`text-sm font-medium truncate ${
+                        isActive ? "text-accent" : "text-content-primary"
+                      }`}
+                    >
                       {b.name}
                     </div>
                     {b.description && (
@@ -92,16 +109,15 @@ export function BoardSwitcher({ boards, activeBoardId, onSelect, onCreate, onClo
                 onChange={(e) => setNewName(e.target.value)}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") handleCreate();
-                  if (e.key === "Escape") { setCreating(false); setNewName(""); }
+                  if (e.key === "Escape") {
+                    setCreating(false);
+                    setNewName("");
+                  }
                 }}
                 placeholder="Board name"
                 autoFocus
               />
-              <Button
-                onClick={handleCreate}
-                disabled={!newName.trim()}
-                size="sm"
-              >
+              <Button onClick={handleCreate} disabled={!newName.trim()} size="sm">
                 Create
               </Button>
             </div>
@@ -112,7 +128,16 @@ export function BoardSwitcher({ boards, activeBoardId, onSelect, onCreate, onClo
               onClick={() => setCreating(true)}
               className="w-full justify-start text-content-tertiary"
             >
-              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
                 <line x1="12" y1="5" x2="12" y2="19" />
                 <line x1="5" y1="12" x2="19" y2="12" />
               </svg>

--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -1,10 +1,10 @@
-import { useState, useRef, useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import { api } from "../lib/api";
 import { formatRelative } from "./TaskDetailFields";
+import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
-import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
-import { Badge } from "./ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 interface ChatPanelProps {
   taskId: string;
@@ -15,7 +15,14 @@ interface ChatPanelProps {
   sseMessages: any[];
 }
 
-export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, sseMessages }: ChatPanelProps) {
+export function ChatPanel({
+  taskId,
+  agentId,
+  userId,
+  taskDone,
+  initialMessages,
+  sseMessages,
+}: ChatPanelProps) {
   const [input, setInput] = useState("");
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
@@ -53,7 +60,7 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
         content: input.trim(),
       });
       setInput("");
-    } catch (err: any) {
+    } catch (_err: any) {
       setSendError("Failed to send. Try again.");
     } finally {
       setSending(false);
@@ -86,13 +93,15 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
           {agentId}
         </Badge>
         <Tooltip>
-          <TooltipTrigger render={
-            <Button
-              variant="ghost"
-              size="icon-xs"
-              onClick={() => navigator.clipboard.writeText(`claude --resume ${agentId}`)}
-            />
-          }>
+          <TooltipTrigger
+            render={
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => navigator.clipboard.writeText(`claude --resume ${agentId}`)}
+              />
+            }
+          >
             ⎘
           </TooltipTrigger>
           <TooltipContent>Copy resume command</TooltipContent>
@@ -100,14 +109,13 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
       </div>
 
       {/* Messages — fills available space */}
-      <div
-        ref={containerRef}
-        className="flex-1 min-h-0 overflow-y-auto space-y-2"
-      >
+      <div ref={containerRef} className="flex-1 min-h-0 overflow-y-auto space-y-2">
         {allMessages.length === 0 && (
           <div className="flex items-center justify-center h-full">
             <p className="text-sm text-content-tertiary">
-              {taskDone ? "No messages were exchanged." : "No messages yet. Send a message to the agent."}
+              {taskDone
+                ? "No messages were exchanged."
+                : "No messages yet. Send a message to the agent."}
             </p>
           </div>
         )}
@@ -122,16 +130,20 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
               {formatRelative(msg.created_at)}
             </span>
             <div className="flex-1 min-w-0">
-              <span className={`text-[11px] font-mono uppercase tracking-wider ${
-                msg.sender_type === "agent" ? "text-accent" : "text-content-tertiary"
-              }`}>
+              <span
+                className={`text-[11px] font-mono uppercase tracking-wider ${
+                  msg.sender_type === "agent" ? "text-accent" : "text-content-tertiary"
+                }`}
+              >
                 {msg.sender_type}
               </span>
-              <p className={`text-[13px] mt-0.5 whitespace-pre-wrap break-words ${
-                msg.sender_type === "agent"
-                  ? "font-mono text-xs text-content-secondary"
-                  : "text-content-primary"
-              }`}>
+              <p
+                className={`text-[13px] mt-0.5 whitespace-pre-wrap break-words ${
+                  msg.sender_type === "agent"
+                    ? "font-mono text-xs text-content-secondary"
+                    : "text-content-primary"
+                }`}
+              >
                 {msg.content}
               </p>
             </div>
@@ -140,9 +152,7 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
       </div>
 
       {/* Send error */}
-      {sendError && (
-        <p className="text-xs text-error shrink-0">{sendError}</p>
-      )}
+      {sendError && <p className="text-xs text-error shrink-0">{sendError}</p>}
 
       {/* Input — pinned at bottom, hidden when task is done */}
       {!taskDone && (
@@ -155,10 +165,7 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
             placeholder="Message the agent..."
             disabled={sending}
           />
-          <Button
-            onClick={handleSend}
-            disabled={!input.trim() || sending}
-          >
+          <Button onClick={handleSend} disabled={!input.trim() || sending}>
             {sending ? "..." : "Send"}
           </Button>
         </div>

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -1,15 +1,20 @@
-import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
-import { getTheme, setTheme, type Theme } from "../lib/theme";
 import { useState } from "react";
-import { signOut, clearAuthToken, useSession } from "../lib/auth-client";
-import { api } from "../lib/api";
+import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { useBoards } from "../hooks/useBoard";
+import { api } from "../lib/api";
+import { clearAuthToken, signOut, useSession } from "../lib/auth-client";
+import { getTheme, setTheme, type Theme } from "../lib/theme";
 import { BoardSwitcher } from "./BoardSwitcher";
+import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { Button } from "./ui/button";
-import { Avatar, AvatarImage, AvatarFallback } from "./ui/avatar";
-import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from "./ui/dropdown-menu";
-import { Tooltip, TooltipTrigger, TooltipContent } from "./ui/tooltip";
-import { Separator } from "./ui/separator";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./ui/tooltip";
 
 const navLinks = [
   { to: "/agents", label: "Agents" },
@@ -19,26 +24,58 @@ const navLinks = [
 function ThemeIcon({ theme }: { theme: Theme }) {
   if (theme === "light") {
     return (
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <circle cx="12" cy="12" r="5" />
-        <line x1="12" y1="1" x2="12" y2="3" /><line x1="12" y1="21" x2="12" y2="23" />
-        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" /><line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-        <line x1="1" y1="12" x2="3" y2="12" /><line x1="21" y1="12" x2="23" y2="12" />
-        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" /><line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+        <line x1="12" y1="1" x2="12" y2="3" />
+        <line x1="12" y1="21" x2="12" y2="23" />
+        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+        <line x1="1" y1="12" x2="3" y2="12" />
+        <line x1="21" y1="12" x2="23" y2="12" />
+        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
       </svg>
     );
   }
   if (theme === "dark") {
     return (
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
       </svg>
     );
   }
   return (
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
       <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
-      <line x1="8" y1="21" x2="16" y2="21" /><line x1="12" y1="17" x2="12" y2="21" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
     </svg>
   );
 }
@@ -89,11 +126,7 @@ export function Header() {
           {activeBoard && (
             <>
               <span className="text-content-tertiary text-xs">/</span>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setSwitcherOpen(true)}
-              >
+              <Button variant="ghost" size="sm" onClick={() => setSwitcherOpen(true)}>
                 {activeBoard.name}
               </Button>
             </>
@@ -106,10 +139,11 @@ export function Header() {
               <Link
                 key={to}
                 to={to}
-                className={`text-xs px-2.5 py-1 rounded-md transition-colors ${location.pathname.startsWith(to)
+                className={`text-xs px-2.5 py-1 rounded-md transition-colors ${
+                  location.pathname.startsWith(to)
                     ? "text-accent bg-accent-soft"
                     : "text-content-tertiary hover:text-content-secondary hover:bg-surface-tertiary"
-                  }`}
+                }`}
               >
                 {label}
               </Link>
@@ -118,9 +152,9 @@ export function Header() {
 
           {/* Avatar + Dropdown */}
           <DropdownMenu>
-            <DropdownMenuTrigger render={
-              <Button variant="ghost" size="icon-sm" className="rounded-full" />
-            }>
+            <DropdownMenuTrigger
+              render={<Button variant="ghost" size="icon-sm" className="rounded-full" />}
+            >
               <Avatar size="sm">
                 {user?.image && <AvatarImage src={user.image} />}
                 <AvatarFallback>{(user?.name || "?")[0].toUpperCase()}</AvatarFallback>
@@ -131,7 +165,9 @@ export function Header() {
               {user && (
                 <>
                   <div className="px-2 py-1.5">
-                    <p className="text-sm font-medium text-content-primary truncate">{user.name || user.email}</p>
+                    <p className="text-sm font-medium text-content-primary truncate">
+                      {user.name || user.email}
+                    </p>
                     {user.name && user.email && (
                       <p className="text-xs text-content-tertiary truncate">{user.email}</p>
                     )}
@@ -141,7 +177,16 @@ export function Header() {
               )}
 
               <DropdownMenuItem onClick={() => navigate("/settings")}>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
                   <circle cx="12" cy="12" r="3" />
                   <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
                 </svg>
@@ -149,7 +194,16 @@ export function Header() {
               </DropdownMenuItem>
 
               <DropdownMenuItem onClick={() => navigate("/repositories")}>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
                   <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
                 </svg>
                 Repositories
@@ -158,7 +212,16 @@ export function Header() {
               <DropdownMenuSeparator />
 
               <DropdownMenuItem onClick={handleSignOut}>
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
                   <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
                   <polyline points="16 17 21 12 16 7" />
                   <line x1="21" y1="12" x2="9" y2="12" />
@@ -170,9 +233,7 @@ export function Header() {
 
           {/* Theme toggle */}
           <Tooltip>
-            <TooltipTrigger render={
-              <Button variant="ghost" size="icon-sm" onClick={cycleTheme} />
-            }>
+            <TooltipTrigger render={<Button variant="ghost" size="icon-sm" onClick={cycleTheme} />}>
               <ThemeIcon theme={theme} />
             </TooltipTrigger>
             <TooltipContent>Theme: {theme}</TooltipContent>

--- a/apps/web/src/components/KanbanColumn.tsx
+++ b/apps/web/src/components/KanbanColumn.tsx
@@ -15,7 +15,9 @@ export function KanbanColumn({ column, onTaskClick, onAgentClick }: KanbanColumn
   return (
     <div className="min-w-0 border-r border-border last:border-r-0 p-4">
       <div className="flex items-center justify-between mb-3">
-        <span className={`text-xs font-semibold uppercase tracking-wide ${hasRecentUpdate ? "text-accent" : "text-content-tertiary"}`}>
+        <span
+          className={`text-xs font-semibold uppercase tracking-wide ${hasRecentUpdate ? "text-accent" : "text-content-tertiary"}`}
+        >
           {column.name}
         </span>
         <span className="font-mono text-[11px] text-content-tertiary bg-surface-tertiary px-1.5 py-0.5 rounded">

--- a/apps/web/src/components/Onboarding.tsx
+++ b/apps/web/src/components/Onboarding.tsx
@@ -1,9 +1,9 @@
 import { useState } from "react";
 import { api } from "../lib/api";
 import { authClient } from "../lib/auth-client";
+import { AddMachineSteps } from "./AddMachineSteps";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
-import { AddMachineSteps } from "./AddMachineSteps";
 
 interface OnboardingProps {
   onComplete: () => void;
@@ -42,9 +42,7 @@ export function Onboarding({ onComplete }: OnboardingProps) {
           <h1 className="text-2xl font-bold text-content-primary">
             Agent <span className="text-accent">Kanban</span>
           </h1>
-          <p className="text-sm text-content-secondary mt-2">
-            Your AI workforce starts here.
-          </p>
+          <p className="text-sm text-content-secondary mt-2">Your AI workforce starts here.</p>
         </div>
 
         {/* Step indicators */}
@@ -59,16 +57,18 @@ export function Onboarding({ onComplete }: OnboardingProps) {
 
         {step === 0 && (
           <div className="space-y-4">
-            <label className="block text-xs font-medium text-content-tertiary uppercase tracking-wide">
+            <label
+              htmlFor="onboarding-board-name"
+              className="block text-xs font-medium text-content-tertiary uppercase tracking-wide"
+            >
               Board name
             </label>
             <Input
+              id="onboarding-board-name"
               value={boardName}
               onChange={(e) => setBoardName(e.target.value)}
             />
-            {error && (
-              <p className="text-xs text-red-400">{error}</p>
-            )}
+            {error && <p className="text-xs text-red-400">{error}</p>}
             <Button
               onClick={handleCreateBoard}
               disabled={loading || !boardName.trim()}
@@ -80,11 +80,7 @@ export function Onboarding({ onComplete }: OnboardingProps) {
         )}
 
         {step === 1 && apiKeyDisplay && apiKeyId && (
-          <AddMachineSteps
-            apiKey={apiKeyDisplay}
-            apiKeyId={apiKeyId}
-            onDone={onComplete}
-          />
+          <AddMachineSteps apiKey={apiKeyDisplay} apiKeyId={apiKeyId} onDone={onComplete} />
         )}
       </div>
     </div>

--- a/apps/web/src/components/SubtaskList.tsx
+++ b/apps/web/src/components/SubtaskList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { api } from "../lib/api";
 
 interface SubtaskListProps {
@@ -10,7 +10,10 @@ export function SubtaskList({ parentId, onTaskClick }: SubtaskListProps) {
   const [subtasks, setSubtasks] = useState<any[]>([]);
 
   useEffect(() => {
-    api.tasks.list({ parent: parentId }).then(setSubtasks).catch(() => {});
+    api.tasks
+      .list({ parent: parentId })
+      .then(setSubtasks)
+      .catch(() => {});
   }, [parentId]);
 
   if (subtasks.length === 0) return null;
@@ -19,13 +22,16 @@ export function SubtaskList({ parentId, onTaskClick }: SubtaskListProps) {
     <div className="space-y-1 pl-6 md:pl-4">
       {subtasks.map((task) => (
         <button
+          type="button"
           key={task.id}
           onClick={() => onTaskClick(task.id)}
           className="w-full text-left flex items-center gap-2 py-1.5 px-2 rounded hover:bg-surface-tertiary transition-colors"
         >
-          <span className={`w-1.5 h-1.5 rounded-full ${
-            task.result ? "bg-success" : task.assigned_to ? "bg-accent" : "bg-content-tertiary"
-          }`} />
+          <span
+            className={`w-1.5 h-1.5 rounded-full ${
+              task.result ? "bg-success" : task.assigned_to ? "bg-accent" : "bg-content-tertiary"
+            }`}
+          />
           <span className="text-sm text-content-secondary truncate">{task.title}</span>
           <span className="font-mono text-[10px] text-content-tertiary ml-auto">{task.id}</span>
         </button>

--- a/apps/web/src/components/TaskCard.tsx
+++ b/apps/web/src/components/TaskCard.tsx
@@ -1,5 +1,5 @@
-import { AgentIdenticon } from "./AgentIdenticon";
 import { agentColor } from "../lib/agentIdentity";
+import { AgentIdenticon } from "./AgentIdenticon";
 import { Badge } from "./ui/badge";
 
 interface TaskCardProps {
@@ -21,26 +21,36 @@ export function TaskCard({ task, onClick, onAgentClick, isNew }: TaskCardProps) 
 
   return (
     <button
+      type="button"
       onClick={onClick}
       className={`
         w-full text-left bg-surface-card border rounded-lg p-3
         transition-all duration-150 cursor-pointer
-        ${isAgentActive
-          ? "border-accent/30 shadow-[0_0_20px_var(--accent-glow),0_0_40px_rgba(34,211,238,0.05)]"
-          : "border-border hover:border-content-tertiary"}
+        ${
+          isAgentActive
+            ? "border-accent/30 shadow-[0_0_20px_var(--accent-glow),0_0_40px_rgba(34,211,238,0.05)]"
+            : "border-border hover:border-content-tertiary"
+        }
         ${isNew ? "animate-card-highlight" : ""}
       `}
-      style={isAgentActive && task.agent_public_key ? {
-        borderColor: `color-mix(in srgb, ${agentColor(task.agent_public_key)} 30%, transparent)`,
-        boxShadow: `0 0 20px color-mix(in srgb, ${agentColor(task.agent_public_key)} 12%, transparent)`,
-      } : undefined}
+      style={
+        isAgentActive && task.agent_public_key
+          ? {
+              borderColor: `color-mix(in srgb, ${agentColor(task.agent_public_key)} 30%, transparent)`,
+              boxShadow: `0 0 20px color-mix(in srgb, ${agentColor(task.agent_public_key)} 12%, transparent)`,
+            }
+          : undefined
+      }
     >
       <div className="flex items-center gap-1.5 mb-2">
         <div className="text-[13px] font-medium leading-snug text-content-primary flex-1">
           {task.title}
         </div>
         {task.blocked && (
-          <Badge variant="destructive" className="text-[10px] font-mono font-semibold uppercase shrink-0">
+          <Badge
+            variant="destructive"
+            className="text-[10px] font-mono font-semibold uppercase shrink-0"
+          >
             Blocked
           </Badge>
         )}
@@ -48,12 +58,18 @@ export function TaskCard({ task, onClick, onAgentClick, isNew }: TaskCardProps) 
 
       <div className="flex items-center gap-1.5 flex-wrap">
         {task.repository_name && (
-          <Badge variant="secondary" className="text-[11px] font-mono bg-accent-soft text-accent border-none">
+          <Badge
+            variant="secondary"
+            className="text-[11px] font-mono bg-accent-soft text-accent border-none"
+          >
             {task.repository_name}
           </Badge>
         )}
         {task.priority && (
-          <Badge variant="secondary" className={`text-[11px] font-mono border-none ${priorityColors[task.priority]}`}>
+          <Badge
+            variant="secondary"
+            className={`text-[11px] font-mono border-none ${priorityColors[task.priority]}`}
+          >
             {task.priority}
           </Badge>
         )}
@@ -63,7 +79,8 @@ export function TaskCard({ task, onClick, onAgentClick, isNew }: TaskCardProps) 
         <div className="flex items-center gap-1.5 mt-2 text-accent">
           {task.agent_public_key && <AgentIdenticon publicKey={task.agent_public_key} size={12} />}
           <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse-glow" />
-          <span
+          <button
+            type="button"
             className="font-mono text-[11px] hover:underline"
             onClick={(e) => {
               if (onAgentClick && task.assigned_to) {
@@ -73,7 +90,7 @@ export function TaskCard({ task, onClick, onAgentClick, isNew }: TaskCardProps) 
             }}
           >
             {task.agent_name || task.assigned_to}
-          </span>
+          </button>
         </div>
       )}
 

--- a/apps/web/src/components/TaskDetail.tsx
+++ b/apps/web/src/components/TaskDetail.tsx
@@ -1,18 +1,18 @@
-import { useState, useEffect } from "react";
-import { api } from "../lib/api";
+import { useEffect, useState } from "react";
 import { useSSE } from "../hooks/useSSE";
+import { api } from "../lib/api";
 import { useSession } from "../lib/auth-client";
-import { EditableText, EditableTextarea, Field, FieldLabel } from "./TaskDetailFields";
 import { ActivityLog } from "./ActivityLog";
 import { ChatPanel } from "./ChatPanel";
 import { SubtaskList } from "./SubtaskList";
+import { EditableText, EditableTextarea, Field, FieldLabel } from "./TaskDetailFields";
+import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
-import { Sheet, SheetContent, SheetTitle, SheetDescription } from "./ui/sheet";
-import { Badge } from "./ui/badge";
-import { Tabs, TabsList, TabsTrigger, TabsContent } from "./ui/tabs";
 import { Separator } from "./ui/separator";
+import { Sheet, SheetContent, SheetDescription, SheetTitle } from "./ui/sheet";
 import { Skeleton } from "./ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 
 const TASK_STATUS_LABELS: Record<string, string> = {
   todo: "Todo",
@@ -36,6 +36,7 @@ interface TaskDetailProps {
 
 const PRIORITIES = ["urgent", "high", "medium", "low"] as const;
 
+// biome-ignore lint/correctness/noUnusedFunctionParameters: part of TaskDetailProps interface, used by parent
 export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDetailProps) {
   const { data: session } = useSession();
   const [task, setTask] = useState<any>(null);
@@ -49,18 +50,25 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
 
   useEffect(() => {
     reload().finally(() => setLoading(false));
-    api.messages.list(taskId).then(setInitialMessages).catch(() => {});
+    api.messages
+      .list(taskId)
+      .then(setInitialMessages)
+      .catch(() => {});
   }, [taskId]);
 
   useEffect(() => {
-    api.repositories.list().then(setRepositories).catch(() => {});
+    api.repositories
+      .list()
+      .then(setRepositories)
+      .catch(() => {});
   }, []);
 
   useEffect(() => {
     if (!task?.depends_on || task.depends_on.length === 0) return;
     const depIds: string[] = task.depends_on;
-    Promise.all(depIds.map((id) => api.tasks.get(id).then((t: any) => [id, t.title] as const)))
-      .then((entries) => setDepTitles(Object.fromEntries(entries)));
+    Promise.all(
+      depIds.map((id) => api.tasks.get(id).then((t: any) => [id, t.title] as const)),
+    ).then((entries) => setDepTitles(Object.fromEntries(entries)));
   }, [task?.depends_on]);
 
   async function handleUpdate(field: string, value: string | null) {
@@ -85,13 +93,20 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
   ) : !task ? (
     <div className="p-6">
       <p className="text-content-secondary">Task not found.</p>
-      <Button variant="link" onClick={onClose} className="mt-4">Back to board</Button>
+      <Button variant="link" onClick={onClose} className="mt-4">
+        Back to board
+      </Button>
     </div>
   ) : null;
 
   if (content) {
     return (
-      <Sheet open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <Sheet
+        open
+        onOpenChange={(open) => {
+          if (!open) onClose();
+        }}
+      >
         <SheetContent showCloseButton={false}>
           <SheetTitle className="sr-only">Task</SheetTitle>
           <SheetDescription className="sr-only">Task details</SheetDescription>
@@ -109,23 +124,40 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
       <div className="grid grid-cols-3 gap-4">
         <div>
           <FieldLabel>Status</FieldLabel>
-          <span className="text-sm font-medium text-accent">{TASK_STATUS_LABELS[task.status] || task.status}</span>
+          <span className="text-sm font-medium text-accent">
+            {TASK_STATUS_LABELS[task.status] || task.status}
+          </span>
         </div>
-        <Field label="Assigned to" value={
-          task.agent_name
-            ? <span className="font-mono text-[13px]">{task.agent_name}</span>
-            : <span className="text-content-tertiary">—</span>
-        } />
-        <Field label="Duration" value={
-          task.duration_minutes != null
-            ? <span className="font-mono text-[13px]">{task.duration_minutes} min</span>
-            : <span className="text-content-tertiary">—</span>
-        } />
+        <Field
+          label="Assigned to"
+          value={
+            task.agent_name ? (
+              <span className="font-mono text-[13px]">{task.agent_name}</span>
+            ) : (
+              <span className="text-content-tertiary">—</span>
+            )
+          }
+        />
+        <Field
+          label="Duration"
+          value={
+            task.duration_minutes != null ? (
+              <span className="font-mono text-[13px]">{task.duration_minutes} min</span>
+            ) : (
+              <span className="text-content-tertiary">—</span>
+            )
+          }
+        />
       </div>
 
       {task.status === "in_review" && (
         <div className="flex gap-2">
-          {(Object.entries(REVIEW_ACTIONS) as [keyof typeof REVIEW_ACTIONS, typeof REVIEW_ACTIONS[keyof typeof REVIEW_ACTIONS]][]).map(([action, config]) => (
+          {(
+            Object.entries(REVIEW_ACTIONS) as [
+              keyof typeof REVIEW_ACTIONS,
+              (typeof REVIEW_ACTIONS)[keyof typeof REVIEW_ACTIONS],
+            ][]
+          ).map(([action, config]) => (
             <Button
               key={action}
               variant={config.variant}
@@ -179,7 +211,12 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
       {task.pr_url && (
         <div>
           <FieldLabel>PR</FieldLabel>
-          <a href={task.pr_url} target="_blank" rel="noopener noreferrer" className="text-sm text-accent hover:underline">
+          <a
+            href={task.pr_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-sm text-accent hover:underline"
+          >
             {task.pr_url}
           </a>
         </div>
@@ -190,7 +227,12 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
           <Separator />
           <div>
             <FieldLabel>Subtasks ({task.subtask_count})</FieldLabel>
-            <SubtaskList parentId={taskId} onTaskClick={(id) => { /* navigate to subtask */ }} />
+            <SubtaskList
+              parentId={taskId}
+              onTaskClick={(_id) => {
+                /* navigate to subtask */
+              }}
+            />
           </div>
         </>
       )}
@@ -199,15 +241,10 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
 
       <div>
         <FieldLabel>Activity</FieldLabel>
-        <ActivityLog
-          taskId={taskId}
-          initialLogs={task.logs || []}
-          assigned={!!task.assigned_to}
-        />
+        <ActivityLog taskId={taskId} initialLogs={task.logs || []} assigned={!!task.assigned_to} />
       </div>
 
       <Separator />
-
     </div>
   );
 
@@ -225,7 +262,12 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
   );
 
   return (
-    <Sheet open onOpenChange={(open) => { if (!open) onClose(); }}>
+    <Sheet
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
       <SheetContent showCloseButton={false} className="overflow-y-auto p-0 gap-0">
         <SheetTitle className="sr-only">{task.title}</SheetTitle>
         <SheetDescription className="sr-only">Task detail panel</SheetDescription>
@@ -240,37 +282,52 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
                 className="text-lg font-semibold text-content-primary"
               />
               {task.blocked && (
-                <Badge variant="destructive" className="text-[10px] font-mono font-semibold uppercase">
+                <Badge
+                  variant="destructive"
+                  className="text-[10px] font-mono font-semibold uppercase"
+                >
                   Blocked
                 </Badge>
               )}
             </div>
             <div className="flex gap-1.5 mt-2 flex-wrap">
-              <Select value={task.repository_id || "__none__"} onValueChange={(v) => handleUpdate("repository_id", v === "__none__" ? null : v)}>
+              <Select
+                value={task.repository_id || "__none__"}
+                onValueChange={(v) => handleUpdate("repository_id", v === "__none__" ? null : v)}
+              >
                 <SelectTrigger size="sm" className="text-[11px] font-mono h-6">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="__none__">no repo</SelectItem>
                   {repositories.map((r) => (
-                    <SelectItem key={r.id} value={r.id}>{r.name}</SelectItem>
+                    <SelectItem key={r.id} value={r.id}>
+                      {r.name}
+                    </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-              <Select value={task.priority || "__none__"} onValueChange={(v) => handleUpdate("priority", v === "__none__" ? null : v)}>
+              <Select
+                value={task.priority || "__none__"}
+                onValueChange={(v) => handleUpdate("priority", v === "__none__" ? null : v)}
+              >
                 <SelectTrigger size="sm" className="text-[11px] font-mono h-6">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="__none__">no priority</SelectItem>
                   {PRIORITIES.map((p) => (
-                    <SelectItem key={p} value={p}>{p}</SelectItem>
+                    <SelectItem key={p} value={p}>
+                      {p}
+                    </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
             </div>
           </div>
-          <Button variant="ghost" size="icon-sm" onClick={onClose}>✕</Button>
+          <Button variant="ghost" size="icon-sm" onClick={onClose}>
+            ✕
+          </Button>
         </div>
 
         {hasAgent ? (

--- a/apps/web/src/components/TaskDetailFields.tsx
+++ b/apps/web/src/components/TaskDetailFields.tsx
@@ -1,15 +1,27 @@
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Textarea } from "./ui/textarea";
-import { Button } from "./ui/button";
 
-export function EditableText({ value, onSave, className }: { value: string; onSave: (v: string) => void; className?: string }) {
+export function EditableText({
+  value,
+  onSave,
+  className,
+}: {
+  value: string;
+  onSave: (v: string) => void;
+  className?: string;
+}) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => { setDraft(value); }, [value]);
-  useEffect(() => { if (editing) inputRef.current?.focus(); }, [editing]);
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
 
   function commit() {
     setEditing(false);
@@ -24,29 +36,48 @@ export function EditableText({ value, onSave, className }: { value: string; onSa
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={commit}
-        onKeyDown={(e) => { if (e.key === "Enter") commit(); if (e.key === "Escape") { setDraft(value); setEditing(false); } }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          if (e.key === "Escape") {
+            setDraft(value);
+            setEditing(false);
+          }
+        }}
         className={`${className} border-accent`}
       />
     );
   }
 
   return (
-    <span
+    <button
+      type="button"
       onClick={() => setEditing(true)}
       className={`${className} cursor-pointer hover:border-b hover:border-content-tertiary`}
     >
       {value}
-    </span>
+    </button>
   );
 }
 
-export function EditableTextarea({ value, placeholder, onSave }: { value: string; placeholder: string; onSave: (v: string) => void }) {
+export function EditableTextarea({
+  value,
+  placeholder,
+  onSave,
+}: {
+  value: string;
+  placeholder: string;
+  onSave: (v: string) => void;
+}) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
   const ref = useRef<HTMLTextAreaElement>(null);
 
-  useEffect(() => { setDraft(value); }, [value]);
-  useEffect(() => { if (editing) ref.current?.focus(); }, [editing]);
+  useEffect(() => {
+    setDraft(value);
+  }, [value]);
+  useEffect(() => {
+    if (editing) ref.current?.focus();
+  }, [editing]);
 
   function commit() {
     setEditing(false);
@@ -60,7 +91,12 @@ export function EditableTextarea({ value, placeholder, onSave }: { value: string
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={commit}
-        onKeyDown={(e) => { if (e.key === "Escape") { setDraft(value); setEditing(false); } }}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            setDraft(value);
+            setEditing(false);
+          }
+        }}
         rows={3}
         className="resize-y"
       />
@@ -68,24 +104,39 @@ export function EditableTextarea({ value, placeholder, onSave }: { value: string
   }
 
   return (
-    <p
+    <button
+      type="button"
       onClick={() => setEditing(true)}
-      className={`text-sm cursor-pointer rounded-md p-2 hover:bg-surface-tertiary transition-colors ${
+      className={`text-sm cursor-pointer rounded-md p-2 hover:bg-surface-tertiary transition-colors w-full text-left ${
         value ? "text-content-secondary" : "text-content-tertiary"
       }`}
     >
       {value || placeholder}
-    </p>
+    </button>
   );
 }
 
-export function EditableBadge({ value, placeholder, onSave, className }: { value: string | null; placeholder: string; onSave: (v: string) => void; className: string }) {
+export function EditableBadge({
+  value,
+  placeholder,
+  onSave,
+  className,
+}: {
+  value: string | null;
+  placeholder: string;
+  onSave: (v: string) => void;
+  className: string;
+}) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value || "");
   const ref = useRef<HTMLInputElement>(null);
 
-  useEffect(() => { setDraft(value || ""); }, [value]);
-  useEffect(() => { if (editing) ref.current?.focus(); }, [editing]);
+  useEffect(() => {
+    setDraft(value || "");
+  }, [value]);
+  useEffect(() => {
+    if (editing) ref.current?.focus();
+  }, [editing]);
 
   function commit() {
     setEditing(false);
@@ -99,7 +150,13 @@ export function EditableBadge({ value, placeholder, onSave, className }: { value
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={commit}
-        onKeyDown={(e) => { if (e.key === "Enter") commit(); if (e.key === "Escape") { setDraft(value || ""); setEditing(false); } }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          if (e.key === "Escape") {
+            setDraft(value || "");
+            setEditing(false);
+          }
+        }}
         placeholder="project name"
         className="text-[11px] font-mono h-6 w-24"
       />
@@ -108,16 +165,25 @@ export function EditableBadge({ value, placeholder, onSave, className }: { value
 
   if (!value) {
     return (
-      <Button variant="outline" size="xs" onClick={() => setEditing(true)} className="text-[11px] font-mono border-dashed">
+      <Button
+        variant="outline"
+        size="xs"
+        onClick={() => setEditing(true)}
+        className="text-[11px] font-mono border-dashed"
+      >
         {placeholder}
       </Button>
     );
   }
 
   return (
-    <span onClick={() => setEditing(true)} className={`text-[11px] font-mono px-2 py-0.5 rounded cursor-pointer ${className}`}>
+    <button
+      type="button"
+      onClick={() => setEditing(true)}
+      className={`text-[11px] font-mono px-2 py-0.5 rounded cursor-pointer ${className}`}
+    >
       {value}
-    </span>
+    </button>
   );
 }
 

--- a/apps/web/src/components/ui/avatar.tsx
+++ b/apps/web/src/components/ui/avatar.tsx
@@ -1,14 +1,14 @@
-import * as React from "react"
-import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar"
+import { Avatar as AvatarPrimitive } from "@base-ui/react/avatar";
+import type * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Avatar({
   className,
   size = "default",
   ...props
 }: AvatarPrimitive.Root.Props & {
-  size?: "default" | "sm" | "lg"
+  size?: "default" | "sm" | "lg";
 }) {
   return (
     <AvatarPrimitive.Root
@@ -16,40 +16,34 @@ function Avatar({
       data-size={size}
       className={cn(
         "group/avatar relative flex size-8 shrink-0 rounded-full select-none after:absolute after:inset-0 after:rounded-full after:border after:border-border after:mix-blend-darken data-[size=lg]:size-10 data-[size=sm]:size-6 dark:after:mix-blend-lighten",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AvatarImage({ className, ...props }: AvatarPrimitive.Image.Props) {
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
-      className={cn(
-        "aspect-square size-full rounded-full object-cover",
-        className
-      )}
+      className={cn("aspect-square size-full rounded-full object-cover", className)}
       {...props}
     />
-  )
+  );
 }
 
-function AvatarFallback({
-  className,
-  ...props
-}: AvatarPrimitive.Fallback.Props) {
+function AvatarFallback({ className, ...props }: AvatarPrimitive.Fallback.Props) {
   return (
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
       className={cn(
         "flex size-full items-center justify-center rounded-full bg-muted text-sm text-muted-foreground group-data-[size=sm]/avatar:text-xs",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
@@ -61,11 +55,11 @@ function AvatarBadge({ className, ...props }: React.ComponentProps<"span">) {
         "group-data-[size=sm]/avatar:size-2 group-data-[size=sm]/avatar:[&>svg]:hidden",
         "group-data-[size=default]/avatar:size-2.5 group-data-[size=default]/avatar:[&>svg]:size-2",
         "group-data-[size=lg]/avatar:size-3 group-data-[size=lg]/avatar:[&>svg]:size-2",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
@@ -74,34 +68,24 @@ function AvatarGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="avatar-group"
       className={cn(
         "group/avatar-group flex -space-x-2 *:data-[slot=avatar]:ring-2 *:data-[slot=avatar]:ring-background",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-function AvatarGroupCount({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
+function AvatarGroupCount({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="avatar-group-count"
       className={cn(
         "relative flex size-8 shrink-0 items-center justify-center rounded-full bg-muted text-sm text-muted-foreground ring-2 ring-background group-has-data-[size=lg]/avatar-group:size-10 group-has-data-[size=sm]/avatar-group:size-6 [&>svg]:size-4 group-has-data-[size=lg]/avatar-group:[&>svg]:size-5 group-has-data-[size=sm]/avatar-group:[&>svg]:size-3",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export {
-  Avatar,
-  AvatarImage,
-  AvatarFallback,
-  AvatarGroup,
-  AvatarGroupCount,
-  AvatarBadge,
-}
+export { Avatar, AvatarBadge, AvatarFallback, AvatarGroup, AvatarGroupCount, AvatarImage };

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -1,8 +1,8 @@
-import { mergeProps } from "@base-ui/react/merge-props"
-import { useRender } from "@base-ui/react/use-render"
-import { cva, type VariantProps } from "class-variance-authority"
+import { mergeProps } from "@base-ui/react/merge-props";
+import { useRender } from "@base-ui/react/use-render";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
   "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
@@ -10,22 +10,19 @@ const badgeVariants = cva(
     variants: {
       variant: {
         default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
-        secondary:
-          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
         destructive:
           "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
-        outline:
-          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
-        ghost:
-          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 function Badge({
   className,
@@ -39,14 +36,14 @@ function Badge({
       {
         className: cn(badgeVariants({ variant }), className),
       },
-      props
+      props,
     ),
     render,
     state: {
       slot: "badge",
       variant,
     },
-  })
+  });
 }
 
-export { Badge, badgeVariants }
+export { Badge, badgeVariants };

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -1,7 +1,7 @@
-import { Button as ButtonPrimitive } from "@base-ui/react/button"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Button as ButtonPrimitive } from "@base-ui/react/button";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "group/button inline-flex shrink-0 items-center justify-center rounded-lg border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -37,8 +37,8 @@ const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
-)
+  },
+);
 
 function Button({
   className,
@@ -52,7 +52,7 @@ function Button({
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
-  )
+  );
 }
 
-export { Button, buttonVariants }
+export { Button, buttonVariants };

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -1,42 +1,38 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
-
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog";
+import { XIcon } from "lucide-react";
+import type * as React from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 function Dialog({ ...props }: DialogPrimitive.Root.Props) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
 function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
 function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
 function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
-function DialogOverlay({
-  className,
-  ...props
-}: DialogPrimitive.Backdrop.Props) {
+function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
   return (
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
         "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -45,7 +41,7 @@ function DialogContent({
   showCloseButton = true,
   ...props
 }: DialogPrimitive.Popup.Props & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <DialogPortal>
@@ -54,7 +50,7 @@ function DialogContent({
         data-slot="dialog-content"
         className={cn(
           "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className
+          className,
         )}
         {...props}
       >
@@ -62,32 +58,21 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            render={
-              <Button
-                variant="ghost"
-                className="absolute top-2 right-2"
-                size="icon-sm"
-              />
-            }
+            render={<Button variant="ghost" className="absolute top-2 right-2" size="icon-sm" />}
           >
-            <XIcon
-            />
+            <XIcon />
             <span className="sr-only">Close</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Popup>
     </DialogPortal>
-  )
+  );
 }
 
 function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div
-      data-slot="dialog-header"
-      className={cn("flex flex-col gap-2", className)}
-      {...props}
-    />
-  )
+    <div data-slot="dialog-header" className={cn("flex flex-col gap-2", className)} {...props} />
+  );
 }
 
 function DialogFooter({
@@ -96,54 +81,46 @@ function DialogFooter({
   children,
   ...props
 }: React.ComponentProps<"div"> & {
-  showCloseButton?: boolean
+  showCloseButton?: boolean;
 }) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
         "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
-        className
+        className,
       )}
       {...props}
     >
       {children}
       {showCloseButton && (
-        <DialogPrimitive.Close render={<Button variant="outline" />}>
-          Close
-        </DialogPrimitive.Close>
+        <DialogPrimitive.Close render={<Button variant="outline" />}>Close</DialogPrimitive.Close>
       )}
     </div>
-  )
+  );
 }
 
 function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn(
-        "font-heading text-base leading-none font-medium",
-        className
-      )}
+      className={cn("font-heading text-base leading-none font-medium", className)}
       {...props}
     />
-  )
+  );
 }
 
-function DialogDescription({
-  className,
-  ...props
-}: DialogPrimitive.Description.Props) {
+function DialogDescription({ className, ...props }: DialogPrimitive.Description.Props) {
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
         "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -157,4 +134,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};

--- a/apps/web/src/components/ui/drawer.tsx
+++ b/apps/web/src/components/ui/drawer.tsx
@@ -1,30 +1,22 @@
-import * as React from "react"
-import { Drawer as DrawerPrimitive } from "vaul"
+import type * as React from "react";
+import { Drawer as DrawerPrimitive } from "vaul";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Drawer({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />
+function Drawer({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
 }
 
-function DrawerTrigger({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
-  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />
+function DrawerTrigger({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+  return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
 }
 
-function DrawerPortal({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
-  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />
+function DrawerPortal({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+  return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
 }
 
-function DrawerClose({
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Close>) {
-  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />
+function DrawerClose({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+  return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
 }
 
 function DrawerOverlay({
@@ -36,11 +28,11 @@ function DrawerOverlay({
       data-slot="drawer-overlay"
       className={cn(
         "fixed inset-0 z-50 bg-black/10 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DrawerContent({
@@ -55,7 +47,7 @@ function DrawerContent({
         data-slot="drawer-content"
         className={cn(
           "group/drawer-content fixed z-50 flex h-auto flex-col bg-background text-sm data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[80vh] data-[vaul-drawer-direction=bottom]:border-t data-[vaul-drawer-direction=left]:inset-y-0 data-[vaul-drawer-direction=left]:left-0 data-[vaul-drawer-direction=left]:w-3/4 data-[vaul-drawer-direction=left]:border-r data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-1/2 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[80vh] data-[vaul-drawer-direction=top]:border-b",
-          className
+          className,
         )}
         {...props}
       >
@@ -63,7 +55,7 @@ function DrawerContent({
         {children}
       </DrawerPrimitive.Content>
     </DrawerPortal>
-  )
+  );
 }
 
 function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -72,11 +64,11 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="drawer-header"
       className={cn(
         "flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-0.5 md:text-left",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -86,23 +78,17 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("mt-auto flex flex-col gap-2 p-4", className)}
       {...props}
     />
-  )
+  );
 }
 
-function DrawerTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
   return (
     <DrawerPrimitive.Title
       data-slot="drawer-title"
-      className={cn(
-        "font-heading text-base font-medium text-foreground",
-        className
-      )}
+      className={cn("font-heading text-base font-medium text-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
 function DrawerDescription({
@@ -115,18 +101,18 @@ function DrawerDescription({
       className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
   Drawer,
-  DrawerPortal,
-  DrawerOverlay,
-  DrawerTrigger,
   DrawerClose,
   DrawerContent,
-  DrawerHeader,
-  DrawerFooter,
-  DrawerTitle,
   DrawerDescription,
-}
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+};

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,19 +1,18 @@
-import * as React from "react"
-import { Menu as MenuPrimitive } from "@base-ui/react/menu"
-
-import { cn } from "@/lib/utils"
-import { ChevronRightIcon, CheckIcon } from "lucide-react"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu";
+import { CheckIcon, ChevronRightIcon } from "lucide-react";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
 
 function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
-  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
 }
 
 function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
-  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />;
 }
 
 function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
-  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />;
 }
 
 function DropdownMenuContent({
@@ -24,10 +23,7 @@ function DropdownMenuContent({
   className,
   ...props
 }: MenuPrimitive.Popup.Props &
-  Pick<
-    MenuPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  Pick<MenuPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
   return (
     <MenuPrimitive.Portal>
       <MenuPrimitive.Positioner
@@ -39,16 +35,19 @@ function DropdownMenuContent({
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
-          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn(
+            "z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
           {...props}
         />
       </MenuPrimitive.Positioner>
     </MenuPrimitive.Portal>
-  )
+  );
 }
 
 function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
-  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
 }
 
 function DropdownMenuLabel({
@@ -56,7 +55,7 @@ function DropdownMenuLabel({
   inset,
   ...props
 }: MenuPrimitive.GroupLabel.Props & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <MenuPrimitive.GroupLabel
@@ -64,11 +63,11 @@ function DropdownMenuLabel({
       data-inset={inset}
       className={cn(
         "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuItem({
@@ -77,8 +76,8 @@ function DropdownMenuItem({
   variant = "default",
   ...props
 }: MenuPrimitive.Item.Props & {
-  inset?: boolean
-  variant?: "default" | "destructive"
+  inset?: boolean;
+  variant?: "default" | "destructive";
 }) {
   return (
     <MenuPrimitive.Item
@@ -87,15 +86,15 @@ function DropdownMenuItem({
       data-variant={variant}
       className={cn(
         "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
-  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />;
 }
 
 function DropdownMenuSubTrigger({
@@ -104,7 +103,7 @@ function DropdownMenuSubTrigger({
   children,
   ...props
 }: MenuPrimitive.SubmenuTrigger.Props & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <MenuPrimitive.SubmenuTrigger
@@ -112,14 +111,14 @@ function DropdownMenuSubTrigger({
       data-inset={inset}
       className={cn(
         "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
       {children}
       <ChevronRightIcon className="ml-auto" />
     </MenuPrimitive.SubmenuTrigger>
-  )
+  );
 }
 
 function DropdownMenuSubContent({
@@ -133,14 +132,17 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuContent
       data-slot="dropdown-menu-sub-content"
-      className={cn("w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      className={cn(
+        "w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+        className,
+      )}
       align={align}
       alignOffset={alignOffset}
       side={side}
       sideOffset={sideOffset}
       {...props}
     />
-  )
+  );
 }
 
 function DropdownMenuCheckboxItem({
@@ -150,7 +152,7 @@ function DropdownMenuCheckboxItem({
   inset,
   ...props
 }: MenuPrimitive.CheckboxItem.Props & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <MenuPrimitive.CheckboxItem
@@ -158,7 +160,7 @@ function DropdownMenuCheckboxItem({
       data-inset={inset}
       className={cn(
         "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       checked={checked}
       {...props}
@@ -168,22 +170,16 @@ function DropdownMenuCheckboxItem({
         data-slot="dropdown-menu-checkbox-item-indicator"
       >
         <MenuPrimitive.CheckboxItemIndicator>
-          <CheckIcon
-          />
+          <CheckIcon />
         </MenuPrimitive.CheckboxItemIndicator>
       </span>
       {children}
     </MenuPrimitive.CheckboxItem>
-  )
+  );
 }
 
 function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
-  return (
-    <MenuPrimitive.RadioGroup
-      data-slot="dropdown-menu-radio-group"
-      {...props}
-    />
-  )
+  return <MenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
 }
 
 function DropdownMenuRadioItem({
@@ -192,7 +188,7 @@ function DropdownMenuRadioItem({
   inset,
   ...props
 }: MenuPrimitive.RadioItem.Props & {
-  inset?: boolean
+  inset?: boolean;
 }) {
   return (
     <MenuPrimitive.RadioItem
@@ -200,7 +196,7 @@ function DropdownMenuRadioItem({
       data-inset={inset}
       className={cn(
         "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
@@ -209,58 +205,51 @@ function DropdownMenuRadioItem({
         data-slot="dropdown-menu-radio-item-indicator"
       >
         <MenuPrimitive.RadioItemIndicator>
-          <CheckIcon
-          />
+          <CheckIcon />
         </MenuPrimitive.RadioItemIndicator>
       </span>
       {children}
     </MenuPrimitive.RadioItem>
-  )
+  );
 }
 
-function DropdownMenuSeparator({
-  className,
-  ...props
-}: MenuPrimitive.Separator.Props) {
+function DropdownMenuSeparator({ className, ...props }: MenuPrimitive.Separator.Props) {
   return (
     <MenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
       className={cn("-mx-1 my-1 h-px bg-border", className)}
       {...props}
     />
-  )
+  );
 }
 
-function DropdownMenuShortcut({
-  className,
-  ...props
-}: React.ComponentProps<"span">) {
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       data-slot="dropdown-menu-shortcut"
       className={cn(
         "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
   DropdownMenu,
-  DropdownMenuPortal,
-  DropdownMenuTrigger,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuGroup,
-  DropdownMenuLabel,
   DropdownMenuItem,
-  DropdownMenuCheckboxItem,
+  DropdownMenuLabel,
+  DropdownMenuPortal,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuShortcut,
   DropdownMenuSub,
-  DropdownMenuSubTrigger,
   DropdownMenuSubContent,
-}
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+};

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { Input as InputPrimitive } from "@base-ui/react/input"
+import { Input as InputPrimitive } from "@base-ui/react/input";
+import type * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   return (
@@ -10,11 +10,11 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       data-slot="input"
       className={cn(
         "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Input }
+export { Input };

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,18 +1,19 @@
-import * as React from "react"
+import type * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Label({ className, ...props }: React.ComponentProps<"label">) {
   return (
+    // biome-ignore lint/a11y/noLabelWithoutControl: shadcn/ui component - htmlFor is set by consumers
     <label
       data-slot="label"
       className={cn(
         "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Label }
+export { Label };

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -1,12 +1,11 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Select as SelectPrimitive } from "@base-ui/react/select"
+import { Select as SelectPrimitive } from "@base-ui/react/select";
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
+import type * as React from "react";
+import { cn } from "@/lib/utils";
 
-import { cn } from "@/lib/utils"
-import { ChevronDownIcon, CheckIcon, ChevronUpIcon } from "lucide-react"
-
-const Select = SelectPrimitive.Root
+const Select = SelectPrimitive.Root;
 
 function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
   return (
@@ -15,7 +14,7 @@ function SelectGroup({ className, ...props }: SelectPrimitive.Group.Props) {
       className={cn("scroll-my-1 p-1", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
@@ -25,7 +24,7 @@ function SelectValue({ className, ...props }: SelectPrimitive.Value.Props) {
       className={cn("flex flex-1 text-left", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectTrigger({
@@ -34,7 +33,7 @@ function SelectTrigger({
   children,
   ...props
 }: SelectPrimitive.Trigger.Props & {
-  size?: "sm" | "default"
+  size?: "sm" | "default";
 }) {
   return (
     <SelectPrimitive.Trigger
@@ -42,18 +41,16 @@ function SelectTrigger({
       data-size={size}
       className={cn(
         "flex w-fit items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm whitespace-nowrap transition-colors outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-placeholder:text-muted-foreground data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center *:data-[slot=select-value]:gap-1.5 dark:bg-input/30 dark:hover:bg-input/50 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
       {children}
       <SelectPrimitive.Icon
-        render={
-          <ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />
-        }
+        render={<ChevronDownIcon className="pointer-events-none size-4 text-muted-foreground" />}
       />
     </SelectPrimitive.Trigger>
-  )
+  );
 }
 
 function SelectContent({
@@ -83,7 +80,10 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
-          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn(
+            "relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className,
+          )}
           {...props}
         >
           <SelectScrollUpButton />
@@ -92,33 +92,26 @@ function SelectContent({
         </SelectPrimitive.Popup>
       </SelectPrimitive.Positioner>
     </SelectPrimitive.Portal>
-  )
+  );
 }
 
-function SelectLabel({
-  className,
-  ...props
-}: SelectPrimitive.GroupLabel.Props) {
+function SelectLabel({ className, ...props }: SelectPrimitive.GroupLabel.Props) {
   return (
     <SelectPrimitive.GroupLabel
       data-slot="select-label"
       className={cn("px-1.5 py-1 text-xs text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
-function SelectItem({
-  className,
-  children,
-  ...props
-}: SelectPrimitive.Item.Props) {
+function SelectItem({ className, children, ...props }: SelectPrimitive.Item.Props) {
   return (
     <SelectPrimitive.Item
       data-slot="select-item"
       className={cn(
         "relative flex w-full cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2",
-        className
+        className,
       )}
       {...props}
     >
@@ -133,20 +126,17 @@ function SelectItem({
         <CheckIcon className="pointer-events-none" />
       </SelectPrimitive.ItemIndicator>
     </SelectPrimitive.Item>
-  )
+  );
 }
 
-function SelectSeparator({
-  className,
-  ...props
-}: SelectPrimitive.Separator.Props) {
+function SelectSeparator({ className, ...props }: SelectPrimitive.Separator.Props) {
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
       className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SelectScrollUpButton({
@@ -158,14 +148,13 @@ function SelectScrollUpButton({
       data-slot="select-scroll-up-button"
       className={cn(
         "top-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
-      <ChevronUpIcon
-      />
+      <ChevronUpIcon />
     </SelectPrimitive.ScrollUpArrow>
-  )
+  );
 }
 
 function SelectScrollDownButton({
@@ -177,14 +166,13 @@ function SelectScrollDownButton({
       data-slot="select-scroll-down-button"
       className={cn(
         "bottom-0 z-10 flex w-full cursor-default items-center justify-center bg-popover py-1 [&_svg:not([class*='size-'])]:size-4",
-        className
+        className,
       )}
       {...props}
     >
-      <ChevronDownIcon
-      />
+      <ChevronDownIcon />
     </SelectPrimitive.ScrollDownArrow>
-  )
+  );
 }
 
 export {
@@ -198,4 +186,4 @@ export {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
-}
+};

--- a/apps/web/src/components/ui/separator.tsx
+++ b/apps/web/src/components/ui/separator.tsx
@@ -1,23 +1,19 @@
-import { Separator as SeparatorPrimitive } from "@base-ui/react/separator"
+import { Separator as SeparatorPrimitive } from "@base-ui/react/separator";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Separator({
-  className,
-  orientation = "horizontal",
-  ...props
-}: SeparatorPrimitive.Props) {
+function Separator({ className, orientation = "horizontal", ...props }: SeparatorPrimitive.Props) {
   return (
     <SeparatorPrimitive
       data-slot="separator"
       orientation={orientation}
       className={cn(
         "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Separator }
+export { Separator };

--- a/apps/web/src/components/ui/sheet.tsx
+++ b/apps/web/src/components/ui/sheet.tsx
@@ -1,26 +1,25 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
-
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
+import { XIcon } from "lucide-react";
+import type * as React from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 function Sheet({ ...props }: SheetPrimitive.Root.Props) {
-  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />;
 }
 
 function SheetTrigger({ ...props }: SheetPrimitive.Trigger.Props) {
-  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
 }
 
 function SheetClose({ ...props }: SheetPrimitive.Close.Props) {
-  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
 }
 
 function SheetPortal({ ...props }: SheetPrimitive.Portal.Props) {
-  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
 }
 
 function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
@@ -29,11 +28,11 @@ function SheetOverlay({ className, ...props }: SheetPrimitive.Backdrop.Props) {
       data-slot="sheet-overlay"
       className={cn(
         "fixed inset-0 isolate z-50 bg-black/10 duration-150 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function SheetContent({
@@ -43,8 +42,8 @@ function SheetContent({
   showCloseButton = true,
   ...props
 }: SheetPrimitive.Popup.Props & {
-  side?: "top" | "right" | "bottom" | "left"
-  showCloseButton?: boolean
+  side?: "top" | "right" | "bottom" | "left";
+  showCloseButton?: boolean;
 }) {
   return (
     <SheetPortal>
@@ -58,7 +57,7 @@ function SheetContent({
           "data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-1/2 data-[side=left]:border-r data-[side=left]:data-open:slide-in-from-left data-[side=left]:data-closed:slide-out-to-left",
           "data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-open:slide-in-from-bottom data-[side=bottom]:data-closed:slide-out-to-bottom",
           "data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-open:slide-in-from-top data-[side=top]:data-closed:slide-out-to-top",
-          className
+          className,
         )}
         {...props}
       >
@@ -66,22 +65,15 @@ function SheetContent({
         {showCloseButton && (
           <SheetPrimitive.Close
             data-slot="sheet-close"
-            render={
-              <Button
-                variant="ghost"
-                className="absolute top-3 right-3"
-                size="icon-sm"
-              />
-            }
+            render={<Button variant="ghost" className="absolute top-3 right-3" size="icon-sm" />}
           >
-            <XIcon
-            />
+            <XIcon />
             <span className="sr-only">Close</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Popup>
     </SheetPortal>
-  )
+  );
 }
 
 function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
@@ -91,7 +83,7 @@ function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("flex flex-col gap-0.5 p-4", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
@@ -101,42 +93,36 @@ function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("mt-auto flex flex-col gap-2 p-4", className)}
       {...props}
     />
-  )
+  );
 }
 
 function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
   return (
     <SheetPrimitive.Title
       data-slot="sheet-title"
-      className={cn(
-        "font-heading text-base font-medium text-foreground",
-        className
-      )}
+      className={cn("font-heading text-base font-medium text-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
-function SheetDescription({
-  className,
-  ...props
-}: SheetPrimitive.Description.Props) {
+function SheetDescription({ className, ...props }: SheetPrimitive.Description.Props) {
   return (
     <SheetPrimitive.Description
       data-slot="sheet-description"
       className={cn("text-sm text-muted-foreground", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
   Sheet,
-  SheetTrigger,
   SheetClose,
   SheetContent,
-  SheetHeader,
-  SheetFooter,
-  SheetTitle,
   SheetDescription,
-}
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+};

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,4 +1,4 @@
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
@@ -7,7 +7,7 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
       className={cn("animate-pulse rounded-md bg-muted", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };

--- a/apps/web/src/components/ui/tabs.tsx
+++ b/apps/web/src/components/ui/tabs.tsx
@@ -1,26 +1,19 @@
-"use client"
+"use client";
 
-import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
-import { cva, type VariantProps } from "class-variance-authority"
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Tabs({
-  className,
-  orientation = "horizontal",
-  ...props
-}: TabsPrimitive.Root.Props) {
+function Tabs({ className, orientation = "horizontal", ...props }: TabsPrimitive.Root.Props) {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
       data-orientation={orientation}
-      className={cn(
-        "group/tabs flex gap-2 data-horizontal:flex-col",
-        className
-      )}
+      className={cn("group/tabs flex gap-2 data-horizontal:flex-col", className)}
       {...props}
     />
-  )
+  );
 }
 
 const tabsListVariants = cva(
@@ -35,8 +28,8 @@ const tabsListVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 function TabsList({
   className,
@@ -50,7 +43,7 @@ function TabsList({
       className={cn(tabsListVariants({ variant }), className)}
       {...props}
     />
-  )
+  );
 }
 
 function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
@@ -62,11 +55,11 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
         "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
@@ -76,7 +69,7 @@ function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
       className={cn("flex-1 text-sm outline-none", className)}
       {...props}
     />
-  )
+  );
 }
 
-export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }
+export { Tabs, TabsContent, TabsList, TabsTrigger, tabsListVariants };

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -1,6 +1,6 @@
-import * as React from "react"
+import type * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
   return (
@@ -8,11 +8,11 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
       data-slot="textarea"
       className={cn(
         "flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
-export { Textarea }
+export { Textarea };

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -1,28 +1,19 @@
-"use client"
+"use client";
 
-import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip"
+import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function TooltipProvider({
-  delay = 0,
-  ...props
-}: TooltipPrimitive.Provider.Props) {
-  return (
-    <TooltipPrimitive.Provider
-      data-slot="tooltip-provider"
-      delay={delay}
-      {...props}
-    />
-  )
+function TooltipProvider({ delay = 0, ...props }: TooltipPrimitive.Provider.Props) {
+  return <TooltipPrimitive.Provider data-slot="tooltip-provider" delay={delay} {...props} />;
 }
 
 function Tooltip({ ...props }: TooltipPrimitive.Root.Props) {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
 }
 
 function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
-  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
 function TooltipContent({
@@ -34,10 +25,7 @@ function TooltipContent({
   children,
   ...props
 }: TooltipPrimitive.Popup.Props &
-  Pick<
-    TooltipPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset"
-  >) {
+  Pick<TooltipPrimitive.Positioner.Props, "align" | "alignOffset" | "side" | "sideOffset">) {
   return (
     <TooltipPrimitive.Portal>
       <TooltipPrimitive.Positioner
@@ -51,7 +39,7 @@ function TooltipContent({
           data-slot="tooltip-content"
           className={cn(
             "z-50 inline-flex w-fit max-w-xs origin-(--transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-            className
+            className,
           )}
           {...props}
         >
@@ -60,7 +48,7 @@ function TooltipContent({
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>
-  )
+  );
 }
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };

--- a/apps/web/src/globals.css
+++ b/apps/web/src/globals.css
@@ -6,27 +6,27 @@
 /* ── Our design tokens ── */
 
 :root {
-  --bg-primary: #FAFAFA;
-  --bg-secondary: #F4F4F5;
-  --bg-tertiary: #E4E4E7;
-  --bg-card: #FFFFFF;
-  --text-primary: #09090B;
-  --text-secondary: #52525B;
-  --text-tertiary: #A1A1AA;
-  --accent: #0891B2;
+  --bg-primary: #fafafa;
+  --bg-secondary: #f4f4f5;
+  --bg-tertiary: #e4e4e7;
+  --bg-card: #ffffff;
+  --text-primary: #09090b;
+  --text-secondary: #52525b;
+  --text-tertiary: #a1a1aa;
+  --accent: #0891b2;
   --accent-soft: rgba(8, 145, 178, 0.1);
   --accent-glow: rgba(34, 211, 238, 0.15);
 }
 
 .dark {
-  --bg-primary: #09090B;
-  --bg-secondary: #18181B;
-  --bg-tertiary: #27272A;
-  --bg-card: #18181B;
-  --text-primary: #FAFAFA;
-  --text-secondary: #A1A1AA;
-  --text-tertiary: #71717A;
-  --accent: #22D3EE;
+  --bg-primary: #09090b;
+  --bg-secondary: #18181b;
+  --bg-tertiary: #27272a;
+  --bg-card: #18181b;
+  --text-primary: #fafafa;
+  --text-secondary: #a1a1aa;
+  --text-tertiary: #71717a;
+  --accent: #22d3ee;
   --accent-soft: rgba(34, 211, 238, 0.1);
   --accent-glow: rgba(34, 211, 238, 0.12);
 }
@@ -118,10 +118,10 @@ body {
     --secondary-foreground: var(--text-primary);
     --muted: var(--bg-tertiary);
     --muted-foreground: var(--text-secondary);
-    --destructive: #EF4444;
-    --border: #E4E4E7;
-    --input: #E4E4E7;
-    --ring: #A1A1AA;
+    --destructive: #ef4444;
+    --border: #e4e4e7;
+    --input: #e4e4e7;
+    --ring: #a1a1aa;
     --radius: 0.5rem;
   }
   .dark {
@@ -137,10 +137,10 @@ body {
     --secondary-foreground: var(--text-primary);
     --muted: var(--bg-tertiary);
     --muted-foreground: var(--text-secondary);
-    --destructive: #EF4444;
-    --border: #27272A;
-    --input: #27272A;
-    --ring: #71717A;
+    --destructive: #ef4444;
+    --border: #27272a;
+    --input: #27272a;
+    --ring: #71717a;
   }
   * {
     @apply border-border outline-ring/50;

--- a/apps/web/src/hooks/useAgents.ts
+++ b/apps/web/src/hooks/useAgents.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { api } from "../lib/api";
 
 export function useAgents() {
@@ -9,11 +9,16 @@ export function useAgents() {
     try {
       const result = await api.agents.list();
       setAgents(result);
-    } catch { /* ignore */ }
-    finally { setLoading(false); }
+    } catch {
+      /* ignore */
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
-  useEffect(() => { load(); }, [load]);
+  useEffect(() => {
+    load();
+  }, [load]);
 
   return { agents, loading, refresh: load };
 }

--- a/apps/web/src/hooks/useBoard.ts
+++ b/apps/web/src/hooks/useBoard.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../lib/api";
 
 const LAST_BOARD_KEY = "ak-last-board";

--- a/apps/web/src/hooks/useSSE.ts
+++ b/apps/web/src/hooks/useSSE.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { getAuthToken } from "../lib/auth-client";
 
 interface UseSSEOptions {
@@ -69,7 +69,9 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
       ]);
       if (logsRes.ok) setLogs(await logsRes.json());
       if (msgsRes.ok) setMessages(await msgsRes.json());
-    } catch { /* ignore polling errors */ }
+    } catch {
+      /* ignore polling errors */
+    }
   }, [taskId, token]);
 
   useEffect(() => {

--- a/apps/web/src/lib/agentIdentity.ts
+++ b/apps/web/src/lib/agentIdentity.ts
@@ -30,9 +30,14 @@ export function agentIdenticon(publicKey: string): boolean[][] {
 // Hue 160-220 (cyan-blue), vary saturation 60-85% and lightness for distinction
 // Dark mode: lightness 58-72% for readability on dark backgrounds
 // Light mode: lightness 38-48% for contrast on light backgrounds
-function agentHsl(publicKey: string): { hue: number; sat: number; lightDark: number; lightLight: number } {
+function agentHsl(publicKey: string): {
+  hue: number;
+  sat: number;
+  lightDark: number;
+  lightLight: number;
+} {
   const bytes = hashBytes(publicKey);
-  const hue = 160 + ((bytes[0] << 8 | bytes[1]) % 61);
+  const hue = 160 + (((bytes[0] << 8) | bytes[1]) % 61);
   const sat = 60 + (bytes[2] % 26);
   const lightDark = 58 + (bytes[3] % 15);
   const lightLight = 38 + (bytes[3] % 11);
@@ -50,7 +55,8 @@ export function agentColorLight(publicKey: string): string {
 }
 
 function hslToRgb(h: number, s: number, l: number): string {
-  s /= 100; l /= 100;
+  s /= 100;
+  l /= 100;
   const a = s * Math.min(l, 1 - l);
   const f = (n: number) => {
     const k = (n + h / 30) % 12;
@@ -65,8 +71,5 @@ export function agentColorRgb(publicKey: string): string {
 }
 
 export function agentFingerprint(fingerprint: string): string {
-  return fingerprint
-    .slice(0, 8)
-    .match(/.{2}/g)!
-    .join(":");
+  return fingerprint.slice(0, 8).match(/.{2}/g)!.join(":");
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -15,7 +15,7 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
     body: body ? JSON.stringify(body) : undefined,
   });
 
-  const data = await res.json() as any;
+  const data = (await res.json()) as any;
 
   if (!res.ok) {
     const err = new Error(data.error?.message || `HTTP ${res.status}`);
@@ -30,20 +30,23 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
 export const api = {
   tasks: {
     list: (params?: Record<string, string>) => {
-      const qs = params ? "?" + new URLSearchParams(params).toString() : "";
+      const qs = params ? `?${new URLSearchParams(params).toString()}` : "";
       return request<any[]>("GET", `/tasks${qs}`);
     },
     get: (id: string) => request<any>("GET", `/tasks/${id}`),
     create: (input: Record<string, unknown>) => request<any>("POST", "/tasks", input),
-    update: (id: string, body: Record<string, unknown>) => request<any>("PATCH", `/tasks/${id}`, body),
+    update: (id: string, body: Record<string, unknown>) =>
+      request<any>("PATCH", `/tasks/${id}`, body),
     delete: (id: string) => request<void>("DELETE", `/tasks/${id}`),
     claim: (id: string) => request<any>("POST", `/tasks/${id}/claim`),
-    complete: (id: string, body?: Record<string, unknown>) => request<any>("POST", `/tasks/${id}/complete`, body),
+    complete: (id: string, body?: Record<string, unknown>) =>
+      request<any>("POST", `/tasks/${id}/complete`, body),
     release: (id: string) => request<any>("POST", `/tasks/${id}/release`),
     cancel: (id: string) => request<any>("POST", `/tasks/${id}/cancel`),
     review: (id: string) => request<any>("POST", `/tasks/${id}/review`),
     reject: (id: string) => request<any>("POST", `/tasks/${id}/reject`),
-    assign: (id: string, agentId: string) => request<any>("POST", `/tasks/${id}/assign`, { agent_id: agentId }),
+    assign: (id: string, agentId: string) =>
+      request<any>("POST", `/tasks/${id}/assign`, { agent_id: agentId }),
     addLog: (id: string, detail: string) => request<any>("POST", `/tasks/${id}/logs`, { detail }),
     getLogs: (id: string, since?: string) => {
       const qs = since ? `?since=${encodeURIComponent(since)}` : "";
@@ -61,9 +64,18 @@ export const api = {
   agents: {
     list: () => request<any[]>("GET", "/agents"),
     get: (id: string) => request<any>("GET", `/agents/${id}`),
-    create: (input: { name: string; bio?: string; soul?: string; role?: string; handoff_to?: string[]; runtime?: string; model?: string; skills?: string[] }) =>
-      request<any>("POST", "/agents", input),
-    update: (id: string, body: Record<string, unknown>) => request<any>("PATCH", `/agents/${id}`, body),
+    create: (input: {
+      name: string;
+      bio?: string;
+      soul?: string;
+      role?: string;
+      handoff_to?: string[];
+      runtime?: string;
+      model?: string;
+      skills?: string[];
+    }) => request<any>("POST", "/agents", input),
+    update: (id: string, body: Record<string, unknown>) =>
+      request<any>("PATCH", `/agents/${id}`, body),
     delete: (id: string) => request<void>("DELETE", `/agents/${id}`),
     sessions: (agentId: string) => request<any[]>("GET", `/agents/${agentId}/sessions`),
   },
@@ -75,8 +87,10 @@ export const api = {
   boards: {
     list: () => request<any[]>("GET", "/boards"),
     get: (id: string) => request<any>("GET", `/boards/${id}`),
-    create: (input: { name: string; description?: string }) => request<any>("POST", "/boards", input),
-    update: (id: string, body: { name?: string; description?: string }) => request<any>("PATCH", `/boards/${id}`, body),
+    create: (input: { name: string; description?: string }) =>
+      request<any>("POST", "/boards", input),
+    update: (id: string, body: { name?: string; description?: string }) =>
+      request<any>("PATCH", `/boards/${id}`, body),
     delete: (id: string) => request<void>("DELETE", `/boards/${id}`),
   },
   repositories: {

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,6 +1,6 @@
-import { createAuthClient } from "better-auth/react";
 import { agentAuthClient } from "@better-auth/agent-auth/client";
 import { apiKeyClient } from "@better-auth/api-key/client";
+import { createAuthClient } from "better-auth/react";
 
 const TOKEN_KEY = "auth-token";
 

--- a/apps/web/src/lib/theme.ts
+++ b/apps/web/src/lib/theme.ts
@@ -11,8 +11,7 @@ export function setTheme(theme: Theme) {
 
 export function applyTheme(theme: Theme) {
   const isDark =
-    theme === "dark" ||
-    (theme === "system" && matchMedia("(prefers-color-scheme: dark)").matches);
+    theme === "dark" || (theme === "system" && matchMedia("(prefers-color-scheme: dark)").matches);
 
   document.documentElement.classList.toggle("dark", isDark);
 }

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }

--- a/apps/web/src/routes/AccountSettingsPage.tsx
+++ b/apps/web/src/routes/AccountSettingsPage.tsx
@@ -1,11 +1,15 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Header } from "../components/Header";
-import { getTheme, setTheme, type Theme } from "../lib/theme";
-import { api } from "../lib/api";
 import { useBoards } from "../hooks/useBoard";
+import { api } from "../lib/api";
+import { getTheme, setTheme, type Theme } from "../lib/theme";
 
-function BoardItem({ board, onUpdate, onDelete }: {
+function BoardItem({
+  board,
+  onUpdate,
+  onDelete,
+}: {
   board: any;
   onUpdate: () => void;
   onDelete: (id: string) => void;
@@ -44,19 +48,41 @@ function BoardItem({ board, onUpdate, onDelete }: {
 
   return (
     <div className="border border-border rounded-lg overflow-hidden">
+      {/* biome-ignore lint/a11y/useSemanticElements: container with nested interactive children cannot be a button */}
       <div
-        className="flex items-center gap-3 px-4 py-3 cursor-pointer hover:bg-surface-tertiary/50 transition-colors"
+        role="button"
+        tabIndex={0}
+        className="flex items-center gap-3 px-4 py-3 w-full cursor-pointer hover:bg-surface-tertiary/50 transition-colors"
         onClick={() => setExpanded(!expanded)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            setExpanded(!expanded);
+          }
+        }}
       >
         <svg
-          width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
           className={`shrink-0 text-content-tertiary transition-transform ${expanded ? "rotate-90" : ""}`}
         >
           <polyline points="9 18 15 12 9 6" />
         </svg>
-        <span className="text-sm font-medium text-content-primary flex-1 truncate">{board.name}</span>
+        <span className="text-sm font-medium text-content-primary flex-1 truncate">
+          {board.name}
+        </span>
         <button
-          onClick={(e) => { e.stopPropagation(); navigate(`/boards/${board.id}`); }}
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            navigate(`/boards/${board.id}`);
+          }}
           className="text-xs text-content-tertiary hover:text-accent transition-colors"
         >
           Open
@@ -66,16 +92,28 @@ function BoardItem({ board, onUpdate, onDelete }: {
       {expanded && (
         <div className="px-4 pb-4 pt-1 border-t border-border space-y-3">
           <div>
-            <label className="block text-xs text-content-tertiary mb-1">Name</label>
+            <label
+              htmlFor={`board-name-${board.id}`}
+              className="block text-xs text-content-tertiary mb-1"
+            >
+              Name
+            </label>
             <input
+              id={`board-name-${board.id}`}
               value={editName}
               onChange={(e) => setEditName(e.target.value)}
               className="w-full bg-surface-primary border border-border rounded-lg px-3 py-2 text-sm text-content-primary outline-none focus:border-accent"
             />
           </div>
           <div>
-            <label className="block text-xs text-content-tertiary mb-1">Description</label>
+            <label
+              htmlFor={`board-desc-${board.id}`}
+              className="block text-xs text-content-tertiary mb-1"
+            >
+              Description
+            </label>
             <textarea
+              id={`board-desc-${board.id}`}
               value={editDesc}
               onChange={(e) => setEditDesc(e.target.value)}
               rows={2}
@@ -88,15 +126,34 @@ function BoardItem({ board, onUpdate, onDelete }: {
               {confirmDelete ? (
                 <div className="flex items-center gap-2">
                   <span className="text-xs text-error">Delete?</span>
-                  <button onClick={handleDelete} className="text-xs font-medium text-error hover:underline">Yes</button>
-                  <button onClick={() => setConfirmDelete(false)} className="text-xs text-content-tertiary hover:text-content-secondary">No</button>
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    className="text-xs font-medium text-error hover:underline"
+                  >
+                    Yes
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDelete(false)}
+                    className="text-xs text-content-tertiary hover:text-content-secondary"
+                  >
+                    No
+                  </button>
                 </div>
               ) : (
-                <button onClick={() => setConfirmDelete(true)} className="text-xs text-error hover:underline">Delete</button>
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(true)}
+                  className="text-xs text-error hover:underline"
+                >
+                  Delete
+                </button>
               )}
             </div>
             {hasChanges && (
               <button
+                type="button"
                 onClick={handleSave}
                 disabled={saving || !editName.trim()}
                 className="bg-accent text-[#09090B] font-medium text-xs px-3 py-1.5 rounded-md hover:opacity-90 disabled:opacity-50"
@@ -120,7 +177,7 @@ export function AccountSettingsPage() {
     setCurrentTheme(theme);
   }
 
-  function handleBoardDelete(id: string) {
+  function handleBoardDelete(_id: string) {
     refresh();
   }
 
@@ -132,10 +189,13 @@ export function AccountSettingsPage() {
 
         {/* Theme */}
         <section className="space-y-3">
-          <h2 className="text-xs font-semibold text-content-tertiary uppercase tracking-wide">Theme</h2>
+          <h2 className="text-xs font-semibold text-content-tertiary uppercase tracking-wide">
+            Theme
+          </h2>
           <div className="flex gap-2">
             {(["light", "dark", "system"] as Theme[]).map((t) => (
               <button
+                type="button"
                 key={t}
                 onClick={() => handleTheme(t)}
                 className={`text-sm px-4 py-2 rounded-lg border transition-colors capitalize ${
@@ -152,7 +212,9 @@ export function AccountSettingsPage() {
 
         {/* Boards */}
         <section className="space-y-3">
-          <h2 className="text-xs font-semibold text-content-tertiary uppercase tracking-wide">Boards</h2>
+          <h2 className="text-xs font-semibold text-content-tertiary uppercase tracking-wide">
+            Boards
+          </h2>
           {boards.length === 0 ? (
             <p className="text-sm text-content-tertiary">No boards yet.</p>
           ) : (

--- a/apps/web/src/routes/AgentDetailPage.tsx
+++ b/apps/web/src/routes/AgentDetailPage.tsx
@@ -1,20 +1,32 @@
-import { useState, useEffect } from "react";
-import { useParams, Link } from "react-router-dom";
-import { Header } from "../components/Header";
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
 import { AgentIdenticon } from "../components/AgentIdenticon";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "../components/ui/dialog";
-import { api } from "../lib/api";
-import { agentFingerprint, agentColor, agentColorRgb } from "../lib/agentIdentity";
+import { Header } from "../components/Header";
 import { formatRelative } from "../components/TaskDetailFields";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../components/ui/dialog";
+import { agentColor, agentColorRgb, agentFingerprint } from "../lib/agentIdentity";
+import { api } from "../lib/api";
 
 const actionStyles: Record<string, string> = {
-  claimed: "text-accent", assigned: "text-accent", completed: "text-success",
-  released: "text-warning", timed_out: "text-error", review_requested: "text-accent",
+  claimed: "text-accent",
+  assigned: "text-accent",
+  completed: "text-success",
+  released: "text-warning",
+  timed_out: "text-error",
+  review_requested: "text-accent",
 };
 
 const taskStatusStyles: Record<string, string> = {
-  in_progress: "bg-accent/15 text-accent", in_review: "bg-yellow-500/15 text-yellow-500",
-  done: "bg-green-500/15 text-green-500", todo: "bg-zinc-500/15 text-content-tertiary",
+  in_progress: "bg-accent/15 text-accent",
+  in_review: "bg-yellow-500/15 text-yellow-500",
+  done: "bg-green-500/15 text-green-500",
+  todo: "bg-zinc-500/15 text-content-tertiary",
   cancelled: "bg-red-500/15 text-red-500",
 };
 
@@ -43,15 +55,30 @@ export function AgentDetailPage() {
 
   useEffect(() => {
     if (!id) return;
-    api.agents.get(id).then((a) => {
-      setAgent(a);
-      api.agents.sessions(id).then(setSessions).catch(() => {});
-      api.tasks.list({ assigned_to: id }).then((ts) => setTask(ts[0] ?? null)).catch(() => {});
-    }).finally(() => setLoading(false));
+    api.agents
+      .get(id)
+      .then((a) => {
+        setAgent(a);
+        api.agents
+          .sessions(id)
+          .then(setSessions)
+          .catch(() => {});
+        api.tasks
+          .list({ assigned_to: id })
+          .then((ts) => setTask(ts[0] ?? null))
+          .catch(() => {});
+      })
+      .finally(() => setLoading(false));
     const interval = setInterval(() => {
       api.agents.get(id).then(setAgent);
-      api.agents.sessions(id).then(setSessions).catch(() => {});
-      api.tasks.list({ assigned_to: id }).then((ts) => setTask(ts[0] ?? null)).catch(() => {});
+      api.agents
+        .sessions(id)
+        .then(setSessions)
+        .catch(() => {});
+      api.tasks
+        .list({ assigned_to: id })
+        .then((ts) => setTask(ts[0] ?? null))
+        .catch(() => {});
     }, 15000);
     return () => clearInterval(interval);
   }, [id]);
@@ -82,7 +109,8 @@ export function AgentDetailPage() {
   const color = agent.public_key ? agentColor(agent.public_key) : "#22D3EE";
   const fp = agent.fingerprint ? agentFingerprint(agent.fingerprint) : "";
   const isOnline = agent.status === "online";
-  const totalTokens = (agent.input_tokens || 0) + (agent.output_tokens || 0) + (agent.cache_read_tokens || 0);
+  const totalTokens =
+    (agent.input_tokens || 0) + (agent.output_tokens || 0) + (agent.cache_read_tokens || 0);
 
   const tabs: { key: Tab; label: string; count?: number }[] = [
     { key: "mission", label: "Mission" },
@@ -94,7 +122,10 @@ export function AgentDetailPage() {
     <div className="min-h-screen bg-surface-primary">
       <Header />
       <div className="max-w-4xl mx-auto px-8 py-10">
-        <Link to="/agents" className="text-xs text-content-tertiary hover:text-content-secondary transition-colors">
+        <Link
+          to="/agents"
+          className="text-xs text-content-tertiary hover:text-content-secondary transition-colors"
+        >
           &larr; Agents
         </Link>
 
@@ -114,10 +145,21 @@ export function AgentDetailPage() {
           <div className="px-6 py-12 relative overflow-hidden">
             {/* Fingerprint watermark — right side, clickable */}
             <button
+              type="button"
               onClick={() => setShowIdentity(true)}
               className="absolute right-12 top-1/2 -translate-y-1/2 z-10 flex flex-col items-center gap-2 cursor-pointer group transition-opacity hover:opacity-100 opacity-100"
             >
-              <svg width="128" height="128" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="opacity-15 group-hover:opacity-30 transition-opacity">
+              <svg
+                width="128"
+                height="128"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke={color}
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="opacity-15 group-hover:opacity-30 transition-opacity"
+              >
                 <path d="M12 10a2 2 0 0 0-2 2c0 1.02-.1 2.51-.26 4" />
                 <path d="M14 13.12c0 2.38 0 6.38-1 8.88" />
                 <path d="M17.29 21.02c.12-.6.43-2.3.5-3.02" />
@@ -128,7 +170,9 @@ export function AgentDetailPage() {
                 <path d="M8.65 22c.21-.66.45-1.32.57-2" />
                 <path d="M9 6.8a6 6 0 0 1 9 5.2v2" />
               </svg>
-              <span className="font-mono text-[11px] tracking-[0.2em] font-medium text-content-tertiary transition-opacity">{fp}</span>
+              <span className="font-mono text-[11px] tracking-[0.2em] font-medium text-content-tertiary transition-opacity">
+                {fp}
+              </span>
             </button>
 
             <div className="flex items-start gap-6 relative">
@@ -136,11 +180,23 @@ export function AgentDetailPage() {
 
               <div className="flex-1 min-w-0 pt-1">
                 <div className="flex items-center gap-3">
-                  <h1 className="font-mono text-2xl font-bold text-content-primary" style={{ letterSpacing: "-0.02em" }}>
+                  <h1
+                    className="font-mono text-2xl font-bold text-content-primary"
+                    style={{ letterSpacing: "-0.02em" }}
+                  >
                     {agent.name}
                   </h1>
                   {agent.builtin ? (
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" className="text-content-tertiary shrink-0">
+                    <svg
+                      width="14"
+                      height="14"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      className="text-content-tertiary shrink-0"
+                    >
                       <title>Built-in — cannot be modified</title>
                       <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
                       <path d="M7 11V7a5 5 0 0 1 10 0v4" />
@@ -152,9 +208,7 @@ export function AgentDetailPage() {
                   />
                 </div>
 
-                {agent.bio && (
-                  <p className="mt-2 text-sm text-content-secondary">{agent.bio}</p>
-                )}
+                {agent.bio && <p className="mt-2 text-sm text-content-secondary">{agent.bio}</p>}
 
                 {/* Meta */}
                 <div className="mt-3 flex items-center gap-2 flex-wrap">
@@ -177,7 +231,6 @@ export function AgentDetailPage() {
                     </span>
                   )}
                 </div>
-
               </div>
             </div>
           </div>
@@ -192,7 +245,9 @@ export function AgentDetailPage() {
               { label: "COST", value: formatCost(agent.cost_micro_usd || 0) },
             ].map((stat) => (
               <div key={stat.label} className="py-3 px-4 text-center">
-                <div className="text-[9px] font-mono text-content-tertiary uppercase tracking-wider">{stat.label}</div>
+                <div className="text-[9px] font-mono text-content-tertiary uppercase tracking-wider">
+                  {stat.label}
+                </div>
                 <div className="font-mono text-base text-content-primary mt-0.5">{stat.value}</div>
               </div>
             ))}
@@ -201,8 +256,20 @@ export function AgentDetailPage() {
           {/* Token composition bar */}
           {totalTokens > 0 && (
             <div className="h-1 flex">
-              <div style={{ width: `${(agent.input_tokens / totalTokens) * 100}%`, background: color, opacity: 0.8 }} />
-              <div style={{ width: `${(agent.output_tokens / totalTokens) * 100}%`, background: color, opacity: 0.35 }} />
+              <div
+                style={{
+                  width: `${(agent.input_tokens / totalTokens) * 100}%`,
+                  background: color,
+                  opacity: 0.8,
+                }}
+              />
+              <div
+                style={{
+                  width: `${(agent.output_tokens / totalTokens) * 100}%`,
+                  background: color,
+                  opacity: 0.35,
+                }}
+              />
               <div style={{ flex: 1, background: color, opacity: 0.1 }} />
             </div>
           )}
@@ -220,9 +287,16 @@ export function AgentDetailPage() {
 
         {/* ─── Soul ─── */}
         {agent.soul && (
-          <div className="mt-6 bg-surface-secondary rounded-lg px-5 py-4" style={{ boxShadow: "0 0 0 1px var(--border)" }}>
-            <div className="text-[9px] font-mono text-content-tertiary uppercase tracking-wider mb-2">Soul</div>
-            <p className="font-mono text-xs text-content-secondary leading-relaxed whitespace-pre-wrap">{agent.soul}</p>
+          <div
+            className="mt-6 bg-surface-secondary rounded-lg px-5 py-4"
+            style={{ boxShadow: "0 0 0 1px var(--border)" }}
+          >
+            <div className="text-[9px] font-mono text-content-tertiary uppercase tracking-wider mb-2">
+              Soul
+            </div>
+            <p className="font-mono text-xs text-content-secondary leading-relaxed whitespace-pre-wrap">
+              {agent.soul}
+            </p>
           </div>
         )}
 
@@ -230,6 +304,7 @@ export function AgentDetailPage() {
         <div className="mt-10 flex items-center gap-6 border-b border-border">
           {tabs.map((t) => (
             <button
+              type="button"
               key={t.key}
               onClick={() => setTab(t.key)}
               className={`pb-2.5 text-sm font-medium transition-colors relative ${
@@ -240,10 +315,15 @@ export function AgentDetailPage() {
             >
               {t.label}
               {t.count !== undefined && t.count > 0 && (
-                <span className="ml-1.5 text-[10px] font-mono text-content-tertiary">{t.count}</span>
+                <span className="ml-1.5 text-[10px] font-mono text-content-tertiary">
+                  {t.count}
+                </span>
               )}
               {tab === t.key && (
-                <span className="absolute bottom-0 left-0 right-0 h-[2px] rounded-full" style={{ background: color }} />
+                <span
+                  className="absolute bottom-0 left-0 right-0 h-[2px] rounded-full"
+                  style={{ background: color }}
+                />
               )}
             </button>
           ))}
@@ -260,7 +340,7 @@ export function AgentDetailPage() {
   );
 }
 
-function ActivityTab({ logs, rgb }: { logs: any[]; rgb: string }) {
+function ActivityTab({ logs, rgb: _rgb }: { logs: any[]; rgb: string }) {
   if (!logs || logs.length === 0) {
     return <p className="text-sm text-content-tertiary">No activity yet.</p>;
   }
@@ -272,7 +352,9 @@ function ActivityTab({ logs, rgb }: { logs: any[]; rgb: string }) {
           <span className="font-mono text-[11px] text-content-tertiary w-20 shrink-0">
             {formatRelative(log.created_at)}
           </span>
-          <span className={`font-mono text-[12px] w-32 shrink-0 ${actionStyles[log.action] || "text-content-tertiary"}`}>
+          <span
+            className={`font-mono text-[12px] w-32 shrink-0 ${actionStyles[log.action] || "text-content-tertiary"}`}
+          >
             {log.action}
           </span>
           {log.task_title && (
@@ -304,14 +386,20 @@ function SessionsTab({ sessions, color }: { sessions: any[]; color: string }) {
             <span className="font-mono text-[11px] text-content-tertiary w-20 shrink-0">
               {formatRelative(s.created_at)}
             </span>
-            <code className="font-mono text-[11px] text-content-secondary">{s.id.slice(0, 12)}</code>
-            <span className={`text-[10px] font-mono rounded px-1.5 py-0.5 ${
-              isActive ? "text-accent bg-accent/10" : "text-content-tertiary bg-surface-tertiary"
-            }`}>
+            <code className="font-mono text-[11px] text-content-secondary">
+              {s.id.slice(0, 12)}
+            </code>
+            <span
+              className={`text-[10px] font-mono rounded px-1.5 py-0.5 ${
+                isActive ? "text-accent bg-accent/10" : "text-content-tertiary bg-surface-tertiary"
+              }`}
+            >
               {s.status}
             </span>
             {s.machine_name && (
-              <span className="text-[11px] text-content-tertiary font-mono ml-auto">{s.machine_name}</span>
+              <span className="text-[11px] text-content-tertiary font-mono ml-auto">
+                {s.machine_name}
+              </span>
             )}
           </div>
         );
@@ -320,34 +408,54 @@ function SessionsTab({ sessions, color }: { sessions: any[]; color: string }) {
   );
 }
 
-function IdentityModal({ open, onOpenChange, fingerprint, publicKey, rgb }: {
-  open: boolean; onOpenChange: (open: boolean) => void;
-  fingerprint: string; publicKey: string; color: string; rgb: string;
+function IdentityModal({
+  open,
+  onOpenChange,
+  fingerprint,
+  publicKey,
+  rgb,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  fingerprint: string;
+  publicKey: string;
+  color: string;
+  rgb: string;
 }) {
-  const formatFullFingerprint = (fp: string) =>
-    fp.match(/.{2}/g)?.join(":") ?? fp;
+  const formatFullFingerprint = (fp: string) => fp.match(/.{2}/g)?.join(":") ?? fp;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg" style={{ boxShadow: `0 0 0 1px rgba(${rgb}, 0.15)` }}>
         <DialogHeader>
           <DialogTitle>Cryptographic Identity</DialogTitle>
-          <DialogDescription className="sr-only">Agent cryptographic identity details</DialogDescription>
+          <DialogDescription className="sr-only">
+            Agent cryptographic identity details
+          </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-5">
           <div>
             <div className="flex items-center justify-between mb-2">
-              <span className="text-[10px] font-mono text-content-tertiary uppercase tracking-wider">Fingerprint</span>
+              <span className="text-[10px] font-mono text-content-tertiary uppercase tracking-wider">
+                Fingerprint
+              </span>
               <button
+                type="button"
                 onClick={() => navigator.clipboard.writeText(fingerprint)}
                 className="text-[10px] text-content-tertiary hover:text-content-secondary transition-colors"
               >
                 Copy
               </button>
             </div>
-            <div className="bg-surface-primary rounded-md p-4" style={{ border: `1px solid rgba(${rgb}, 0.1)` }}>
-              <code className="font-mono text-[12px] text-content-secondary break-all leading-relaxed block select-all" style={{ wordSpacing: "0.15em" }}>
+            <div
+              className="bg-surface-primary rounded-md p-4"
+              style={{ border: `1px solid rgba(${rgb}, 0.1)` }}
+            >
+              <code
+                className="font-mono text-[12px] text-content-secondary break-all leading-relaxed block select-all"
+                style={{ wordSpacing: "0.15em" }}
+              >
                 {formatFullFingerprint(fingerprint)}
               </code>
             </div>
@@ -355,15 +463,21 @@ function IdentityModal({ open, onOpenChange, fingerprint, publicKey, rgb }: {
 
           <div>
             <div className="flex items-center justify-between mb-2">
-              <span className="text-[10px] font-mono text-content-tertiary uppercase tracking-wider">Ed25519 Public Key</span>
+              <span className="text-[10px] font-mono text-content-tertiary uppercase tracking-wider">
+                Ed25519 Public Key
+              </span>
               <button
+                type="button"
                 onClick={() => navigator.clipboard.writeText(publicKey)}
                 className="text-[10px] text-content-tertiary hover:text-content-secondary transition-colors"
               >
                 Copy
               </button>
             </div>
-            <div className="bg-surface-primary rounded-md p-4" style={{ border: `1px solid rgba(${rgb}, 0.1)` }}>
+            <div
+              className="bg-surface-primary rounded-md p-4"
+              style={{ border: `1px solid rgba(${rgb}, 0.1)` }}
+            >
               <code className="font-mono text-[12px] text-content-secondary break-all leading-relaxed block select-all">
                 {publicKey}
               </code>
@@ -375,7 +489,7 @@ function IdentityModal({ open, onOpenChange, fingerprint, publicKey, rgb }: {
   );
 }
 
-function MissionTab({ task, color, rgb }: { task: any; color: string; rgb: string }) {
+function MissionTab({ task, color, rgb: _rgb }: { task: any; color: string; rgb: string }) {
   if (!task) {
     return <p className="text-sm text-content-tertiary">No active mission.</p>;
   }
@@ -389,13 +503,20 @@ function MissionTab({ task, color, rgb }: { task: any; color: string; rgb: strin
         boxShadow: "0 0 0 1px var(--border)",
       }}
     >
-      <span className={`text-[10px] font-mono uppercase px-2 py-0.5 rounded ${taskStatusStyles[task.status]}`}>
+      <span
+        className={`text-[10px] font-mono uppercase px-2 py-0.5 rounded ${taskStatusStyles[task.status]}`}
+      >
         {task.status.replace("_", " ")}
       </span>
       <span className="text-sm text-content-primary flex-1 truncate">{task.title}</span>
       {task.pr_url && (
-        <a href={task.pr_url} target="_blank" rel="noopener" onClick={(e) => e.stopPropagation()}
-          className="text-[11px] font-mono text-content-tertiary hover:text-content-secondary">
+        <a
+          href={task.pr_url}
+          target="_blank"
+          rel="noopener"
+          onClick={(e) => e.stopPropagation()}
+          className="text-[11px] font-mono text-content-tertiary hover:text-content-secondary"
+        >
           PR &rarr;
         </a>
       )}

--- a/apps/web/src/routes/AgentNewPage.tsx
+++ b/apps/web/src/routes/AgentNewPage.tsx
@@ -1,15 +1,26 @@
-import { useState, useEffect, useRef } from "react";
+import {
+  type AgentTemplate,
+  fetchTemplate,
+  fetchTemplateIndex,
+  type TemplateIndex,
+} from "@agent-kanban/shared";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Header } from "../components/Header";
 import { AgentIdenticon } from "../components/AgentIdenticon";
+import { Header } from "../components/Header";
+import { Button } from "../components/ui/button";
 import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select";
 import { Textarea } from "../components/ui/textarea";
-import { Button } from "../components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../components/ui/select";
-import { api } from "../lib/api";
 import { agentColor } from "../lib/agentIdentity";
-import { fetchTemplateIndex, fetchTemplate, type AgentTemplate, type TemplateIndex } from "@agent-kanban/shared";
+import { api } from "../lib/api";
 
 type Step = "choose" | "recruit" | "form";
 
@@ -51,8 +62,14 @@ export function AgentNewPage() {
 
   function startCustom() {
     setSelectedTemplate(null);
-    setName(""); setBio(""); setSoul(""); setRole("");
-    setHandoffTo([]); setRuntime("claude-code"); setModel(""); setSkills([]);
+    setName("");
+    setBio("");
+    setSoul("");
+    setRole("");
+    setHandoffTo([]);
+    setRuntime("claude-code");
+    setModel("");
+    setSkills([]);
     setStep("form");
   }
 
@@ -92,15 +109,24 @@ export function AgentNewPage() {
           <FormStep
             template={selectedTemplate}
             existingRoles={existingRoles}
-            name={name} setName={setName}
-            bio={bio} setBio={setBio}
-            soul={soul} setSoul={setSoul}
-            role={role} setRole={setRole}
-            handoffTo={handoffTo} setHandoffTo={setHandoffTo}
-            runtime={runtime} setRuntime={setRuntime}
-            model={model} setModel={setModel}
-            skills={skills} setSkills={setSkills}
-            creating={creating} error={error}
+            name={name}
+            setName={setName}
+            bio={bio}
+            setBio={setBio}
+            soul={soul}
+            setSoul={setSoul}
+            role={role}
+            setRole={setRole}
+            handoffTo={handoffTo}
+            setHandoffTo={setHandoffTo}
+            runtime={runtime}
+            setRuntime={setRuntime}
+            model={model}
+            setModel={setModel}
+            skills={skills}
+            setSkills={setSkills}
+            creating={creating}
+            error={error}
             onBack={() => setStep(selectedTemplate ? "recruit" : "choose")}
             onCreate={handleCreate}
           />
@@ -116,26 +142,50 @@ function ChooseStep({ onRecruit, onCustom }: { onRecruit: () => void; onCustom: 
   return (
     <div>
       <button
+        type="button"
         onClick={() => window.history.back()}
         className="flex items-center gap-1.5 text-sm text-content-tertiary hover:text-content-secondary transition-colors mb-6"
       >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
           <path d="M19 12H5M12 19l-7-7 7-7" />
         </svg>
         Back to agents
       </button>
-      <h1 className="text-2xl font-bold text-content-primary mb-2" style={{ letterSpacing: "-0.02em" }}>
+      <h1
+        className="text-2xl font-bold text-content-primary mb-2"
+        style={{ letterSpacing: "-0.02em" }}
+      >
         New agent
       </h1>
       <p className="text-sm text-content-tertiary mb-8">Choose how to create your agent</p>
 
       <div className="grid grid-cols-2 gap-4 max-w-xl">
         <button
+          type="button"
           onClick={onRecruit}
           className="group flex flex-col items-start gap-4 p-6 rounded-lg border border-border hover:border-accent/40 bg-surface-secondary transition-all text-left"
         >
           <div className="w-10 h-10 rounded-full bg-accent/10 flex items-center justify-center">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-accent">
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-accent"
+            >
               <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
               <circle cx="9" cy="7" r="4" />
               <line x1="19" y1="8" x2="19" y2="14" />
@@ -143,21 +193,36 @@ function ChooseStep({ onRecruit, onCustom }: { onRecruit: () => void; onCustom: 
             </svg>
           </div>
           <div>
-            <p className="text-sm font-semibold text-content-primary group-hover:text-accent transition-colors">Recruit</p>
+            <p className="text-sm font-semibold text-content-primary group-hover:text-accent transition-colors">
+              Recruit
+            </p>
             <p className="text-xs text-content-tertiary mt-1">Choose from battle-tested roles</p>
           </div>
         </button>
         <button
+          type="button"
           onClick={onCustom}
           className="group flex flex-col items-start gap-4 p-6 rounded-lg border border-border hover:border-accent/40 bg-surface-secondary transition-all text-left"
         >
           <div className="w-10 h-10 rounded-full bg-surface-tertiary flex items-center justify-center">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-content-tertiary">
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-content-tertiary"
+            >
               <path d="M12 5v14M5 12h14" />
             </svg>
           </div>
           <div>
-            <p className="text-sm font-semibold text-content-primary group-hover:text-accent transition-colors">Custom</p>
+            <p className="text-sm font-semibold text-content-primary group-hover:text-accent transition-colors">
+              Custom
+            </p>
             <p className="text-xs text-content-tertiary mt-1">Build your own from scratch</p>
           </div>
         </button>
@@ -168,15 +233,21 @@ function ChooseStep({ onRecruit, onCustom }: { onRecruit: () => void; onCustom: 
 
 /* ── Step 2: Recruit — pick a template ── */
 
-function RecruitStep({ onSelect, onBack }: {
-  onSelect: (t: AgentTemplate) => void; onBack: () => void;
+function RecruitStep({
+  onSelect,
+  onBack,
+}: {
+  onSelect: (t: AgentTemplate) => void;
+  onBack: () => void;
 }) {
   const [index, setIndex] = useState<TemplateIndex[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingSlug, setLoadingSlug] = useState<string | null>(null);
 
   useEffect(() => {
-    fetchTemplateIndex().then(setIndex).finally(() => setLoading(false));
+    fetchTemplateIndex()
+      .then(setIndex)
+      .finally(() => setLoading(false));
   }, []);
 
   async function handleSelect(slug: string) {
@@ -193,15 +264,28 @@ function RecruitStep({ onSelect, onBack }: {
   return (
     <div>
       <button
+        type="button"
         onClick={onBack}
         className="flex items-center gap-1.5 text-sm text-content-tertiary hover:text-content-secondary transition-colors mb-6"
       >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
           <path d="M19 12H5M12 19l-7-7 7-7" />
         </svg>
         Back
       </button>
-      <h1 className="text-2xl font-bold text-content-primary mb-2" style={{ letterSpacing: "-0.02em" }}>
+      <h1
+        className="text-2xl font-bold text-content-primary mb-2"
+        style={{ letterSpacing: "-0.02em" }}
+      >
         Recruit an agent
       </h1>
       <p className="text-sm text-content-tertiary mb-8">Select a role template to get started</p>
@@ -216,6 +300,7 @@ function RecruitStep({ onSelect, onBack }: {
         <div className="grid grid-cols-3 gap-3">
           {index.map((entry) => (
             <button
+              type="button"
               key={entry.slug}
               onClick={() => handleSelect(entry.slug)}
               disabled={loadingSlug === entry.slug}
@@ -244,24 +329,52 @@ function RecruitStep({ onSelect, onBack }: {
 interface FormStepProps {
   template: AgentTemplate | null;
   existingRoles: string[];
-  name: string; setName: (v: string) => void;
-  bio: string; setBio: (v: string) => void;
-  soul: string; setSoul: (v: string) => void;
-  role: string; setRole: (v: string) => void;
-  handoffTo: string[]; setHandoffTo: (v: string[]) => void;
-  runtime: string; setRuntime: (v: string) => void;
-  model: string; setModel: (v: string) => void;
-  skills: string[]; setSkills: (v: string[]) => void;
-  creating: boolean; error: string | null;
+  name: string;
+  setName: (v: string) => void;
+  bio: string;
+  setBio: (v: string) => void;
+  soul: string;
+  setSoul: (v: string) => void;
+  role: string;
+  setRole: (v: string) => void;
+  handoffTo: string[];
+  setHandoffTo: (v: string[]) => void;
+  runtime: string;
+  setRuntime: (v: string) => void;
+  model: string;
+  setModel: (v: string) => void;
+  skills: string[];
+  setSkills: (v: string[]) => void;
+  creating: boolean;
+  error: string | null;
   onBack: () => void;
   onCreate: () => void;
 }
 
 function FormStep(props: FormStepProps) {
   const {
-    template, existingRoles, name, setName, bio, setBio, soul, setSoul, role, setRole,
-    handoffTo, setHandoffTo, runtime, setRuntime, model, setModel,
-    skills, setSkills, creating, error, onBack, onCreate,
+    template,
+    existingRoles,
+    name,
+    setName,
+    bio,
+    setBio,
+    soul,
+    setSoul,
+    role,
+    setRole,
+    handoffTo,
+    setHandoffTo,
+    runtime,
+    setRuntime,
+    model,
+    setModel,
+    skills,
+    setSkills,
+    creating,
+    error,
+    onBack,
+    onCreate,
   } = props;
 
   const previewKey = name.trim() || "preview";
@@ -270,15 +383,28 @@ function FormStep(props: FormStepProps) {
   return (
     <div>
       <button
+        type="button"
         onClick={onBack}
         className="flex items-center gap-1.5 text-sm text-content-tertiary hover:text-content-secondary transition-colors mb-6"
       >
-        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
           <path d="M19 12H5M12 19l-7-7 7-7" />
         </svg>
         Back
       </button>
-      <h1 className="text-2xl font-bold text-content-primary mb-8" style={{ letterSpacing: "-0.02em" }}>
+      <h1
+        className="text-2xl font-bold text-content-primary mb-8"
+        style={{ letterSpacing: "-0.02em" }}
+      >
         {template ? `Recruit ${template.name}` : "Create agent"}
       </h1>
 
@@ -287,34 +413,67 @@ function FormStep(props: FormStepProps) {
         <div className="space-y-6">
           {/* Identity */}
           <fieldset className="space-y-4">
-            <legend className="text-[11px] font-mono font-medium text-content-tertiary uppercase tracking-[0.08em] mb-3">Identity</legend>
+            <legend className="text-[11px] font-mono font-medium text-content-tertiary uppercase tracking-[0.08em] mb-3">
+              Identity
+            </legend>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
                 <Label htmlFor="agent-name">Name</Label>
-                <Input id="agent-name" value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Bolt" className="font-mono" />
+                <Input
+                  id="agent-name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="e.g. Bolt"
+                  className="font-mono"
+                />
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="agent-role">Role</Label>
-                <Input id="agent-role" value={role} onChange={(e) => setRole(e.target.value)} placeholder="e.g. backend-developer" className="font-mono" />
+                <Input
+                  id="agent-role"
+                  value={role}
+                  onChange={(e) => setRole(e.target.value)}
+                  placeholder="e.g. backend-developer"
+                  className="font-mono"
+                />
               </div>
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="agent-bio">Bio</Label>
-              <Input id="agent-bio" value={bio} onChange={(e) => setBio(e.target.value)} placeholder="Short description" />
+              <Input
+                id="agent-bio"
+                value={bio}
+                onChange={(e) => setBio(e.target.value)}
+                placeholder="Short description"
+              />
             </div>
             <div className="space-y-1.5">
               <Label htmlFor="agent-soul">Soul</Label>
-              <Textarea id="agent-soul" value={soul} onChange={(e) => setSoul(e.target.value)} placeholder="Personality prompt..." rows={4} className="resize-none" />
+              <Textarea
+                id="agent-soul"
+                value={soul}
+                onChange={(e) => setSoul(e.target.value)}
+                placeholder="Personality prompt..."
+                rows={4}
+                className="resize-none"
+              />
             </div>
           </fieldset>
 
           {/* Runtime */}
           <fieldset className="space-y-4">
-            <legend className="text-[11px] font-mono font-medium text-content-tertiary uppercase tracking-[0.08em] mb-3">Runtime</legend>
+            <legend className="text-[11px] font-mono font-medium text-content-tertiary uppercase tracking-[0.08em] mb-3">
+              Runtime
+            </legend>
             <div className="grid grid-cols-2 gap-3">
               <div className="space-y-1.5">
                 <Label htmlFor="agent-runtime">Runtime</Label>
-                <Select value={runtime} onValueChange={(v) => { if (v) setRuntime(v); }}>
+                <Select
+                  value={runtime}
+                  onValueChange={(v) => {
+                    if (v) setRuntime(v);
+                  }}
+                >
                   <SelectTrigger>
                     <SelectValue />
                   </SelectTrigger>
@@ -327,28 +486,45 @@ function FormStep(props: FormStepProps) {
               </div>
               <div className="space-y-1.5">
                 <Label htmlFor="agent-model">Model</Label>
-                <Input id="agent-model" value={model} onChange={(e) => setModel(e.target.value)} placeholder="e.g. claude-sonnet-4-6" />
+                <Input
+                  id="agent-model"
+                  value={model}
+                  onChange={(e) => setModel(e.target.value)}
+                  placeholder="e.g. claude-sonnet-4-6"
+                />
               </div>
             </div>
           </fieldset>
 
           {/* Workflow */}
           <fieldset className="space-y-4">
-            <legend className="text-[11px] font-mono font-medium text-content-tertiary uppercase tracking-[0.08em] mb-3">Workflow</legend>
+            <legend className="text-[11px] font-mono font-medium text-content-tertiary uppercase tracking-[0.08em] mb-3">
+              Workflow
+            </legend>
             <div className="space-y-1.5">
               <Label>Handoff to</Label>
-              <RoleMultiSelect selected={handoffTo} onChange={setHandoffTo} options={existingRoles} />
+              <RoleMultiSelect
+                selected={handoffTo}
+                onChange={setHandoffTo}
+                options={existingRoles}
+              />
             </div>
             <div className="space-y-1.5">
               <Label>Skills</Label>
-              <TagInput tags={skills} onChange={setSkills} placeholder="Type a skill and press Enter" />
+              <TagInput
+                tags={skills}
+                onChange={setSkills}
+                placeholder="Type a skill and press Enter"
+              />
             </div>
           </fieldset>
 
           {error && <p className="text-xs text-destructive">{error}</p>}
 
           <div className="flex items-center gap-3 pt-2">
-            <Button variant="ghost" onClick={onBack}>Cancel</Button>
+            <Button variant="ghost" onClick={onBack}>
+              Cancel
+            </Button>
             <Button onClick={onCreate} disabled={!name.trim() || creating}>
               {creating ? "Creating..." : template ? "Recruit" : "Create agent"}
             </Button>
@@ -357,7 +533,9 @@ function FormStep(props: FormStepProps) {
 
         {/* Right: live preview card */}
         <div className="sticky top-24">
-          <p className="text-[11px] font-mono font-medium text-content-tertiary uppercase tracking-[0.08em] mb-3">Preview</p>
+          <p className="text-[11px] font-mono font-medium text-content-tertiary uppercase tracking-[0.08em] mb-3">
+            Preview
+          </p>
           <div className="rounded-lg overflow-hidden border border-border bg-surface-secondary">
             <div className="h-[3px]" style={{ background: previewColor }} />
             <div className="flex flex-col items-center pt-6 pb-4 px-5">
@@ -374,7 +552,16 @@ function FormStep(props: FormStepProps) {
                 className="mt-2 inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5"
                 style={{ background: "var(--bg-secondary)" }}
               >
-                <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke={previewColor} strokeWidth="2" strokeLinecap="round" className="opacity-50">
+                <svg
+                  width="9"
+                  height="9"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke={previewColor}
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  className="opacity-50"
+                >
                   <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
                   <path d="M7 11V7a5 5 0 0 1 10 0v4" />
                 </svg>
@@ -402,8 +589,14 @@ function FormStep(props: FormStepProps) {
 
 /* ── Shared components ── */
 
-function RoleMultiSelect({ selected, onChange, options }: {
-  selected: string[]; onChange: (v: string[]) => void; options: string[];
+function RoleMultiSelect({
+  selected,
+  onChange,
+  options,
+}: {
+  selected: string[];
+  onChange: (v: string[]) => void;
+  options: string[];
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -424,17 +617,48 @@ function RoleMultiSelect({ selected, onChange, options }: {
 
   return (
     <div ref={ref} className="relative">
+      {/* biome-ignore lint/a11y/useSemanticElements: container with nested interactive children cannot be a button */}
       <div
+        role="button"
+        tabIndex={0}
         onClick={() => options.length > 0 && setOpen(!open)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            options.length > 0 && setOpen(!open);
+          }
+        }}
         className={`flex h-9 w-full items-center gap-1.5 rounded-md border px-3 text-sm shadow-xs ${
-          options.length === 0 ? "border-input/50 cursor-not-allowed" : "border-input cursor-pointer"
+          options.length === 0
+            ? "border-input/50 cursor-not-allowed"
+            : "border-input cursor-pointer"
         } focus-within:ring-1 focus-within:ring-ring`}
       >
         {selected.map((r) => (
-          <span key={r} className="inline-flex items-center gap-1 bg-accent/10 text-accent font-mono text-xs px-2 py-0.5 rounded">
+          <span
+            key={r}
+            className="inline-flex items-center gap-1 bg-accent/10 text-accent font-mono text-xs px-2 py-0.5 rounded"
+          >
             {r}
-            <button onClick={(e) => { e.stopPropagation(); toggle(r); }} className="hover:opacity-70">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                toggle(r);
+              }}
+              className="hover:opacity-70"
+            >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+              >
+                <path d="M18 6 6 18M6 6l12 12" />
+              </svg>
             </button>
           </span>
         ))}
@@ -447,7 +671,12 @@ function RoleMultiSelect({ selected, onChange, options }: {
       {open && available.length > 0 && (
         <div className="absolute z-10 mt-1 w-full bg-popover border border-border rounded-md shadow-lg py-1 max-h-40 overflow-y-auto">
           {available.map((r) => (
-            <button key={r} onClick={() => toggle(r)} className="w-full text-left px-3 py-1.5 text-sm font-mono hover:bg-surface-tertiary transition-colors">
+            <button
+              type="button"
+              key={r}
+              onClick={() => toggle(r)}
+              className="w-full text-left px-3 py-1.5 text-sm font-mono hover:bg-surface-tertiary transition-colors"
+            >
               {r}
             </button>
           ))}
@@ -457,8 +686,14 @@ function RoleMultiSelect({ selected, onChange, options }: {
   );
 }
 
-function TagInput({ tags, onChange, placeholder }: {
-  tags: string[]; onChange: (v: string[]) => void; placeholder: string;
+function TagInput({
+  tags,
+  onChange,
+  placeholder,
+}: {
+  tags: string[];
+  onChange: (v: string[]) => void;
+  placeholder: string;
 }) {
   const [input, setInput] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -481,15 +716,44 @@ function TagInput({ tags, onChange, placeholder }: {
   }
 
   return (
+    // biome-ignore lint/a11y/useSemanticElements: container with nested interactive children cannot be a button
     <div
+      role="button"
+      tabIndex={0}
       onClick={() => inputRef.current?.focus()}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          inputRef.current?.focus();
+        }
+      }}
       className="flex flex-wrap items-center gap-1.5 rounded-md border border-input px-3 py-1.5 min-h-9 cursor-text shadow-xs focus-within:ring-1 focus-within:ring-ring"
     >
       {tags.map((tag) => (
-        <span key={tag} className="inline-flex items-center gap-1 bg-secondary text-secondary-foreground font-mono text-xs px-2 py-0.5 rounded">
+        <span
+          key={tag}
+          className="inline-flex items-center gap-1 bg-secondary text-secondary-foreground font-mono text-xs px-2 py-0.5 rounded"
+        >
           {tag}
-          <button onClick={(e) => { e.stopPropagation(); onChange(tags.filter((t) => t !== tag)); }} className="hover:opacity-70">
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M18 6 6 18M6 6l12 12" /></svg>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onChange(tags.filter((t) => t !== tag));
+            }}
+            className="hover:opacity-70"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+            >
+              <path d="M18 6 6 18M6 6l12 12" />
+            </svg>
           </button>
         </span>
       ))}

--- a/apps/web/src/routes/AgentsPage.tsx
+++ b/apps/web/src/routes/AgentsPage.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Header } from "../components/Header";
 import { AgentIdenticon } from "../components/AgentIdenticon";
-import { agentFingerprint, agentColor, agentColorRgb } from "../lib/agentIdentity";
-import { api } from "../lib/api";
+import { Header } from "../components/Header";
 import { formatRelative } from "../components/TaskDetailFields";
+import { agentColor, agentColorRgb, agentFingerprint } from "../lib/agentIdentity";
+import { api } from "../lib/api";
 
 function formatTokens(n: number): string {
   if (!n) return "0";
@@ -38,7 +38,10 @@ export function AgentsPage() {
       <div className="max-w-5xl mx-auto px-8 py-10">
         <div className="flex items-center justify-between mb-8">
           <div className="flex items-baseline gap-4">
-            <h1 className="text-2xl font-bold text-content-primary" style={{ letterSpacing: "-0.02em" }}>
+            <h1
+              className="text-2xl font-bold text-content-primary"
+              style={{ letterSpacing: "-0.02em" }}
+            >
               Agents
             </h1>
             {agents.length > 0 && (
@@ -112,7 +115,16 @@ function AgentCard({ agent }: { agent: any }) {
             {agent.name}
           </h2>
           {agent.builtin ? (
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" className="text-content-tertiary shrink-0">
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              className="text-content-tertiary shrink-0"
+            >
               <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
               <path d="M7 11V7a5 5 0 0 1 10 0v4" />
             </svg>
@@ -124,7 +136,16 @@ function AgentCard({ agent }: { agent: any }) {
           className="mt-1.5 inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5"
           style={{ background: "var(--bg-secondary)" }}
         >
-          <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" className="opacity-50">
+          <svg
+            width="9"
+            height="9"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke={color}
+            strokeWidth="2"
+            strokeLinecap="round"
+            className="opacity-50"
+          >
             <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
             <path d="M7 11V7a5 5 0 0 1 10 0v4" />
           </svg>
@@ -140,7 +161,11 @@ function AgentCard({ agent }: { agent: any }) {
             style={{ backgroundColor: isOnline ? color : "#3f3f46" }}
           />
           <span className="text-[11px] text-content-tertiary">
-            {isOnline ? "Online" : agent.last_active_at ? formatRelative(agent.last_active_at) : "Offline"}
+            {isOnline
+              ? "Online"
+              : agent.last_active_at
+                ? formatRelative(agent.last_active_at)
+                : "Offline"}
           </span>
         </div>
       </div>
@@ -154,4 +179,3 @@ function AgentCard({ agent }: { agent: any }) {
     </Link>
   );
 }
-

--- a/apps/web/src/routes/AuthPage.tsx
+++ b/apps/web/src/routes/AuthPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { authClient, signIn, signUp, setAuthToken } from "../lib/auth-client";
 import { useNavigate } from "react-router-dom";
+import { authClient, setAuthToken, signIn, signUp } from "../lib/auth-client";
 
 function GitHubIcon() {
   return (
@@ -90,9 +90,7 @@ export function AuthPage() {
             className="w-full bg-surface-secondary border border-border rounded-lg px-3 py-2 text-sm text-content-primary outline-none focus:border-accent transition-colors"
           />
 
-          {error && (
-            <p className="text-sm text-error">{error}</p>
-          )}
+          {error && <p className="text-sm text-error">{error}</p>}
 
           <button
             type="submit"
@@ -113,7 +111,10 @@ export function AuthPage() {
         </div>
 
         <button
-          onClick={() => authClient.signIn.social({ provider: "github", callbackURL: "/auth/callback" })}
+          type="button"
+          onClick={() =>
+            authClient.signIn.social({ provider: "github", callbackURL: "/auth/callback" })
+          }
           className="w-full flex items-center justify-center gap-2 bg-surface-secondary border border-border text-content-primary font-semibold text-sm py-2 rounded-lg hover:bg-surface-tertiary transition-colors"
         >
           <GitHubIcon />
@@ -123,7 +124,11 @@ export function AuthPage() {
         <p className="text-center text-xs text-content-tertiary">
           {mode === "signin" ? "No account? " : "Already have an account? "}
           <button
-            onClick={() => { setMode(mode === "signin" ? "signup" : "signin"); setError(null); }}
+            type="button"
+            onClick={() => {
+              setMode(mode === "signin" ? "signup" : "signin");
+              setError(null);
+            }}
             className="text-accent hover:underline"
           >
             {mode === "signin" ? "Sign up" : "Sign in"}

--- a/apps/web/src/routes/BoardPage.tsx
+++ b/apps/web/src/routes/BoardPage.tsx
@@ -1,13 +1,13 @@
-import { useState, useMemo } from "react";
-import { useParams, useNavigate } from "react-router-dom";
-import { api } from "../lib/api";
-import { Header } from "../components/Header";
-import { FilterBar } from "../components/FilterBar";
-import { KanbanColumn } from "../components/KanbanColumn";
-import { TaskDetail } from "../components/TaskDetail";
+import { useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 import { AgentProfile } from "../components/AgentProfile";
+import { FilterBar } from "../components/FilterBar";
+import { Header } from "../components/Header";
+import { KanbanColumn } from "../components/KanbanColumn";
 import { Onboarding } from "../components/Onboarding";
+import { TaskDetail } from "../components/TaskDetail";
 import { useBoard } from "../hooks/useBoard";
+import { api } from "../lib/api";
 
 const TASK_STATUSES = ["todo", "in_progress", "in_review", "done", "cancelled"] as const;
 
@@ -62,12 +62,18 @@ export function BoardPage() {
     return (
       <div className="min-h-screen bg-surface-primary">
         <Header />
-        <div className="grid gap-0 p-4" style={{ gridTemplateColumns: `repeat(5, minmax(0, 1fr))` }}>
+        <div
+          className="grid gap-0 p-4"
+          style={{ gridTemplateColumns: `repeat(5, minmax(0, 1fr))` }}
+        >
           {[0, 1, 2, 3, 4].map((i) => (
             <div key={i} className="p-4 space-y-3">
               <div className="h-4 w-20 bg-surface-tertiary rounded animate-pulse" />
               {[0, 1].map((j) => (
-                <div key={j} className="h-20 bg-surface-secondary border border-border rounded-lg animate-pulse" />
+                <div
+                  key={j}
+                  className="h-20 bg-surface-secondary border border-border rounded-lg animate-pulse"
+                />
               ))}
             </div>
           ))}
@@ -81,10 +87,12 @@ export function BoardPage() {
     return (
       <div className="min-h-screen bg-surface-primary">
         <Header />
-        <Onboarding onComplete={async () => {
-          const boards = await api.boards.list();
-          if (boards.length > 0) navigate(`/boards/${boards[0].id}`, { replace: true });
-        }} />
+        <Onboarding
+          onComplete={async () => {
+            const boards = await api.boards.list();
+            if (boards.length > 0) navigate(`/boards/${boards[0].id}`, { replace: true });
+          }}
+        />
       </div>
     );
   }
@@ -92,12 +100,18 @@ export function BoardPage() {
   return (
     <div className="min-h-screen bg-surface-primary">
       <Header />
-      <FilterBar repositories={repositories} activeRepository={activeRepository} onRepositoryChange={setActiveRepository} />
+      <FilterBar
+        repositories={repositories}
+        activeRepository={activeRepository}
+        onRepositoryChange={setActiveRepository}
+      />
 
       {error && (
         <div className="mx-5 mt-3 px-4 py-2 bg-error/10 border-l-2 border-error text-error text-sm rounded">
           {error}
-          <button onClick={refresh} className="ml-2 underline">Retry</button>
+          <button type="button" onClick={refresh} className="ml-2 underline">
+            Retry
+          </button>
         </div>
       )}
 
@@ -105,6 +119,7 @@ export function BoardPage() {
       <div className="flex md:hidden border-b border-border">
         {columns.map((col, i) => (
           <button
+            type="button"
             key={col.status}
             onClick={() => setMobileTab(i)}
             className={`flex-1 py-2.5 text-xs font-semibold uppercase tracking-wide text-center transition-colors ${
@@ -117,7 +132,10 @@ export function BoardPage() {
       </div>
 
       {/* Desktop: 5-column grid */}
-      <div className="hidden md:grid min-h-[calc(100vh-100px)]" style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))` }}>
+      <div
+        className="hidden md:grid min-h-[calc(100vh-100px)]"
+        style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))` }}
+      >
         {columns.map((col) => (
           <KanbanColumn
             key={col.status}
@@ -130,14 +148,16 @@ export function BoardPage() {
 
       {/* Mobile: single column based on tab */}
       <div className="md:hidden min-h-[calc(100vh-160px)]">
-        {columns.filter((_, i) => i === mobileTab).map((col) => (
-          <KanbanColumn
-            key={col.status}
-            column={col}
-            onTaskClick={setSelectedTask}
-            onAgentClick={setSelectedAgent}
-          />
-        ))}
+        {columns
+          .filter((_, i) => i === mobileTab)
+          .map((col) => (
+            <KanbanColumn
+              key={col.status}
+              column={col}
+              onTaskClick={setSelectedTask}
+              onAgentClick={setSelectedAgent}
+            />
+          ))}
       </div>
 
       {selectedTask && (
@@ -145,7 +165,10 @@ export function BoardPage() {
           taskId={selectedTask}
           onClose={() => setSelectedTask(null)}
           onRefresh={refresh}
-          onAgentClick={(agentId) => { setSelectedTask(null); setSelectedAgent(agentId); }}
+          onAgentClick={(agentId) => {
+            setSelectedTask(null);
+            setSelectedAgent(agentId);
+          }}
         />
       )}
 
@@ -153,7 +176,10 @@ export function BoardPage() {
         <AgentProfile
           agentId={selectedAgent}
           onClose={() => setSelectedAgent(null)}
-          onTaskClick={(taskId) => { setSelectedAgent(null); setSelectedTask(taskId); }}
+          onTaskClick={(taskId) => {
+            setSelectedAgent(null);
+            setSelectedTask(taskId);
+          }}
         />
       )}
     </div>

--- a/apps/web/src/routes/BoardRedirect.tsx
+++ b/apps/web/src/routes/BoardRedirect.tsx
@@ -1,5 +1,5 @@
 import { Navigate } from "react-router-dom";
-import { useBoards, getLastBoardId } from "../hooks/useBoard";
+import { getLastBoardId, useBoards } from "../hooks/useBoard";
 
 export function BoardRedirect() {
   const { boards, loading } = useBoards();
@@ -7,9 +7,7 @@ export function BoardRedirect() {
   if (loading) return null;
 
   const lastId = getLastBoardId();
-  const target = lastId && boards.some((b: any) => b.id === lastId)
-    ? lastId
-    : boards[0]?.id;
+  const target = lastId && boards.some((b: any) => b.id === lastId) ? lastId : boards[0]?.id;
 
   if (target) {
     return <Navigate to={`/boards/${target}`} replace />;

--- a/apps/web/src/routes/MachineDetailPage.tsx
+++ b/apps/web/src/routes/MachineDetailPage.tsx
@@ -1,11 +1,18 @@
-import { useState, useEffect } from "react";
-import { useParams, useNavigate, Link } from "react-router-dom";
 import type { UsageWindow } from "@agent-kanban/shared";
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { Header } from "../components/Header";
-import { Dialog, DialogContent, DialogHeader, DialogFooter, DialogTitle, DialogDescription } from "../components/ui/dialog";
-import { Button } from "../components/ui/button";
-import { api } from "../lib/api";
 import { formatRelative } from "../components/TaskDetailFields";
+import { Button } from "../components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "../components/ui/dialog";
+import { api } from "../lib/api";
 
 const USAGE_LABELS: Record<string, string> = {
   five_hour: "5-Hour",
@@ -50,7 +57,10 @@ export function MachineDetailPage() {
 
   useEffect(() => {
     if (!id) return;
-    api.machines.get(id).then(setMachine).finally(() => setLoading(false));
+    api.machines
+      .get(id)
+      .then(setMachine)
+      .finally(() => setLoading(false));
     const interval = setInterval(() => {
       api.machines.get(id).then(setMachine);
     }, 15000);
@@ -97,7 +107,9 @@ export function MachineDetailPage() {
       <div className="max-w-4xl mx-auto p-8 space-y-6">
         {/* Breadcrumb */}
         <div className="flex items-center gap-2 text-xs text-content-tertiary">
-          <Link to="/machines" className="hover:text-content-secondary transition-colors">Machines</Link>
+          <Link to="/machines" className="hover:text-content-secondary transition-colors">
+            Machines
+          </Link>
           <span>/</span>
           <span className="text-content-secondary">{machine.name}</span>
         </div>
@@ -112,6 +124,7 @@ export function MachineDetailPage() {
             </span>
           </div>
           <button
+            type="button"
             onClick={() => setShowDeleteDialog(true)}
             className="text-xs text-error hover:underline"
           >
@@ -127,17 +140,25 @@ export function MachineDetailPage() {
               <span className="font-mono text-xs text-content-primary">{machine.os || "—"}</span>
             </div>
             <div className="flex items-center justify-between">
-              <span className="text-[11px] text-content-tertiary uppercase tracking-wide">Version</span>
-              <span className="font-mono text-xs text-content-primary">{machine.version || "—"}</span>
+              <span className="text-[11px] text-content-tertiary uppercase tracking-wide">
+                Version
+              </span>
+              <span className="font-mono text-xs text-content-primary">
+                {machine.version || "—"}
+              </span>
             </div>
             <div className="flex items-center justify-between">
-              <span className="text-[11px] text-content-tertiary uppercase tracking-wide">Last Heartbeat</span>
+              <span className="text-[11px] text-content-tertiary uppercase tracking-wide">
+                Last Heartbeat
+              </span>
               <span className="font-mono text-xs text-content-primary">
                 {machine.last_heartbeat_at ? formatRelative(machine.last_heartbeat_at) : "—"}
               </span>
             </div>
             <div className="flex items-center justify-between">
-              <span className="text-[11px] text-content-tertiary uppercase tracking-wide">Created</span>
+              <span className="text-[11px] text-content-tertiary uppercase tracking-wide">
+                Created
+              </span>
               <span className="font-mono text-xs text-content-primary">
                 {formatRelative(machine.created_at)}
               </span>
@@ -145,10 +166,15 @@ export function MachineDetailPage() {
           </div>
           {runtimes.length > 0 && (
             <div>
-              <span className="text-[11px] text-content-tertiary uppercase tracking-wide block mb-1.5">Runtimes</span>
+              <span className="text-[11px] text-content-tertiary uppercase tracking-wide block mb-1.5">
+                Runtimes
+              </span>
               <div className="flex gap-1.5">
                 {runtimes.map((r: string) => (
-                  <span key={r} className="text-[11px] font-mono text-accent bg-accent-soft px-2 py-0.5 rounded">
+                  <span
+                    key={r}
+                    className="text-[11px] font-mono text-accent bg-accent-soft px-2 py-0.5 rounded"
+                  >
                     {r}
                   </span>
                 ))}
@@ -160,51 +186,64 @@ export function MachineDetailPage() {
         {/* Stats */}
         <div className="grid grid-cols-2 gap-4">
           <div className="bg-surface-secondary border border-border rounded-lg px-4 py-3">
-            <div className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide mb-1">Sessions</div>
+            <div className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide mb-1">
+              Sessions
+            </div>
             <span className="font-mono text-lg text-content-primary">{machine.session_count}</span>
           </div>
           <div className="bg-surface-secondary border border-border rounded-lg px-4 py-3">
-            <div className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide mb-1">Active</div>
+            <div className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide mb-1">
+              Active
+            </div>
             <span className="font-mono text-lg text-accent">{machine.active_session_count}</span>
           </div>
         </div>
 
         {/* Usage quota */}
-        {machine.usage_info && (() => {
-          const windows = Object.entries(machine.usage_info)
-            .filter(([k]) => k !== "updated_at" && USAGE_LABELS[k])
-            .map(([k, v]) => ({ key: k, label: USAGE_LABELS[k], ...(v as UsageWindow) }));
-          if (windows.length === 0) return null;
-          return (
-            <div className="bg-surface-secondary border border-border rounded-lg px-5 py-4 space-y-3">
-              <div className="flex items-center justify-between">
-                <span className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide">Usage</span>
-                <span className="text-[11px] font-mono text-content-tertiary">
-                  {machine.usage_info.updated_at ? formatRelative(machine.usage_info.updated_at) : ""}
-                </span>
-              </div>
-              <div className="space-y-2.5">
-                {windows.map(w => (
-                  <div key={w.key}>
-                    <div className="flex items-center justify-between mb-1">
-                      <span className="text-xs text-content-secondary">{w.label}</span>
-                      <div className="flex items-center gap-2">
-                        <span className="font-mono text-xs text-content-primary">{Math.round(w.utilization)}%</span>
-                        <span className="text-[11px] text-content-tertiary">resets {formatResetCountdown(w.resets_at)}</span>
+        {machine.usage_info &&
+          (() => {
+            const windows = Object.entries(machine.usage_info)
+              .filter(([k]) => k !== "updated_at" && USAGE_LABELS[k])
+              .map(([k, v]) => ({ key: k, label: USAGE_LABELS[k], ...(v as UsageWindow) }));
+            if (windows.length === 0) return null;
+            return (
+              <div className="bg-surface-secondary border border-border rounded-lg px-5 py-4 space-y-3">
+                <div className="flex items-center justify-between">
+                  <span className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide">
+                    Usage
+                  </span>
+                  <span className="text-[11px] font-mono text-content-tertiary">
+                    {machine.usage_info.updated_at
+                      ? formatRelative(machine.usage_info.updated_at)
+                      : ""}
+                  </span>
+                </div>
+                <div className="space-y-2.5">
+                  {windows.map((w) => (
+                    <div key={w.key}>
+                      <div className="flex items-center justify-between mb-1">
+                        <span className="text-xs text-content-secondary">{w.label}</span>
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono text-xs text-content-primary">
+                            {Math.round(w.utilization)}%
+                          </span>
+                          <span className="text-[11px] text-content-tertiary">
+                            resets {formatResetCountdown(w.resets_at)}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="h-1.5 bg-surface-tertiary rounded-full overflow-hidden">
+                        <div
+                          className={`h-full rounded-full transition-all ${usageBarColor(w.utilization)}`}
+                          style={{ width: `${Math.min(w.utilization, 100)}%` }}
+                        />
                       </div>
                     </div>
-                    <div className="h-1.5 bg-surface-tertiary rounded-full overflow-hidden">
-                      <div
-                        className={`h-full rounded-full transition-all ${usageBarColor(w.utilization)}`}
-                        style={{ width: `${Math.min(w.utilization, 100)}%` }}
-                      />
-                    </div>
-                  </div>
-                ))}
+                  ))}
+                </div>
               </div>
-            </div>
-          );
-        })()}
+            );
+          })()}
 
         {/* Offline reconnect guide */}
         {isOffline && (
@@ -214,7 +253,7 @@ export function MachineDetailPage() {
               Restart the daemon to reconnect this machine:
             </p>
             <pre className="bg-surface-primary border border-border rounded-lg p-3 text-xs font-mono text-content-secondary overflow-x-auto">
-{`ak start --api-url ${apiUrl}`}
+              {`ak start --api-url ${apiUrl}`}
             </pre>
           </div>
         )}
@@ -233,7 +272,9 @@ export function MachineDetailPage() {
                   key={agent.id}
                   to={`/agents/${agent.id}`}
                   className={`flex items-center justify-between bg-surface-secondary border rounded-lg px-4 py-3 hover:border-accent/30 transition-colors ${
-                    agent.status === "working" ? "border-accent/30 shadow-[0_0_16px_rgba(34,211,238,0.06)]" : "border-border"
+                    agent.status === "working"
+                      ? "border-accent/30 shadow-[0_0_16px_rgba(34,211,238,0.06)]"
+                      : "border-border"
                   }`}
                 >
                   <div className="flex items-center gap-3">
@@ -245,8 +286,12 @@ export function MachineDetailPage() {
                     <div>
                       <span className="font-mono text-sm text-accent">{agent.name}</span>
                       <div className="flex items-center gap-1.5 mt-0.5">
-                        <span className={`w-1.5 h-1.5 rounded-full ${agentStatusDotColors[agent.status] || "bg-content-tertiary"}`} />
-                        <span className="text-[11px] text-content-tertiary capitalize">{agent.status}</span>
+                        <span
+                          className={`w-1.5 h-1.5 rounded-full ${agentStatusDotColors[agent.status] || "bg-content-tertiary"}`}
+                        />
+                        <span className="text-[11px] text-content-tertiary capitalize">
+                          {agent.status}
+                        </span>
                       </div>
                     </div>
                   </div>
@@ -266,11 +311,15 @@ export function MachineDetailPage() {
           <DialogHeader>
             <DialogTitle>Delete Machine</DialogTitle>
             <DialogDescription>
-              This will revoke the API key for <span className="font-mono text-content-primary">{machine.name}</span>. The daemon will stop authenticating and any running agents will lose access.
+              This will revoke the API key for{" "}
+              <span className="font-mono text-content-primary">{machine.name}</span>. The daemon
+              will stop authenticating and any running agents will lose access.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>Cancel</Button>
+            <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>
+              Cancel
+            </Button>
             <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
               {deleting ? "Deleting..." : "Delete"}
             </Button>

--- a/apps/web/src/routes/MachinesPage.tsx
+++ b/apps/web/src/routes/MachinesPage.tsx
@@ -1,11 +1,17 @@
-import { useState, useEffect, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import { Header } from "../components/Header";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "../components/ui/dialog";
 import { AddMachineSteps } from "../components/AddMachineSteps";
+import { Header } from "../components/Header";
+import { formatRelative } from "../components/TaskDetailFields";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../components/ui/dialog";
 import { api } from "../lib/api";
 import { authClient } from "../lib/auth-client";
-import { formatRelative } from "../components/TaskDetailFields";
 
 const statusDotColors: Record<string, string> = {
   online: "bg-success",
@@ -31,7 +37,10 @@ export function MachinesPage() {
   const [connected, setConnected] = useState(false);
 
   useEffect(() => {
-    api.machines.list().then(setMachines).finally(() => setLoading(false));
+    api.machines
+      .list()
+      .then(setMachines)
+      .finally(() => setLoading(false));
     const interval = setInterval(() => {
       api.machines.list().then(setMachines);
     }, 15000);
@@ -79,6 +88,7 @@ export function MachinesPage() {
               {machines.filter((m) => m.status === "online").length} online
             </span>
             <button
+              type="button"
               onClick={() => setShowDialog(true)}
               className="bg-accent text-[#09090B] font-medium text-xs px-3 py-1.5 rounded-md hover:opacity-90 transition-opacity"
             >
@@ -90,14 +100,25 @@ export function MachinesPage() {
         {loading ? (
           <div className="space-y-3">
             {[0, 1, 2].map((i) => (
-              <div key={i} className="h-20 bg-surface-secondary border border-border rounded-lg animate-pulse" />
+              <div
+                key={i}
+                className="h-20 bg-surface-secondary border border-border rounded-lg animate-pulse"
+              />
             ))}
           </div>
         ) : machines.length === 0 ? (
           <div className="text-center py-16 space-y-3">
             <p className="text-content-secondary text-sm">No machines registered.</p>
             <p className="text-content-tertiary text-xs">
-              Click <button onClick={() => setShowDialog(true)} className="text-accent hover:underline">Add Machine</button> to get started.
+              Click{" "}
+              <button
+                type="button"
+                onClick={() => setShowDialog(true)}
+                className="text-accent hover:underline"
+              >
+                Add Machine
+              </button>{" "}
+              to get started.
             </p>
           </div>
         ) : (
@@ -112,7 +133,9 @@ export function MachinesPage() {
                   <div className="flex items-center gap-3">
                     <span className={`w-2 h-2 rounded-full ${statusDotColors[machine.status]}`} />
                     <div>
-                      <span className="font-mono text-sm text-content-primary font-medium">{machine.name}</span>
+                      <span className="font-mono text-sm text-content-primary font-medium">
+                        {machine.name}
+                      </span>
                       {machine.os && (
                         <span className="text-[11px] text-content-tertiary ml-2">{machine.os}</span>
                       )}
@@ -141,7 +164,12 @@ export function MachinesPage() {
                   {machine.runtimes && (
                     <div className="flex gap-1 ml-auto">
                       {machine.runtimes.map((r: string) => (
-                        <span key={r} className="text-[10px] font-mono text-accent bg-accent-soft px-1.5 py-0.5 rounded">{r}</span>
+                        <span
+                          key={r}
+                          className="text-[10px] font-mono text-accent bg-accent-soft px-1.5 py-0.5 rounded"
+                        >
+                          {r}
+                        </span>
                       ))}
                     </div>
                   )}
@@ -153,35 +181,66 @@ export function MachinesPage() {
       </div>
 
       {/* Add Machine Dialog */}
-      <Dialog open={showDialog} onOpenChange={(open) => { if (!open) closeDialog(); }}>
+      <Dialog
+        open={showDialog}
+        onOpenChange={(open) => {
+          if (!open) closeDialog();
+        }}
+      >
         <DialogContent className="sm:max-w-md" showCloseButton={false}>
           <DialogHeader>
             <DialogTitle>Add Machine</DialogTitle>
-            <DialogDescription className="sr-only">Add a new machine to run agents</DialogDescription>
+            <DialogDescription className="sr-only">
+              Add a new machine to run agents
+            </DialogDescription>
           </DialogHeader>
 
           {dialogStep === "choose" && (
             <div className="space-y-2">
               <p className="text-xs text-content-secondary">Where will this machine run?</p>
               <button
+                type="button"
                 onClick={handleChooseLocal}
                 className="w-full flex items-center gap-3 bg-surface-primary border border-border rounded-lg px-4 py-3 hover:border-accent/50 transition-colors text-left"
               >
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-content-secondary shrink-0">
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-content-secondary shrink-0"
+                >
                   <rect x="2" y="3" width="20" height="14" rx="2" ry="2" />
                   <line x1="8" y1="21" x2="16" y2="21" />
                   <line x1="12" y1="17" x2="12" y2="21" />
                 </svg>
                 <div>
                   <div className="text-sm font-medium text-content-primary">Your Computer</div>
-                  <div className="text-[11px] text-content-tertiary">Run the daemon on this machine</div>
+                  <div className="text-[11px] text-content-tertiary">
+                    Run the daemon on this machine
+                  </div>
                 </div>
               </button>
               <button
+                type="button"
                 disabled
                 className="w-full flex items-center gap-3 bg-surface-primary border border-border rounded-lg px-4 py-3 opacity-50 cursor-not-allowed text-left"
               >
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-content-tertiary shrink-0">
+                <svg
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="text-content-tertiary shrink-0"
+                >
                   <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z" />
                 </svg>
                 <div>

--- a/apps/web/src/routes/RepositoriesPage.tsx
+++ b/apps/web/src/routes/RepositoriesPage.tsx
@@ -1,8 +1,14 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState } from "react";
 import { Header } from "../components/Header";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "../components/ui/dialog";
-import { api } from "../lib/api";
 import { formatRelative } from "../components/TaskDetailFields";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "../components/ui/dialog";
+import { api } from "../lib/api";
 
 export function RepositoriesPage() {
   const [repos, setRepos] = useState<any[]>([]);
@@ -13,7 +19,10 @@ export function RepositoriesPage() {
   const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
-    api.repositories.list().then(setRepos).finally(() => setLoading(false));
+    api.repositories
+      .list()
+      .then(setRepos)
+      .finally(() => setLoading(false));
   }, []);
 
   async function handleAdd() {
@@ -39,10 +48,9 @@ export function RepositoriesPage() {
         <div className="flex items-center justify-between">
           <h1 className="text-xl font-bold text-content-primary">Repositories</h1>
           <div className="flex items-center gap-3">
-            <span className="text-xs text-content-tertiary font-mono">
-              {repos.length} total
-            </span>
+            <span className="text-xs text-content-tertiary font-mono">{repos.length} total</span>
             <button
+              type="button"
               onClick={() => setShowDialog(true)}
               className="bg-accent text-[#09090B] font-medium text-xs px-3 py-1.5 rounded-md hover:opacity-90 transition-opacity"
             >
@@ -54,23 +62,32 @@ export function RepositoriesPage() {
         {loading ? (
           <div className="space-y-3">
             {[0, 1, 2].map((i) => (
-              <div key={i} className="h-16 bg-surface-secondary border border-border rounded-lg animate-pulse" />
+              <div
+                key={i}
+                className="h-16 bg-surface-secondary border border-border rounded-lg animate-pulse"
+              />
             ))}
           </div>
         ) : repos.length === 0 ? (
           <div className="text-center py-16 space-y-3">
             <p className="text-content-secondary text-sm">No repositories registered.</p>
             <p className="text-content-tertiary text-xs">
-              Repositories are added when you run <code className="font-mono text-accent">ak link</code> in a project directory.
+              Repositories are added when you run{" "}
+              <code className="font-mono text-accent">ak link</code> in a project directory.
             </p>
             <pre className="inline-block bg-surface-secondary border border-border rounded-lg px-4 py-2 text-xs font-mono text-content-secondary mt-2">
               npx agent-kanban link
             </pre>
             <p className="text-content-tertiary text-xs mt-3">
               Or{" "}
-              <button onClick={() => setShowDialog(true)} className="text-accent hover:underline">
+              <button
+                type="button"
+                onClick={() => setShowDialog(true)}
+                className="text-accent hover:underline"
+              >
                 add manually
-              </button>.
+              </button>
+              .
             </p>
           </div>
         ) : (
@@ -90,6 +107,7 @@ export function RepositoriesPage() {
                     </span>
                   </div>
                   <button
+                    type="button"
                     onClick={() => handleDelete(repo.id)}
                     className="text-xs text-content-tertiary hover:text-error transition-colors shrink-0 ml-3"
                   >
@@ -117,16 +135,29 @@ export function RepositoriesPage() {
         )}
       </div>
 
-      <Dialog open={showDialog} onOpenChange={(open) => { if (!open) setShowDialog(false); }}>
+      <Dialog
+        open={showDialog}
+        onOpenChange={(open) => {
+          if (!open) setShowDialog(false);
+        }}
+      >
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <DialogTitle>Add Repository</DialogTitle>
-            <DialogDescription className="sr-only">Add a new repository to track tasks</DialogDescription>
+            <DialogDescription className="sr-only">
+              Add a new repository to track tasks
+            </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div className="space-y-2">
-              <label className="text-xs text-content-tertiary uppercase tracking-wide font-medium">Name</label>
+              <label
+                htmlFor="repo-name"
+                className="text-xs text-content-tertiary uppercase tracking-wide font-medium"
+              >
+                Name
+              </label>
               <input
+                id="repo-name"
                 value={newName}
                 onChange={(e) => setNewName(e.target.value)}
                 placeholder="my-repo"
@@ -134,8 +165,14 @@ export function RepositoriesPage() {
               />
             </div>
             <div className="space-y-2">
-              <label className="text-xs text-content-tertiary uppercase tracking-wide font-medium">Clone URL</label>
+              <label
+                htmlFor="repo-clone-url"
+                className="text-xs text-content-tertiary uppercase tracking-wide font-medium"
+              >
+                Clone URL
+              </label>
               <input
+                id="repo-clone-url"
                 value={newUrl}
                 onChange={(e) => setNewUrl(e.target.value)}
                 placeholder="https://github.com/user/repo.git"
@@ -143,6 +180,7 @@ export function RepositoriesPage() {
               />
             </div>
             <button
+              type="button"
               onClick={handleAdd}
               disabled={!newName.trim() || !newUrl.trim() || submitting}
               className="w-full bg-accent text-[#09090B] font-medium text-sm py-2.5 rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,8 @@
       "apps/web/functions/**",
       "packages/cli/src/**",
       "packages/shared/src/**",
-      "tests/**"
+      "tests/**",
+      "!**/*.css"
     ]
   },
   "formatter": {
@@ -43,10 +44,29 @@
       }
     }
   },
+  "css": {
+    "parser": {
+      "cssModules": false,
+      "allowWrongLineComments": true
+    },
+    "linter": {
+      "enabled": false
+    },
+    "formatter": {
+      "enabled": false
+    }
+  },
   "javascript": {
     "formatter": {
       "quoteStyle": "double",
       "semicolons": "always"
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.css"],
+      "formatter": { "enabled": false },
+      "linter": { "enabled": false }
+    }
+  ]
 }

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true,
+    "includes": [
+      "apps/web/src/**",
+      "apps/web/functions/**",
+      "packages/cli/src/**",
+      "packages/shared/src/**",
+      "tests/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "correctness": {
+        "noUnusedImports": "warn",
+        "useExhaustiveDependencies": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off",
+        "useImportType": "warn"
+      },
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
+      "a11y": {
+        "useButtonType": "warn",
+        "useAltText": "warn",
+        "noSvgWithoutTitle": "off"
+      }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always"
+    }
+  }
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,10 @@
+pre-commit:
+  parallel: true
+  commands:
+    biome-check:
+      glob: "*.{ts,tsx,js,jsx,json}"
+      run: npx @biomejs/biome check --staged --no-errors-on-unmatched {staged_files}
+      stage_fixed: true
+    typecheck:
+      glob: "*.{ts,tsx}"
+      run: pnpm -r --parallel run lint

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "build": "pnpm --filter @agent-kanban/shared build && pnpm --filter @agent-kanban/web build",
     "test": "vitest",
     "lint": "pnpm -r --parallel run lint",
-    "install:cli": "bash scripts/install-cli.sh"
+    "check": "biome check",
+    "check:fix": "biome check --write",
+    "format": "biome format --write",
+    "install:cli": "bash scripts/install-cli.sh",
+    "prepare": "lefthook install"
   },
   "keywords": [
     "kanban",
@@ -20,6 +24,7 @@
   "license": "FSL-1.1-ALv2",
   "packageManager": "pnpm@10.30.2",
   "devDependencies": {
+    "@biomejs/biome": "^2.4.8",
     "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -28,6 +33,7 @@
     "concurrently": "^9.2.1",
     "jose": "^6.2.2",
     "jsdom": "^29.0.1",
+    "lefthook": "^2.1.4",
     "miniflare": "^4.20260317.1",
     "tsup": "^8.5.1",
     "typescript": "^5.7.0",

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -1,10 +1,13 @@
+import { randomUUID } from "node:crypto";
 import { SignJWT } from "jose";
-import { randomUUID } from "crypto";
-import type { UsageInfo } from "./types.js";
 import { getConfigValue } from "./config.js";
+import type { UsageInfo } from "./types.js";
 
 export class ApiError extends Error {
-  constructor(public status: number, message: string) {
+  constructor(
+    public status: number,
+    message: string,
+  ) {
     super(message);
   }
 }
@@ -30,7 +33,7 @@ export abstract class ApiClient {
       signal: AbortSignal.timeout(10000),
     });
 
-    const data = await res.json() as T & { error?: { code: string; message: string } };
+    const data = (await res.json()) as T & { error?: { code: string; message: string } };
 
     if (!res.ok) {
       let msg = (data as any).error?.message || `HTTP ${res.status}`;
@@ -45,12 +48,16 @@ export abstract class ApiClient {
   }
 
   // Tasks
-  createTask(input: Record<string, unknown>) { return this.request("POST", "/api/tasks", input); }
+  createTask(input: Record<string, unknown>) {
+    return this.request("POST", "/api/tasks", input);
+  }
   listTasks(params?: Record<string, string>) {
-    const qs = params ? "?" + new URLSearchParams(params).toString() : "";
+    const qs = params ? `?${new URLSearchParams(params).toString()}` : "";
     return this.request("GET", `/api/tasks${qs}`);
   }
-  getTask(id: string) { return this.request("GET", `/api/tasks/${id}`); }
+  getTask(id: string) {
+    return this.request("GET", `/api/tasks/${id}`);
+  }
   claimTask(id: string) {
     return this.request("POST", `/api/tasks/${id}/claim`);
   }
@@ -75,7 +82,9 @@ export abstract class ApiClient {
   addLog(taskId: string, detail: string) {
     return this.request("POST", `/api/tasks/${taskId}/logs`, { detail });
   }
-  deleteTask(id: string) { return this.request("DELETE", `/api/tasks/${id}`); }
+  deleteTask(id: string) {
+    return this.request("DELETE", `/api/tasks/${id}`);
+  }
   rejectTask(id: string, body: Record<string, unknown> = {}) {
     return this.request("POST", `/api/tasks/${id}/reject`, body);
   }
@@ -83,21 +92,29 @@ export abstract class ApiClient {
     const qs = since ? `?since=${encodeURIComponent(since)}` : "";
     return this.request("GET", `/api/tasks/${taskId}/logs${qs}`);
   }
-  getAgent(agentId: string) { return this.request("GET", `/api/agents/${agentId}`); }
-  deleteAgent(agentId: string) { return this.request("DELETE", `/api/agents/${agentId}`); }
+  getAgent(agentId: string) {
+    return this.request("GET", `/api/agents/${agentId}`);
+  }
+  deleteAgent(agentId: string) {
+    return this.request("DELETE", `/api/agents/${agentId}`);
+  }
 
   // Machines
   registerMachine(info: { name: string; os: string; version: string; runtimes: string[] }) {
     return this.request<{ id: string; name: string }>("POST", "/api/machines", info);
   }
-  heartbeat(machineId: string, info: { version?: string; runtimes?: string[]; usage_info?: UsageInfo | null }) {
+  heartbeat(
+    machineId: string,
+    info: { version?: string; runtimes?: string[]; usage_info?: UsageInfo | null },
+  ) {
     return this.request("POST", `/api/machines/${machineId}/heartbeat`, info);
   }
 
   // Agent Sessions
   createSession(agentId: string, sessionId: string, sessionPublicKey: string) {
     return this.request<{ delegation_proof: string }>("POST", `/api/agents/${agentId}/sessions`, {
-      session_id: sessionId, session_public_key: sessionPublicKey,
+      session_id: sessionId,
+      session_public_key: sessionPublicKey,
     });
   }
   closeSession(agentId: string, sessionId: string) {
@@ -106,9 +123,22 @@ export abstract class ApiClient {
   reopenSession(agentId: string, sessionId: string) {
     return this.request("POST", `/api/agents/${agentId}/sessions/${sessionId}/reopen`);
   }
-  listAgents() { return this.request("GET", "/api/agents"); }
-  listSessions(agentId: string) { return this.request<any[]>("GET", `/api/agents/${agentId}/sessions`); }
-  createAgent(input: { name: string; bio?: string; soul?: string; role?: string; handoff_to?: string[]; runtime?: string; model?: string; skills?: string[] }) {
+  listAgents() {
+    return this.request("GET", "/api/agents");
+  }
+  listSessions(agentId: string) {
+    return this.request<any[]>("GET", `/api/agents/${agentId}/sessions`);
+  }
+  createAgent(input: {
+    name: string;
+    bio?: string;
+    soul?: string;
+    role?: string;
+    handoff_to?: string[];
+    runtime?: string;
+    model?: string;
+    skills?: string[];
+  }) {
     return this.request("POST", "/api/agents", input);
   }
 
@@ -116,13 +146,21 @@ export abstract class ApiClient {
   createBoard(input: { name: string; description?: string }) {
     return this.request("POST", "/api/boards", input);
   }
-  listBoards() { return this.request<any[]>("GET", "/api/boards"); }
-  getBoardByName(name: string) { return this.request("GET", `/api/boards?name=${encodeURIComponent(name)}`); }
-  getBoard(boardId: string) { return this.request("GET", `/api/boards/${boardId}`); }
+  listBoards() {
+    return this.request<any[]>("GET", "/api/boards");
+  }
+  getBoardByName(name: string) {
+    return this.request("GET", `/api/boards?name=${encodeURIComponent(name)}`);
+  }
+  getBoard(boardId: string) {
+    return this.request("GET", `/api/boards/${boardId}`);
+  }
   updateBoard(boardId: string, body: Record<string, unknown>) {
     return this.request("PATCH", `/api/boards/${boardId}`, body);
   }
-  deleteBoard(boardId: string) { return this.request("DELETE", `/api/boards/${boardId}`); }
+  deleteBoard(boardId: string) {
+    return this.request("DELETE", `/api/boards/${boardId}`);
+  }
 
   // Repositories
   createRepository(input: { name: string; url: string }) {
@@ -134,10 +172,22 @@ export abstract class ApiClient {
     const qs = params.toString();
     return this.request<any[]>("GET", `/api/repositories${qs ? `?${qs}` : ""}`);
   }
-  deleteRepository(repoId: string) { return this.request("DELETE", `/api/repositories/${repoId}`); }
+  deleteRepository(repoId: string) {
+    return this.request("DELETE", `/api/repositories/${repoId}`);
+  }
 
   // Session usage
-  updateSessionUsage(agentId: string, sessionId: string, usage: { input_tokens: number; output_tokens: number; cache_read_tokens: number; cache_creation_tokens: number; cost_micro_usd: number }) {
+  updateSessionUsage(
+    agentId: string,
+    sessionId: string,
+    usage: {
+      input_tokens: number;
+      output_tokens: number;
+      cache_read_tokens: number;
+      cache_creation_tokens: number;
+      cost_micro_usd: number;
+    },
+  ) {
     return this.request("PATCH", `/api/agents/${agentId}/sessions/${sessionId}/usage`, usage);
   }
 
@@ -188,13 +238,22 @@ export class AgentClient extends ApiClient {
     if (!agentId || !sessionId || !keyJson || !apiUrl) return null;
 
     const privateKey = await crypto.subtle.importKey(
-      "jwk", JSON.parse(keyJson), { name: "Ed25519" } as any, false, ["sign"],
+      "jwk",
+      JSON.parse(keyJson),
+      { name: "Ed25519" } as any,
+      false,
+      ["sign"],
     );
     return new AgentClient(apiUrl, agentId, sessionId, privateKey);
   }
 
   protected async authorize(): Promise<string> {
-    const jwt = await new SignJWT({ sub: this.sessionId, aid: this.agentId, jti: randomUUID(), aud: this.baseUrl })
+    const jwt = await new SignJWT({
+      sub: this.sessionId,
+      aid: this.agentId,
+      jti: randomUUID(),
+      aud: this.baseUrl,
+    })
       .setProtectedHeader({ alg: "EdDSA", typ: "agent+jwt" })
       .setIssuedAt()
       .setExpirationTime("60s")
@@ -202,8 +261,12 @@ export class AgentClient extends ApiClient {
     return `Bearer ${jwt}`;
   }
 
-  getAgentId(): string { return this.agentId; }
-  getSessionId(): string { return this.sessionId; }
+  getAgentId(): string {
+    return this.agentId;
+  }
+  getSessionId(): string {
+    return this.sessionId;
+  }
 }
 
 /**
@@ -211,5 +274,5 @@ export class AgentClient extends ApiClient {
  * otherwise MachineClient (API key from config).
  */
 export async function createClient(): Promise<ApiClient> {
-  return await AgentClient.fromEnv() ?? new MachineClient();
+  return (await AgentClient.fromEnv()) ?? new MachineClient();
 }

--- a/packages/cli/src/commands/link.ts
+++ b/packages/cli/src/commands/link.ts
@@ -1,9 +1,9 @@
-import { execSync } from "child_process";
-import { existsSync, rmSync } from "fs";
-import { basename } from "path";
+import { execSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { basename } from "node:path";
 import type { Command } from "commander";
 import { MachineClient } from "../client.js";
-import { setLink, removeLink, findPathForRepository } from "../links.js";
+import { findPathForRepository, removeLink, setLink } from "../links.js";
 import { REPOS_DIR } from "../paths.js";
 
 function getGitRepoRoot(): string {
@@ -72,15 +72,14 @@ export function registerLinkCommand(program: Command) {
     });
 }
 
-
 export function registerUnlinkCommand(program: Command) {
   program
     .command("unlink")
     .description("Remove local directory link for current repo")
     .action(async () => {
-      let repoRoot: string;
+      let _repoRoot: string;
       try {
-        repoRoot = getGitRepoRoot();
+        _repoRoot = getGitRepoRoot();
       } catch {
         console.error("Not a git repository. Run this command from a git repo.");
         process.exit(1);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1,7 +1,7 @@
-import { createInterface } from "readline";
+import { createInterface } from "node:readline";
 import type { Command } from "commander";
+import { deleteConfigValue, getConfigValue, setConfigValue } from "../config.js";
 import { startDaemon } from "../daemon.js";
-import { setConfigValue, getConfigValue, deleteConfigValue } from "../config.js";
 import { clearLinks } from "../links.js";
 
 function confirm(question: string): Promise<boolean> {
@@ -31,7 +31,7 @@ export function registerStartCommand(program: Command) {
         if (oldKey && oldKey !== opts.apiKey && getConfigValue("machine-id")) {
           const machineId = getConfigValue("machine-id");
           const yes = await confirm(
-            `This machine is already registered (${machineId}) with a different API key.\nSwitch to the new key and re-register? [y/N] `
+            `This machine is already registered (${machineId}) with a different API key.\nSwitch to the new key and re-register? [y/N] `,
           );
           if (!yes) {
             console.log("Aborted.");
@@ -44,7 +44,9 @@ export function registerStartCommand(program: Command) {
       }
 
       if (!getConfigValue("api-url") || !getConfigValue("api-key")) {
-        console.error("API URL and key required. Pass --api-url and --api-key, or set via: ak config set api-url <url>");
+        console.error(
+          "API URL and key required. Pass --api-url and --api-key, or set via: ak config set api-url <url>",
+        );
         process.exit(1);
       }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync, mkdirSync } from "fs";
-import { dirname } from "path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { CONFIG_FILE, PID_FILE } from "./paths.js";
 
 interface Config {
@@ -18,7 +18,7 @@ export function readConfig(): Config {
 
 export function writeConfig(config: Config): void {
   mkdirSync(dirname(CONFIG_FILE), { recursive: true });
-  writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2) + "\n");
+  writeFileSync(CONFIG_FILE, `${JSON.stringify(config, null, 2)}\n`);
 }
 
 export function getConfigValue(key: string): string | undefined {

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -1,16 +1,23 @@
-import { existsSync, writeFileSync, unlinkSync, readFileSync, appendFileSync, mkdirSync } from "fs";
-import { join } from "path";
-import { hostname, platform, arch, release } from "os";
-import { execSync } from "child_process";
-import { randomUUID } from "crypto";
-import { MachineClient, AgentClient, ApiError } from "./client.js";
-import { ProcessManager } from "./processManager.js";
-import { PrMonitor } from "./prMonitor.js";
-import { generateSystemPrompt, writePromptFile, type AgentInfo } from "./systemPrompt.js";
-import { getLinks, findPathForRepository, setLink } from "./links.js";
-import { getConfigValue, setConfigValue, PID_FILE } from "./config.js";
-import { getUsage } from "./usage.js";
+import { execSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { arch, hostname, platform, release } from "node:os";
+import { join } from "node:path";
+import { AgentClient, ApiError, MachineClient } from "./client.js";
+import { getConfigValue, PID_FILE, setConfigValue } from "./config.js";
+import { findPathForRepository, getLinks, setLink } from "./links.js";
 import { REPOS_DIR, WORKTREES_DIR } from "./paths.js";
+import { PrMonitor } from "./prMonitor.js";
+import { ProcessManager } from "./processManager.js";
+import { type AgentInfo, generateSystemPrompt, writePromptFile } from "./systemPrompt.js";
+import { getUsage } from "./usage.js";
 
 // Daemon Lifecycle:
 //   STARTING → check PID lock → load config → load links
@@ -63,9 +70,15 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   let resumeTimer: ReturnType<typeof setTimeout> | null = null;
   let resumeTargetMs = 0;
 
-  const pm = new ProcessManager(client, opts.agentCli, () => {
-    schedulePoll(baseInterval);
-  }, pauseForRateLimit, opts.taskTimeout);
+  const pm = new ProcessManager(
+    client,
+    opts.agentCli,
+    () => {
+      schedulePoll(baseInterval);
+    },
+    pauseForRateLimit,
+    opts.taskTimeout,
+  );
 
   const prMonitor = new PrMonitor(client);
   prMonitor.start();
@@ -92,7 +105,9 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
 
-  console.log(`[INFO] Daemon started (PID ${process.pid}, max_concurrent=${opts.maxConcurrent}, agent=${opts.agentCli})`);
+  console.log(
+    `[INFO] Daemon started (PID ${process.pid}, max_concurrent=${opts.maxConcurrent}, agent=${opts.agentCli})`,
+  );
 
   // Register machine (first run) or reuse existing
   const machineInfo = getMachineInfo();
@@ -105,15 +120,24 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     console.log(`[INFO] Machine registered: ${machineId}`);
   }
 
-  await client.heartbeat(machineId, { version: machineInfo.version, runtimes: machineInfo.runtimes });
+  await client.heartbeat(machineId, {
+    version: machineInfo.version,
+    runtimes: machineInfo.runtimes,
+  });
   await cleanupStaleSessions(client, machineId);
-  console.log(`[INFO] Machine online: ${machineInfo.name} (${machineInfo.os}, runtimes: ${machineInfo.runtimes.join(", ") || "none"})`);
+  console.log(
+    `[INFO] Machine online: ${machineInfo.name} (${machineInfo.os}, runtimes: ${machineInfo.runtimes.join(", ") || "none"})`,
+  );
 
   const heartbeatInterval = setInterval(async () => {
     const usageInfo = await getUsage();
-    client.heartbeat(machineId!, { version: machineInfo.version, runtimes: machineInfo.runtimes, usage_info: usageInfo }).catch((err: any) =>
-      console.error(`[WARN] Heartbeat failed: ${err.message}`)
-    );
+    client
+      .heartbeat(machineId!, {
+        version: machineInfo.version,
+        runtimes: machineInfo.runtimes,
+        usage_info: usageInfo,
+      })
+      .catch((err: any) => console.error(`[WARN] Heartbeat failed: ${err.message}`));
   }, 30000);
 
   function pauseForRateLimit(resetAt: string) {
@@ -123,7 +147,9 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     paused = true;
     resumeTargetMs = resetTime;
     const waitMs = Math.max(resetTime - Date.now(), 60_000);
-    console.warn(`[WARN] Usage exhausted — pausing dispatch until ${resetAt} (${Math.round(waitMs / 60_000)}min)`);
+    console.warn(
+      `[WARN] Usage exhausted — pausing dispatch until ${resetAt} (${Math.round(waitMs / 60_000)}min)`,
+    );
     if (resumeTimer) clearTimeout(resumeTimer);
     resumeTimer = setTimeout(resume, waitMs);
   }
@@ -141,7 +167,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     const sessions = pm.getSuspended();
     pm.clearSuspended();
     for (const s of sessions) {
-      const task = await client.getTask(s.taskId) as any;
+      const task = (await client.getTask(s.taskId)) as any;
       if (!task || task.status === "cancelled" || task.status === "done") continue;
 
       try {
@@ -169,7 +195,21 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       console.log(`[INFO] Resuming task ${s.taskId} (session=${s.sessionId.slice(0, 8)})`);
       try {
         const resumeCleanup = () => removeWorktree(s.repoDir, s.cwd, s.branchName);
-        await pm.spawnAgent(s.taskId, s.sessionId, s.cwd, s.repoDir, s.branchName, "", agentClient, agentEnv, s.privateKey, s.privateKeyJwk, undefined, true, resumeCleanup);
+        await pm.spawnAgent(
+          s.taskId,
+          s.sessionId,
+          s.cwd,
+          s.repoDir,
+          s.branchName,
+          "",
+          agentClient,
+          agentEnv,
+          s.privateKey,
+          s.privateKeyJwk,
+          undefined,
+          true,
+          resumeCleanup,
+        );
       } catch {
         console.warn(`[WARN] Failed to resume task ${s.taskId}, releasing`);
         await client.releaseTask(s.taskId).catch(() => {});
@@ -190,7 +230,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       // Check for cancelled tasks and kill their agents
       const activeTaskIds = pm.getActiveTaskIds();
       for (const taskId of activeTaskIds) {
-        const task = await client.getTask(taskId) as any;
+        const task = (await client.getTask(taskId)) as any;
         if (task?.status === "cancelled") {
           await pm.killTask(taskId);
         }
@@ -201,7 +241,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         return;
       }
 
-      const tasks = await client.listTasks({ status: "todo" }) as any[];
+      const tasks = (await client.listTasks({ status: "todo" })) as any[];
 
       // Auto-clone repos that have no local link
       const unlinkedRepoIds = new Set<string>();
@@ -218,7 +258,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       }
 
       const available = tasks.filter((t: any) => {
-        if (t.blocked || !t.assigned_to) return false;  // must be assigned to an agent
+        if (t.blocked || !t.assigned_to) return false; // must be assigned to an agent
         if (pm.hasTask(t.id)) return false;
         if (!t.repository_id) return false;
         if (!findPathForRepository(t.repository_id)) return false;
@@ -255,7 +295,9 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       const sessionId = randomUUID();
 
       const { publicKey, privateKey } = await crypto.subtle.generateKey(
-        { name: "Ed25519" } as any, true, ["sign", "verify"]
+        { name: "Ed25519" } as any,
+        true,
+        ["sign", "verify"],
       );
       const pubKeyJwk = await crypto.subtle.exportKey("jwk", publicKey);
       const privKeyJwk = await crypto.subtle.exportKey("jwk", privateKey);
@@ -271,10 +313,12 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         throw err;
       }
 
-      console.log(`[INFO] Session ${sessionId.slice(0, 8)} for agent ${agentId} on task ${task.id}: ${task.title}`);
+      console.log(
+        `[INFO] Session ${sessionId.slice(0, 8)} for agent ${agentId} on task ${task.id}: ${task.title}`,
+      );
 
       // Fetch agent details early — needed for both skill install and system prompt
-      const agentDetails = await client.getAgent(agentId) as AgentInfo | null;
+      const agentDetails = (await client.getAgent(agentId)) as AgentInfo | null;
       if (!agentDetails) {
         console.error(`[ERROR] Agent ${agentId} not found, releasing task ${task.id}`);
         await client.releaseTask(task.id).catch(() => {});
@@ -299,9 +343,13 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       if (!ensureSkills(worktreeDir, agentSkills)) {
         console.error(`[ERROR] Skill install failed for task ${task.id}, releasing task`);
         removeWorktree(repoDir, worktreeDir, branchName);
-        await client.releaseTask(task.id).catch((err: any) =>
-          console.error(`[ERROR] Failed to release task ${task.id} after skill failure: ${err.message}`)
-        );
+        await client
+          .releaseTask(task.id)
+          .catch((err: any) =>
+            console.error(
+              `[ERROR] Failed to release task ${task.id} after skill failure: ${err.message}`,
+            ),
+          );
         await client.closeSession(agentId, sessionId).catch(() => {});
         schedulePoll(baseInterval);
         return;
@@ -332,15 +380,30 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         task.priority ? `Priority: ${task.priority}` : null,
         `Repository: ${taskRepo?.url ?? task.repository_id}`,
         `Board: ${task.board_id}`,
-      ].filter(Boolean).join("\n");
+      ]
+        .filter(Boolean)
+        .join("\n");
 
       const cleanup = () => removeWorktree(repoDir, worktreeDir, branchName);
-      await pm.spawnAgent(task.id, sessionId, worktreeDir, repoDir, branchName, taskContext, agentClient, agentEnv, privateKey, privKeyJwk, systemPromptFile, false, cleanup);
+      await pm.spawnAgent(
+        task.id,
+        sessionId,
+        worktreeDir,
+        repoDir,
+        branchName,
+        taskContext,
+        agentClient,
+        agentEnv,
+        privateKey,
+        privKeyJwk,
+        systemPromptFile,
+        false,
+        cleanup,
+      );
       prMonitor.track(task.id);
 
       backoffMs = baseInterval;
       schedulePoll(baseInterval);
-
     } catch (err: any) {
       if (err instanceof ApiError && err.status === 429) {
         console.warn(`[WARN] Rate limited, backing off`);
@@ -355,7 +418,6 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
 
   schedulePoll(0);
 }
-
 
 const SKILL_SOURCE = "saltbo/agent-kanban";
 const SKILL_NAME = "agent-kanban";
@@ -402,7 +464,10 @@ function ensureSkills(worktreeDir: string, agentSkills: string[]): boolean {
     const existing = existsSync(gitignorePath) ? readFileSync(gitignorePath, "utf-8") : "";
     const missing = SKILL_GITIGNORE_ENTRIES.filter((e) => !existing.includes(e));
     if (missing.length > 0) {
-      appendFileSync(gitignorePath, "\n# agent skills (managed by daemon)\n" + missing.join("\n") + "\n");
+      appendFileSync(
+        gitignorePath,
+        `\n# agent skills (managed by daemon)\n${missing.join("\n")}\n`,
+      );
     }
 
     return true;
@@ -414,8 +479,14 @@ function ensureSkills(worktreeDir: string, agentSkills: string[]): boolean {
 
 const LEFTHOOK_LABEL = "setup:lefthook";
 const LEFTHOOK_CONFIG_FILES = [
-  "lefthook.yml", "lefthook.yaml", "lefthook.json", "lefthook.toml",
-  ".lefthook.yml", ".lefthook.yaml", ".lefthook.json", ".lefthook.toml",
+  "lefthook.yml",
+  "lefthook.yaml",
+  "lefthook.json",
+  "lefthook.toml",
+  ".lefthook.yml",
+  ".lefthook.yaml",
+  ".lefthook.json",
+  ".lefthook.toml",
 ];
 
 function hasLefthookConfig(repoDir: string): boolean {
@@ -423,27 +494,33 @@ function hasLefthookConfig(repoDir: string): boolean {
 }
 
 /** Returns true if a lefthook setup task was created (caller should skip this poll cycle). */
-async function ensureLefthookTask(client: MachineClient, task: any, repoDir: string, allTasks: any[]): Promise<boolean> {
+async function ensureLefthookTask(
+  client: MachineClient,
+  task: any,
+  repoDir: string,
+  allTasks: any[],
+): Promise<boolean> {
   if (hasLefthookConfig(repoDir)) return false;
   if (task.labels?.includes(LEFTHOOK_LABEL)) return false;
 
   console.log(`[INFO] No lefthook config in ${repoDir}, creating setup task`);
 
-  const agents = await client.listAgents() as any[];
+  const agents = (await client.listAgents()) as any[];
   const qualityAgent = agents.find((a: any) => a.builtin && a.role === "quality-goalkeeper");
   if (!qualityAgent) {
     console.log("[WARN] No builtin quality-goalkeeper agent found, skipping lefthook setup");
     return false;
   }
 
-  const setupTask = await client.createTask({
+  const setupTask = (await client.createTask({
     title: "Setup lefthook quality gates for this repository",
-    description: "This repository has no lefthook configuration. Analyze the project's tech stack, set up appropriate quality checks, and enforce them via lefthook pre-commit hooks.",
+    description:
+      "This repository has no lefthook configuration. Analyze the project's tech stack, set up appropriate quality checks, and enforce them via lefthook pre-commit hooks.",
     board_id: task.board_id,
     repository_id: task.repository_id,
     labels: [LEFTHOOK_LABEL],
     assigned_to: qualityAgent.id,
-  }) as any;
+  })) as any;
 
   console.log(`[INFO] Created lefthook setup task ${setupTask.id}`);
 
@@ -480,7 +557,9 @@ function cloneAndLink(repo: any): void {
 
 function prepareRepo(repoDir: string): boolean {
   try {
-    const status = execSync("git status --porcelain", { cwd: repoDir, stdio: "pipe" }).toString().trim();
+    const status = execSync("git status --porcelain", { cwd: repoDir, stdio: "pipe" })
+      .toString()
+      .trim();
     if (status) {
       console.log(`[INFO] Stashing dirty working tree in ${repoDir}`);
       execSync("git stash --include-untracked", { cwd: repoDir, stdio: "pipe" });
@@ -495,7 +574,10 @@ function prepareRepo(repoDir: string): boolean {
   }
 }
 
-function createWorktree(repoDir: string, sessionId: string): { worktreeDir: string; branchName: string } {
+function createWorktree(
+  repoDir: string,
+  sessionId: string,
+): { worktreeDir: string; branchName: string } {
   const branchName = `ak/${sessionId.slice(0, 8)}`;
   mkdirSync(WORKTREES_DIR, { recursive: true });
   const worktreeDir = join(WORKTREES_DIR, sessionId.slice(0, 8));
@@ -515,7 +597,11 @@ function removeWorktree(repoDir: string, worktreeDir: string, branchName: string
 }
 
 function removePidFile() {
-  try { unlinkSync(PID_FILE); } catch { /* ignore */ }
+  try {
+    unlinkSync(PID_FILE);
+  } catch {
+    /* ignore */
+  }
 }
 
 function detectRuntimes(): string[] {
@@ -529,7 +615,9 @@ function detectRuntimes(): string[] {
     try {
       execSync(`which ${cmd}`, { stdio: "ignore" });
       found.push(label);
-    } catch { /* not installed */ }
+    } catch {
+      /* not installed */
+    }
   }
   return found;
 }
@@ -545,10 +633,10 @@ function isProcessAlive(sessionId: string): boolean {
 
 async function cleanupStaleSessions(client: MachineClient, machineId: string): Promise<void> {
   try {
-    const agents = await client.listAgents() as any[];
+    const agents = (await client.listAgents()) as any[];
     let closed = 0;
     for (const agent of agents) {
-      const sessions = await client.listSessions(agent.id) as any[];
+      const sessions = (await client.listSessions(agent.id)) as any[];
       for (const session of sessions) {
         if (session.status !== "active" || session.machine_id !== machineId) continue;
         if (!isProcessAlive(session.id)) {
@@ -570,6 +658,8 @@ function getMachineInfo() {
   try {
     const pkg = JSON.parse(readFileSync(join(import.meta.dirname, "../package.json"), "utf-8"));
     version = pkg.version;
-  } catch { /* ignore */ }
+  } catch {
+    /* ignore */
+  }
   return { name: hostname(), os, version, runtimes };
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,12 +1,23 @@
-import { readFileSync } from "fs";
-import { join } from "path";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fetchTemplate } from "@agent-kanban/shared";
 import { Command } from "commander";
-import { setConfigValue, getConfigValue } from "./config.js";
-import { type ApiClient, MachineClient, createClient } from "./client.js";
-import { getFormat, output, formatTaskList, formatTask, formatTaskLogs, formatBoard, formatAgent, formatAgentList, formatBoardList, formatRepositoryList } from "./output.js";
+import { type ApiClient, createClient } from "./client.js";
 import { registerLinkCommand, registerUnlinkCommand } from "./commands/link.js";
 import { registerStartCommand } from "./commands/start.js";
-import { fetchTemplate } from "@agent-kanban/shared";
+import { getConfigValue, setConfigValue } from "./config.js";
+import {
+  formatAgent,
+  formatAgentList,
+  formatBoard,
+  formatBoardList,
+  formatRepositoryList,
+  formatTask,
+  formatTaskList,
+  formatTaskLogs,
+  getFormat,
+  output,
+} from "./output.js";
 
 function isUrl(value: string): boolean {
   return value.includes("://") || value.startsWith("git@");
@@ -84,8 +95,12 @@ taskCmd
     if (opts.parent) body.created_from = opts.parent;
     if (opts.dependsOn) body.depends_on = opts.dependsOn.split(",").map((id: string) => id.trim());
     if (opts.input) {
-      try { body.input = JSON.parse(opts.input); }
-      catch { console.error("Invalid JSON for --input"); process.exit(1); }
+      try {
+        body.input = JSON.parse(opts.input);
+      } catch {
+        console.error("Invalid JSON for --input");
+        process.exit(1);
+      }
     }
 
     const task = await client.createTask(body);
@@ -207,8 +222,12 @@ taskCmd
     if (opts.dependsOn) body.depends_on = opts.dependsOn.split(",").map((id: string) => id.trim());
     if (opts.repo) body.repository_id = await resolveRepoId(client, opts.repo);
     if (opts.input) {
-      try { body.input = JSON.parse(opts.input); }
-      catch { console.error("Invalid JSON for --input"); process.exit(1); }
+      try {
+        body.input = JSON.parse(opts.input);
+      } catch {
+        console.error("Invalid JSON for --input");
+        process.exit(1);
+      }
     }
     if (Object.keys(body).length === 0) {
       console.error("Nothing to update. Provide at least one option.");
@@ -450,9 +469,11 @@ boardCmd
 
 async function resolveBoardId(client: ApiClient, nameOrId: string): Promise<string> {
   try {
-    const board = await client.getBoard(nameOrId) as any;
+    const board = (await client.getBoard(nameOrId)) as any;
     if (board?.id) return board.id;
-  } catch { /* not a valid ID, try name lookup */ }
+  } catch {
+    /* not a valid ID, try name lookup */
+  }
   const boards = await client.listBoards();
   const match = boards.find((b: any) => b.name === nameOrId);
   if (!match) {

--- a/packages/cli/src/links.ts
+++ b/packages/cli/src/links.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync, mkdirSync } from "fs";
-import { dirname } from "path";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import { LINKS_FILE } from "./paths.js";
 
 interface Links {
@@ -16,7 +16,7 @@ function readLinks(): Links {
 
 function writeLinks(links: Links): void {
   mkdirSync(dirname(LINKS_FILE), { recursive: true });
-  writeFileSync(LINKS_FILE, JSON.stringify(links, null, 2) + "\n");
+  writeFileSync(LINKS_FILE, `${JSON.stringify(links, null, 2)}\n`);
 }
 
 export function setLink(repositoryId: string, localPath: string): void {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -6,7 +6,11 @@ export function getFormat(explicit?: string): "json" | "text" {
   return isTTY ? "text" : "json";
 }
 
-export function output(data: unknown, format: "json" | "text", textFormatter?: (data: any) => string): void {
+export function output(
+  data: unknown,
+  format: "json" | "text",
+  textFormatter?: (data: any) => string,
+): void {
   if (format === "json") {
     console.log(JSON.stringify(data, null, 2));
   } else if (textFormatter) {
@@ -82,11 +86,13 @@ export function formatTask(task: any): string {
 
 export function formatTaskLogs(logs: any[]): string {
   if (logs.length === 0) return "No logs.";
-  return logs.map((l) => {
-    const time = new Date(l.created_at).toLocaleString();
-    const actor = l.actor_id ? ` [${l.actor_id}]` : "";
-    return `  ${time}  ${l.action.padEnd(18)}${actor}  ${l.detail || ""}`;
-  }).join("\n");
+  return logs
+    .map((l) => {
+      const time = new Date(l.created_at).toLocaleString();
+      const actor = l.actor_id ? ` [${l.actor_id}]` : "";
+      return `  ${time}  ${l.action.padEnd(18)}${actor}  ${l.detail || ""}`;
+    })
+    .join("\n");
 }
 
 export function formatAgent(agent: any): string {
@@ -108,35 +114,27 @@ export function formatBoard(board: any): string {
   const cols = board.columns || [];
   const maxWidth = 30;
 
-  const header = cols.map((c: any) =>
-    `│ ${(c.name + ` (${c.tasks.length})`).padEnd(maxWidth)} `
-  ).join("") + "│";
+  const header = `${cols.map((c: any) => `│ ${(`${c.name} (${c.tasks.length})`).padEnd(maxWidth)} `).join("")}│`;
 
-  const sep = cols.map(() => "├" + "─".repeat(maxWidth + 2)).join("") + "┤";
-  const topSep = cols.map(() => "┌" + "─".repeat(maxWidth + 2)).join("") + "┐";
-  const botSep = cols.map(() => "└" + "─".repeat(maxWidth + 2)).join("") + "┘";
+  const sep = `${cols.map(() => `├${"─".repeat(maxWidth + 2)}`).join("")}┤`;
+  const topSep = `${cols.map(() => `┌${"─".repeat(maxWidth + 2)}`).join("")}┐`;
+  const botSep = `${cols.map(() => `└${"─".repeat(maxWidth + 2)}`).join("")}┘`;
 
   const maxRows = Math.max(...cols.map((c: any) => c.tasks.length), 0);
   const rows: string[] = [];
 
   for (let i = 0; i < maxRows; i++) {
-    const row = cols.map((c: any) => {
-      const task = c.tasks[i];
-      if (!task) return `│ ${"".padEnd(maxWidth)} `;
-      const title = task.title.length > maxWidth - 2
-        ? task.title.slice(0, maxWidth - 5) + "..."
-        : task.title;
-      return `│ ${title.padEnd(maxWidth)} `;
-    }).join("") + "│";
+    const row = `${cols
+      .map((c: any) => {
+        const task = c.tasks[i];
+        if (!task) return `│ ${"".padEnd(maxWidth)} `;
+        const title =
+          task.title.length > maxWidth - 2 ? `${task.title.slice(0, maxWidth - 5)}...` : task.title;
+        return `│ ${title.padEnd(maxWidth)} `;
+      })
+      .join("")}│`;
     rows.push(row);
   }
 
-  return [
-    `Board: ${board.name}`,
-    topSep,
-    header,
-    sep,
-    ...rows,
-    botSep,
-  ].join("\n");
+  return [`Board: ${board.name}`, topSep, header, sep, ...rows, botSep].join("\n");
 }

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -1,5 +1,5 @@
-import { join } from "path";
-import { homedir } from "os";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 const home = homedir();
 

--- a/packages/cli/src/prMonitor.ts
+++ b/packages/cli/src/prMonitor.ts
@@ -1,6 +1,6 @@
-import { execSync } from "child_process";
-import { readFileSync, writeFileSync, mkdirSync } from "fs";
-import { dirname } from "path";
+import { execSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import type { ApiClient } from "./client.js";
 import { TRACKED_TASKS_FILE } from "./paths.js";
 
@@ -84,7 +84,9 @@ function getPrState(prUrl: string): "OPEN" | "MERGED" | "CLOSED" | null {
     const raw = execSync(`gh pr view "${prUrl}" --json state -q .state`, {
       stdio: ["pipe", "pipe", "pipe"],
       timeout: 10_000,
-    }).toString().trim();
+    })
+      .toString()
+      .trim();
     if (raw === "OPEN" || raw === "MERGED" || raw === "CLOSED") return raw;
     return null;
   } catch {
@@ -103,5 +105,5 @@ function loadTrackedTasks(): Set<string> {
 
 function saveTrackedTasks(tasks: Set<string>): void {
   mkdirSync(dirname(TRACKED_TASKS_FILE), { recursive: true });
-  writeFileSync(TRACKED_TASKS_FILE, JSON.stringify([...tasks]) + "\n");
+  writeFileSync(TRACKED_TASKS_FILE, `${JSON.stringify([...tasks])}\n`);
 }

--- a/packages/cli/src/processManager.ts
+++ b/packages/cli/src/processManager.ts
@@ -1,5 +1,5 @@
-import { spawn, type ChildProcess } from "child_process";
-import type { ApiClient, AgentClient } from "./client.js";
+import { type ChildProcess, spawn } from "node:child_process";
+import type { AgentClient, ApiClient } from "./client.js";
 import { cleanupPromptFile } from "./systemPrompt.js";
 
 // Agent Process Lifecycle:
@@ -47,7 +47,13 @@ export class ProcessManager {
   private onRateLimited: (resetAt: string) => void;
   private taskTimeoutMs: number;
 
-  constructor(client: ApiClient, agentCli: string, onSlotFreed: () => void, onRateLimited: (resetAt: string) => void, taskTimeoutMs = 2 * 60 * 60 * 1000) {
+  constructor(
+    client: ApiClient,
+    agentCli: string,
+    onSlotFreed: () => void,
+    onRateLimited: (resetAt: string) => void,
+    taskTimeoutMs = 2 * 60 * 60 * 1000,
+  ) {
     this.client = client;
     this.agentCli = agentCli;
     this.onSlotFreed = onSlotFreed;
@@ -79,8 +85,26 @@ export class ProcessManager {
     onCleanup?: () => void,
   ): Promise<void> {
     const args = resume
-      ? ["--resume", "--verbose", "--output-format", "stream-json", "--dangerously-skip-permissions", "--session-id", sessionId]
-      : ["--print", "--verbose", "--input-format", "stream-json", "--output-format", "stream-json", "--dangerously-skip-permissions", "--session-id", sessionId];
+      ? [
+          "--resume",
+          "--verbose",
+          "--output-format",
+          "stream-json",
+          "--dangerously-skip-permissions",
+          "--session-id",
+          sessionId,
+        ]
+      : [
+          "--print",
+          "--verbose",
+          "--input-format",
+          "stream-json",
+          "--output-format",
+          "stream-json",
+          "--dangerously-skip-permissions",
+          "--session-id",
+          sessionId,
+        ];
     if (!resume && systemPromptFile) {
       args.push("--system-prompt-file", systemPromptFile);
     }
@@ -104,12 +128,25 @@ export class ProcessManager {
       return;
     }
 
-    const agent: AgentProcess = { taskId, sessionId, cwd, repoDir, branchName, process: proc, agentClient, privateKey, privateKeyJwk, onCleanup };
+    const agent: AgentProcess = {
+      taskId,
+      sessionId,
+      cwd,
+      repoDir,
+      branchName,
+      process: proc,
+      agentClient,
+      privateKey,
+      privateKeyJwk,
+      onCleanup,
+    };
     this.agents.set(taskId, agent);
 
     if (this.taskTimeoutMs > 0) {
       agent.timeoutTimer = setTimeout(() => {
-        console.warn(`[WARN] Agent for task ${taskId} exceeded timeout (${Math.round(this.taskTimeoutMs / 60000)}m), killing`);
+        console.warn(
+          `[WARN] Agent for task ${taskId} exceeded timeout (${Math.round(this.taskTimeoutMs / 60000)}m), killing`,
+        );
         proc.kill("SIGTERM");
       }, this.taskTimeoutMs);
     }
@@ -122,7 +159,7 @@ export class ProcessManager {
           type: "user",
           message: { role: "user", content: taskContext },
         });
-        proc.stdin?.write(payload + "\n");
+        proc.stdin?.write(`${payload}\n`);
         proc.stdin?.end();
       });
     }
@@ -137,7 +174,9 @@ export class ProcessManager {
         try {
           const event = JSON.parse(line);
           this.handleEvent(taskId, sessionId, event, agentClient);
-        } catch { /* non-JSON line, skip */ }
+        } catch {
+          /* non-JSON line, skip */
+        }
       }
     });
 
@@ -158,7 +197,9 @@ export class ProcessManager {
         try {
           const event = JSON.parse(stdoutBuffer);
           this.handleEvent(taskId, sessionId, event, agentClient);
-        } catch { /* skip */ }
+        } catch {
+          /* skip */
+        }
       }
 
       this.agents.delete(taskId);
@@ -170,7 +211,16 @@ export class ProcessManager {
         agent.onCleanup?.();
       } else if (agent.rateLimited) {
         console.warn(`[WARN] Agent for task ${taskId} exited due to rate limit, suspending`);
-        this.suspended.push({ taskId, sessionId, cwd: agent.cwd, repoDir: agent.repoDir, branchName: agent.branchName, agentId: agentClient.getAgentId(), privateKey: agent.privateKey, privateKeyJwk: agent.privateKeyJwk });
+        this.suspended.push({
+          taskId,
+          sessionId,
+          cwd: agent.cwd,
+          repoDir: agent.repoDir,
+          branchName: agent.branchName,
+          agentId: agentClient.getAgentId(),
+          privateKey: agent.privateKey,
+          privateKeyJwk: agent.privateKeyJwk,
+        });
       } else {
         console.warn(`[WARN] Agent crashed on task ${taskId} (exit ${code})`);
         if (stderrBuffer.trim()) {
@@ -195,7 +245,9 @@ export class ProcessManager {
       this.onSlotFreed();
     });
 
-    console.log(`[INFO] Spawned ${this.agentCli} (session=${sessionId}) for task ${taskId} in ${cwd}`);
+    console.log(
+      `[INFO] Spawned ${this.agentCli} (session=${sessionId}) for task ${taskId} in ${cwd}`,
+    );
   }
 
   async killTask(taskId: string): Promise<void> {
@@ -206,9 +258,13 @@ export class ProcessManager {
     agent.process.kill("SIGTERM");
     this.agents.delete(taskId);
     agent.onCleanup?.();
-    await this.client.closeSession(agent.agentClient.getAgentId(), agent.sessionId).catch((err: any) =>
-      console.error(`[WARN] Failed to close session for cancelled task ${taskId}: ${err.message}`)
-    );
+    await this.client
+      .closeSession(agent.agentClient.getAgentId(), agent.sessionId)
+      .catch((err: any) =>
+        console.error(
+          `[WARN] Failed to close session for cancelled task ${taskId}: ${err.message}`,
+        ),
+      );
     this.onSlotFreed();
   }
 
@@ -256,22 +312,30 @@ export class ProcessManager {
       if (textBlock?.text) detail = textBlock.text;
     }
     if (!detail) {
-      detail = event.error?.message
-        || (event.error !== "unknown" ? event.error : undefined)
-        || event.message
-        || JSON.stringify(event);
+      detail =
+        event.error?.message ||
+        (event.error !== "unknown" ? event.error : undefined) ||
+        event.message ||
+        JSON.stringify(event);
     }
 
     return { code, detail: String(detail) };
   }
 
-  private handleEvent(taskId: string, sessionId: string, event: any, agentClient: AgentClient): void {
+  private handleEvent(
+    taskId: string,
+    _sessionId: string,
+    event: any,
+    agentClient: AgentClient,
+  ): void {
     // rate_limit_event — structured rate limit info from Claude CLI
     if (event.type === "rate_limit_event") {
       const info = event.rate_limit_info;
       if (info && info.status !== "allowed") {
         const resetAt = new Date(info.resetsAt * 1000).toISOString();
-        console.warn(`[WARN] Claude rate limited (${info.rateLimitType}, status=${info.status}) on task ${taskId}, resets at ${resetAt}`);
+        console.warn(
+          `[WARN] Claude rate limited (${info.rateLimitType}, status=${info.status}) on task ${taskId}, resets at ${resetAt}`,
+        );
         const agent = this.agents.get(taskId);
         if (agent) agent.rateLimited = true;
         this.onRateLimited(resetAt);
@@ -297,8 +361,15 @@ export class ProcessManager {
     if (event.type === "assistant" && Array.isArray(event.message?.content)) {
       for (const block of event.message.content) {
         if (block.type === "text" && block.text) {
-          agentClient.sendMessage(taskId, { sender_type: "agent", sender_id: agentClient.getAgentId(), content: block.text })
-            .catch((e: any) => console.error(`[ERROR] Failed to send message for task ${taskId}: ${e.message}`));
+          agentClient
+            .sendMessage(taskId, {
+              sender_type: "agent",
+              sender_id: agentClient.getAgentId(),
+              content: block.text,
+            })
+            .catch((e: any) =>
+              console.error(`[ERROR] Failed to send message for task ${taskId}: ${e.message}`),
+            );
         }
       }
     }
@@ -306,20 +377,28 @@ export class ProcessManager {
       const cost = event.total_cost_usd || 0;
       const usage = event.usage || {};
       console.log(`[INFO] Agent result for task ${taskId}: cost=$${cost.toFixed(4)}`);
-      agentClient.updateSessionUsage(agentClient.getAgentId(), agentClient.getSessionId(), {
-        input_tokens: usage.input_tokens || 0,
-        output_tokens: usage.output_tokens || 0,
-        cache_read_tokens: usage.cache_read_input_tokens || 0,
-        cache_creation_tokens: usage.cache_creation_input_tokens || 0,
-        cost_micro_usd: Math.round(cost * 1_000_000),
-      }).catch((e: any) => console.error(`[ERROR] Failed to report usage for task ${taskId}: ${e.message}`));
+      agentClient
+        .updateSessionUsage(agentClient.getAgentId(), agentClient.getSessionId(), {
+          input_tokens: usage.input_tokens || 0,
+          output_tokens: usage.output_tokens || 0,
+          cache_read_tokens: usage.cache_read_input_tokens || 0,
+          cache_creation_tokens: usage.cache_creation_input_tokens || 0,
+          cost_micro_usd: Math.round(cost * 1_000_000),
+        })
+        .catch((e: any) =>
+          console.error(`[ERROR] Failed to report usage for task ${taskId}: ${e.message}`),
+        );
     }
   }
 
   private async closeSession(agentClient: AgentClient): Promise<void> {
-    await this.client.closeSession(agentClient.getAgentId(), agentClient.getSessionId()).catch((err: any) =>
-      console.error(`[WARN] Failed to close session ${agentClient.getSessionId()}: ${err.message}`)
-    );
+    await this.client
+      .closeSession(agentClient.getAgentId(), agentClient.getSessionId())
+      .catch((err: any) =>
+        console.error(
+          `[WARN] Failed to close session ${agentClient.getSessionId()}: ${err.message}`,
+        ),
+      );
   }
 
   private async releaseTask(taskId: string, retries = 3): Promise<void> {
@@ -328,10 +407,14 @@ export class ProcessManager {
         await this.client.releaseTask(taskId);
         return;
       } catch (err: any) {
-        console.error(`[WARN] Failed to release task ${taskId} (attempt ${i + 1}/${retries}): ${err.message}`);
+        console.error(
+          `[WARN] Failed to release task ${taskId} (attempt ${i + 1}/${retries}): ${err.message}`,
+        );
         if (i < retries - 1) await new Promise((r) => setTimeout(r, 1000 * (i + 1)));
       }
     }
-    console.error(`[ERROR] Could not release task ${taskId} after ${retries} attempts. Task will remain locked until stale detection.`);
+    console.error(
+      `[ERROR] Could not release task ${taskId} after ${retries} attempts. Task will remain locked until stale detection.`,
+    );
   }
 }

--- a/packages/cli/src/systemPrompt.ts
+++ b/packages/cli/src/systemPrompt.ts
@@ -1,6 +1,6 @@
-import { writeFileSync, unlinkSync } from "fs";
-import { join } from "path";
-import { tmpdir } from "os";
+import { unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 export interface AgentInfo {
   name: string;
@@ -12,8 +12,9 @@ export interface AgentInfo {
 
 export function generateSystemPrompt(agent: AgentInfo): string {
   const handoffRoles = agent.handoff_to ?? [];
-  const handoffSection = handoffRoles.length > 0
-    ? `
+  const handoffSection =
+    handoffRoles.length > 0
+      ? `
 ## Handoff
 
 If your work reveals NEW independent work (not review of your current task), you can create tasks for these roles: ${handoffRoles.join(", ")}
@@ -25,9 +26,9 @@ To hand off:
 
 Do NOT create handoff tasks for reviewing your PR — review is handled by the platform after you submit \`task review\`.
 `
-    : "";
+      : "";
 
-  return `# Agent Work Protocol
+  return `${`# Agent Work Protocol
 
 You are an autonomous agent on the Agent Kanban platform, working as part of a team.
 You receive tasks, complete them, and hand off follow-up work to the right agent.
@@ -61,7 +62,7 @@ Name: ${agent.name}
 Role: ${agent.role ?? "general"}
 
 ${agent.soul ?? ""}
-`.trim() + "\n";
+`.trim()}\n`;
 }
 
 export function writePromptFile(sessionId: string, content: string): string {
@@ -73,5 +74,7 @@ export function writePromptFile(sessionId: string, content: string): string {
 export function cleanupPromptFile(sessionId: string): void {
   try {
     unlinkSync(join(tmpdir(), `ak-prompt-${sessionId}.txt`));
-  } catch { /* already deleted */ }
+  } catch {
+    /* already deleted */
+  }
 }

--- a/packages/cli/src/usage.ts
+++ b/packages/cli/src/usage.ts
@@ -1,7 +1,7 @@
-import { execSync } from "child_process";
-import { readFileSync } from "fs";
-import { join } from "path";
-import { homedir, platform } from "os";
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
 import type { UsageInfo } from "./types.js";
 
 const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
@@ -21,7 +21,11 @@ function readOAuthToken(): string | null {
   if (cachedToken) return cachedToken;
   try {
     if (platform() === "darwin") {
-      const raw = execSync('security find-generic-password -s "Claude Code-credentials" -w', { stdio: ["pipe", "pipe", "pipe"] }).toString().trim();
+      const raw = execSync('security find-generic-password -s "Claude Code-credentials" -w', {
+        stdio: ["pipe", "pipe", "pipe"],
+      })
+        .toString()
+        .trim();
       cachedToken = parseToken(raw);
     } else {
       cachedToken = parseToken(readFileSync(CREDENTIALS_PATH, "utf-8"));
@@ -54,12 +58,12 @@ export async function getUsage(): Promise<UsageInfo | null> {
       return cachedUsage;
     }
 
-    const data = await res.json() as Record<string, { utilization: number; resets_at: string }>;
+    const data = (await res.json()) as Record<string, { utilization: number; resets_at: string }>;
     cachedUsage = {
-      ...data.five_hour && { five_hour: data.five_hour },
-      ...data.seven_day && { seven_day: data.seven_day },
-      ...data.seven_day_sonnet && { seven_day_sonnet: data.seven_day_sonnet },
-      ...data.seven_day_opus && { seven_day_opus: data.seven_day_opus },
+      ...(data.five_hour && { five_hour: data.five_hour }),
+      ...(data.seven_day && { seven_day: data.seven_day }),
+      ...(data.seven_day_sonnet && { seven_day_sonnet: data.seven_day_sonnet }),
+      ...(data.seven_day_opus && { seven_day_opus: data.seven_day_opus }),
       updated_at: new Date().toISOString(),
     };
     cachedAt = Date.now();

--- a/packages/shared/src/crypto.ts
+++ b/packages/shared/src/crypto.ts
@@ -76,5 +76,7 @@ function bytesToBase64Url(bytes: Uint8Array): string {
 }
 
 function bytesToHex(bytes: Uint8Array): string {
-  return Array.from(bytes).map((b) => b.toString(16).padStart(2, "0")).join("");
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,5 @@
-export * from "./types.js";
 export * from "./constants.js";
 export * from "./crypto.js";
-export * from "./templates.js";
 export * from "./taskStateMachine.js";
+export * from "./templates.js";
+export * from "./types.js";

--- a/packages/shared/src/taskStateMachine.ts
+++ b/packages/shared/src/taskStateMachine.ts
@@ -3,12 +3,12 @@ import type { TaskStatus } from "./types.js";
 export type IdentityType = "user" | "machine" | "agent";
 
 export type TaskTransition =
-  | "claim"      // todo → in_progress
-  | "review"     // in_progress → in_review
-  | "reject"     // in_review → in_progress
-  | "complete"   // in_review → done
-  | "cancel"     // todo|in_review → cancelled
-  | "release";   // in_progress → todo (machine only)
+  | "claim" // todo → in_progress
+  | "review" // in_progress → in_review
+  | "reject" // in_review → in_progress
+  | "complete" // in_review → done
+  | "cancel" // todo|in_review → cancelled
+  | "release"; // in_progress → todo (machine only)
 
 interface TransitionDef {
   from: TaskStatus[];
@@ -17,12 +17,12 @@ interface TransitionDef {
 }
 
 const TRANSITIONS: Record<TaskTransition, TransitionDef> = {
-  claim:    { from: ["todo"],        to: "in_progress", allow: ["agent"] },
-  review:   { from: ["in_progress"], to: "in_review",   allow: ["agent"] },
-  reject:   { from: ["in_review"],   to: "in_progress", allow: ["user", "machine"] },
-  complete: { from: ["in_review"],   to: "done",        allow: ["user", "machine"] },
-  cancel:   { from: ["in_progress", "in_review"], to: "cancelled", allow: ["user", "machine"] },
-  release:  { from: ["in_progress", "in_review"], to: "todo", allow: ["machine"] },
+  claim: { from: ["todo"], to: "in_progress", allow: ["agent"] },
+  review: { from: ["in_progress"], to: "in_review", allow: ["agent"] },
+  reject: { from: ["in_review"], to: "in_progress", allow: ["user", "machine"] },
+  complete: { from: ["in_review"], to: "done", allow: ["user", "machine"] },
+  cancel: { from: ["in_progress", "in_review"], to: "cancelled", allow: ["user", "machine"] },
+  release: { from: ["in_progress", "in_review"], to: "todo", allow: ["machine"] },
 };
 
 export interface TransitionError {
@@ -56,7 +56,10 @@ export function getTargetStatus(action: TaskTransition): TaskStatus {
   return TRANSITIONS[action].to;
 }
 
-export function getAllowedActions(currentStatus: TaskStatus, identity: IdentityType): TaskTransition[] {
+export function getAllowedActions(
+  currentStatus: TaskStatus,
+  identity: IdentityType,
+): TaskTransition[] {
   return (Object.keys(TRANSITIONS) as TaskTransition[]).filter((action) => {
     const def = TRANSITIONS[action];
     return def.from.includes(currentStatus) && def.allow.includes(identity);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -201,7 +201,6 @@ export interface ErrorEnvelope {
   };
 }
 
-
 export interface CreateTaskInput {
   title: string;
   description?: string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: workspace:*
         version: link:packages/shared
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.8
+        version: 2.4.8
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
@@ -36,6 +39,9 @@ importers:
       jsdom:
         specifier: ^29.0.1
         version: 29.0.1(@noble/hashes@2.0.1)
+      lefthook:
+        specifier: ^2.1.4
+        version: 2.1.4
       miniflare:
         specifier: ^4.20260317.1
         version: 4.20260317.1
@@ -466,6 +472,63 @@ packages:
 
   '@better-fetch/fetch@1.1.21':
     resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
+
+  '@biomejs/biome@2.4.8':
+    resolution: {integrity: sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.8':
+    resolution: {integrity: sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.8':
+    resolution: {integrity: sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.8':
+    resolution: {integrity: sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.8':
+    resolution: {integrity: sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.8':
+    resolution: {integrity: sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.8':
+    resolution: {integrity: sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.8':
+    resolution: {integrity: sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.8':
+    resolution: {integrity: sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -2725,6 +2788,60 @@ packages:
     resolution: {integrity: sha512-SU3lgh0rPvq7upc6vvdVrCsSMUG1h3ChvHVOY7wJ2fw4C9QEB7X3d5eyYEyULUX7UQtxZJtZXGuT6U2US72UYA==}
     engines: {node: '>=20.0.0'}
 
+  lefthook-darwin-arm64@2.1.4:
+    resolution: {integrity: sha512-BUAAE9+rUrjr39a+wH/1zHmGrDdwUQ2Yq/z6BQbM/yUb9qtXBRcQ5eOXxApqWW177VhGBpX31aqIlfAZ5Q7wzw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@2.1.4:
+    resolution: {integrity: sha512-K1ncIMEe84fe+ss1hQNO7rIvqiKy2TJvTFpkypvqFodT7mJXZn7GLKYTIXdIuyPAYthRa9DwFnx5uMoHwD2F1Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@2.1.4:
+    resolution: {integrity: sha512-PVUhjOhVN71YaYsVdQyNbFZ4a2jFB2Tg5hKrrn9kaWpx64aLz/XivLjwr8sEuTaP1GRlEWBpW6Bhrcsyo39qFw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@2.1.4:
+    resolution: {integrity: sha512-ZWV9o/LeyWNEBoVO+BhLqxH3rGTba05nkm5NvMjEFSj7LbUNUDbQmupZwtHl1OMGJO66eZP0CalzRfUH6GhBxQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@2.1.4:
+    resolution: {integrity: sha512-iWN0pGnTjrIvNIcSI1vQBJXUbybTqJ5CLMniPA0olabMXQfPDrdMKVQe+mgdwHK+E3/Y0H0ZNL3lnOj6Sk6szA==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@2.1.4:
+    resolution: {integrity: sha512-96bTBE/JdYgqWYAJDh+/e/0MaxJ25XTOAk7iy/fKoZ1ugf6S0W9bEFbnCFNooXOcxNVTan5xWKfcjJmPIKtsJA==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-openbsd-arm64@2.1.4:
+    resolution: {integrity: sha512-oYUoK6AIJNEr9lUSpIMj6g7sWzotvtc3ryw7yoOyQM6uqmEduw73URV/qGoUcm4nqqmR93ZalZwR2r3Gd61zvw==}
+    cpu: [arm64]
+    os: [openbsd]
+
+  lefthook-openbsd-x64@2.1.4:
+    resolution: {integrity: sha512-i/Dv9Jcm68y9cggr1PhyUhOabBGP9+hzQPoiyOhKks7y9qrJl79A8XfG6LHekSuYc2VpiSu5wdnnrE1cj2nfTg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  lefthook-windows-arm64@2.1.4:
+    resolution: {integrity: sha512-hSww7z+QX4YMnw2lK7DMrs3+w7NtxksuMKOkCKGyxUAC/0m1LAICo0ZbtdDtZ7agxRQQQ/SEbzFRhU5ysNcbjA==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@2.1.4:
+    resolution: {integrity: sha512-eE68LwnogxwcPgGsbVGPGxmghyMGmU9SdGwcc+uhGnUxPz1jL89oECMWJNc36zjVK24umNeDAzB5KA3lw1MuWw==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@2.1.4:
+    resolution: {integrity: sha512-JNfJ5gAn0KADvJ1I6/xMcx70+/6TL6U9gqGkKvPw5RNMfatC7jIg0Evl97HN846xmfz959BV70l8r3QsBJk30w==}
+    hasBin: true
+
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -4215,6 +4332,41 @@ snapshots:
   '@better-auth/utils@0.3.1': {}
 
   '@better-fetch/fetch@1.1.21': {}
+
+  '@biomejs/biome@2.4.8':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.8
+      '@biomejs/cli-darwin-x64': 2.4.8
+      '@biomejs/cli-linux-arm64': 2.4.8
+      '@biomejs/cli-linux-arm64-musl': 2.4.8
+      '@biomejs/cli-linux-x64': 2.4.8
+      '@biomejs/cli-linux-x64-musl': 2.4.8
+      '@biomejs/cli-win32-arm64': 2.4.8
+      '@biomejs/cli-win32-x64': 2.4.8
+
+  '@biomejs/cli-darwin-arm64@2.4.8':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.8':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.8':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.8':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.8':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.8':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.8':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.8':
+    optional: true
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -6163,6 +6315,49 @@ snapshots:
       kysely: 0.28.14
 
   kysely@0.28.14: {}
+
+  lefthook-darwin-arm64@2.1.4:
+    optional: true
+
+  lefthook-darwin-x64@2.1.4:
+    optional: true
+
+  lefthook-freebsd-arm64@2.1.4:
+    optional: true
+
+  lefthook-freebsd-x64@2.1.4:
+    optional: true
+
+  lefthook-linux-arm64@2.1.4:
+    optional: true
+
+  lefthook-linux-x64@2.1.4:
+    optional: true
+
+  lefthook-openbsd-arm64@2.1.4:
+    optional: true
+
+  lefthook-openbsd-x64@2.1.4:
+    optional: true
+
+  lefthook-windows-arm64@2.1.4:
+    optional: true
+
+  lefthook-windows-x64@2.1.4:
+    optional: true
+
+  lefthook@2.1.4:
+    optionalDependencies:
+      lefthook-darwin-arm64: 2.1.4
+      lefthook-darwin-x64: 2.1.4
+      lefthook-freebsd-arm64: 2.1.4
+      lefthook-freebsd-x64: 2.1.4
+      lefthook-linux-arm64: 2.1.4
+      lefthook-linux-x64: 2.1.4
+      lefthook-openbsd-arm64: 2.1.4
+      lefthook-openbsd-x64: 2.1.4
+      lefthook-windows-arm64: 2.1.4
+      lefthook-windows-x64: 2.1.4
 
   lightningcss-android-arm64@1.32.0:
     optional: true

--- a/tests/agent-auth.test.ts
+++ b/tests/agent-auth.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
+
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { SignJWT } from "jose";
-import { randomUUID } from "crypto";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 // Integration test: validates the new agent-auth bridge
 // User creates Agent → Machine creates Session (CSR) → Session JWT → auth
@@ -20,7 +21,10 @@ async function applyMigrations(db: D1Database) {
   const files = ["0001_initial.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-    const statements = sql.split(";").map((s) => s.trim()).filter((s) => s.length > 0);
+    const statements = sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
     for (const stmt of statements) {
       await db.prepare(stmt).run();
     }
@@ -30,9 +34,12 @@ async function applyMigrations(db: D1Database) {
 async function seedUser(db: D1Database): Promise<string> {
   const userId = "test-user-001";
   const now = new Date().toISOString();
-  await db.prepare(
-    "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)"
-  ).bind(userId, "Test User", "test@example.com", now, now).run();
+  await db
+    .prepare(
+      "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)",
+    )
+    .bind(userId, "Test User", "test@example.com", now, now)
+    .run();
   return userId;
 }
 
@@ -65,16 +72,35 @@ describe("agent-auth bridge", () => {
     const { createAuth } = await import("../apps/web/functions/api/betterAuth");
     const { createMachine } = await import("../apps/web/functions/api/machineRepo");
 
-    const env = { DB: db, AUTH_SECRET, ALLOWED_HOSTS: "localhost:8788", GITHUB_CLIENT_ID: "x", GITHUB_CLIENT_SECRET: "x" };
+    const env = {
+      DB: db,
+      AUTH_SECRET,
+      ALLOWED_HOSTS: "localhost:8788",
+      GITHUB_CLIENT_ID: "x",
+      GITHUB_CLIENT_SECRET: "x",
+    };
     const auth = createAuth(env);
-    const machine = await createMachine(db, userId, { name: "test-machine", os: "darwin arm64", version: "1.0.0", runtimes: ["Claude Code"] });
+    const machine = await createMachine(db, userId, {
+      name: "test-machine",
+      os: "darwin arm64",
+      version: "1.0.0",
+      runtimes: ["Claude Code"],
+    });
     machineId = machine.id;
 
     const authCtx = await auth.$context;
     const now = new Date();
     await (authCtx.adapter.create as any)({
       model: "agentHost",
-      data: { id: machine.id, name: machine.name, userId, status: "active", activatedAt: now, createdAt: now, updatedAt: now },
+      data: {
+        id: machine.id,
+        name: machine.name,
+        userId,
+        status: "active",
+        activatedAt: now,
+        createdAt: now,
+        updatedAt: now,
+      },
       forceAllowId: true,
     });
 
@@ -98,16 +124,28 @@ describe("agent-auth bridge", () => {
 
   it("creates a session with delegation proof via CSR", async () => {
     const { createSession } = await import("../apps/web/functions/api/agentSessionRepo");
-    const env = { DB: db, AUTH_SECRET, ALLOWED_HOSTS: "localhost:8788", GITHUB_CLIENT_ID: "x", GITHUB_CLIENT_SECRET: "x" };
+    const env = {
+      DB: db,
+      AUTH_SECRET,
+      ALLOWED_HOSTS: "localhost:8788",
+      GITHUB_CLIENT_ID: "x",
+      GITHUB_CLIENT_SECRET: "x",
+    };
 
     const sessionId = randomUUID();
-    const { publicKey } = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, ["sign", "verify"]);
+    const { publicKey } = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, [
+      "sign",
+      "verify",
+    ]);
     const pubJwk = await crypto.subtle.exportKey("jwk", publicKey);
 
     const result = await createSession(db, env, agentId, machineId, sessionId, pubJwk.x!, userId);
     expect(result.delegation_proof).toBeTruthy();
 
-    const session = await db.prepare("SELECT * FROM agent_sessions WHERE id = ?").bind(sessionId).first();
+    const session = await db
+      .prepare("SELECT * FROM agent_sessions WHERE id = ?")
+      .bind(sessionId)
+      .first();
     expect(session).toBeTruthy();
     expect(session!.agent_id).toBe(agentId);
     expect(session!.delegation_proof).toBe(result.delegation_proof);
@@ -120,35 +158,68 @@ describe("agent-auth bridge", () => {
   it("session JWT authenticates through HTTP handler", async () => {
     const { createSession } = await import("../apps/web/functions/api/agentSessionRepo");
     const { api } = await import("../apps/web/functions/api/routes");
-    const env = { DB: db, AUTH_SECRET, ALLOWED_HOSTS: "localhost:8788", GITHUB_CLIENT_ID: "x", GITHUB_CLIENT_SECRET: "x" };
+    const env = {
+      DB: db,
+      AUTH_SECRET,
+      ALLOWED_HOSTS: "localhost:8788",
+      GITHUB_CLIENT_ID: "x",
+      GITHUB_CLIENT_SECRET: "x",
+    };
 
     const sessionId = randomUUID();
-    const { publicKey, privateKey } = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, ["sign", "verify"]);
+    const { publicKey, privateKey } = await crypto.subtle.generateKey(
+      { name: "Ed25519" } as any,
+      true,
+      ["sign", "verify"],
+    );
     const pubJwk = await crypto.subtle.exportKey("jwk", publicKey);
 
     await createSession(db, env, agentId, machineId, sessionId, pubJwk.x!, userId);
 
-    const jwt = await new SignJWT({ sub: sessionId, aid: agentId, jti: randomUUID(), aud: BETTER_AUTH_URL })
+    const jwt = await new SignJWT({
+      sub: sessionId,
+      aid: agentId,
+      jti: randomUUID(),
+      aud: BETTER_AUTH_URL,
+    })
       .setProtectedHeader({ alg: "EdDSA", typ: "agent+jwt" })
       .setIssuedAt()
       .setExpirationTime("60s")
       .sign(privateKey);
 
-    const res = await api.request("/api/agents", {
-      method: "GET",
-      headers: { Authorization: `Bearer ${jwt}`, Host: "localhost:8788", "x-forwarded-proto": "http" },
-    }, env);
+    const res = await api.request(
+      "/api/agents",
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${jwt}`,
+          Host: "localhost:8788",
+          "x-forwarded-proto": "http",
+        },
+      },
+      env,
+    );
     expect(res.status).toBe(200);
   });
 
   it("delegation proof is verifiable with agent public key", async () => {
     const { verifyDelegation } = await import("@agent-kanban/shared");
 
-    const agent = await db.prepare("SELECT public_key FROM agents WHERE id = ?").bind(agentId).first<{ public_key: string }>();
-    const sessions = await db.prepare("SELECT * FROM agent_sessions WHERE agent_id = ?").bind(agentId).all();
+    const agent = await db
+      .prepare("SELECT public_key FROM agents WHERE id = ?")
+      .bind(agentId)
+      .first<{ public_key: string }>();
+    const sessions = await db
+      .prepare("SELECT * FROM agent_sessions WHERE agent_id = ?")
+      .bind(agentId)
+      .all();
 
     for (const session of sessions.results as any[]) {
-      const valid = await verifyDelegation(agent!.public_key, session.public_key, session.delegation_proof);
+      const valid = await verifyDelegation(
+        agent!.public_key,
+        session.public_key,
+        session.delegation_proof,
+      );
       expect(valid).toBe(true);
     }
   });

--- a/tests/agent-json-fields.test.ts
+++ b/tests/agent-json-fields.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Miniflare } from "miniflare";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const MIGRATIONS_DIR = join(__dirname, "../apps/web/migrations");
 
@@ -13,7 +14,10 @@ async function applyMigrations(db: D1Database) {
   const files = ["0001_initial.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-    for (const stmt of sql.split(";").map(s => s.trim()).filter(Boolean)) {
+    for (const stmt of sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       await db.prepare(stmt).run();
     }
   }
@@ -41,13 +45,19 @@ describe("agent JSON field parsing (skills, handoff_to)", () => {
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
     const agent = await createAgent(db, ownerId, {
       name: "Test Agent",
-      skills: ["trailofbits/skills@differential-review", "obra/superpowers@verification-before-completion"],
+      skills: [
+        "trailofbits/skills@differential-review",
+        "obra/superpowers@verification-before-completion",
+      ],
       handoff_to: ["quality-goalkeeper", "enduser"],
     });
     agentId = agent.id;
 
     expect(Array.isArray(agent.skills)).toBe(true);
-    expect(agent.skills).toEqual(["trailofbits/skills@differential-review", "obra/superpowers@verification-before-completion"]);
+    expect(agent.skills).toEqual([
+      "trailofbits/skills@differential-review",
+      "obra/superpowers@verification-before-completion",
+    ]);
     expect(Array.isArray(agent.handoff_to)).toBe(true);
     expect(agent.handoff_to).toEqual(["quality-goalkeeper", "enduser"]);
   });
@@ -63,10 +73,13 @@ describe("agent JSON field parsing (skills, handoff_to)", () => {
   it("listAgents returns parsed arrays", async () => {
     const { listAgents } = await import("../apps/web/functions/api/agentRepo");
     const agents = await listAgents(db, ownerId);
-    const agent = agents.find(a => a.id === agentId)!;
+    const agent = agents.find((a) => a.id === agentId)!;
 
     expect(Array.isArray(agent.skills)).toBe(true);
-    expect(agent.skills).toEqual(["trailofbits/skills@differential-review", "obra/superpowers@verification-before-completion"]);
+    expect(agent.skills).toEqual([
+      "trailofbits/skills@differential-review",
+      "obra/superpowers@verification-before-completion",
+    ]);
     expect(Array.isArray(agent.handoff_to)).toBe(true);
     expect(agent.handoff_to).toEqual(["quality-goalkeeper", "enduser"]);
   });
@@ -77,7 +90,10 @@ describe("agent JSON field parsing (skills, handoff_to)", () => {
 
     expect(agent).toBeTruthy();
     expect(Array.isArray(agent!.skills)).toBe(true);
-    expect(agent!.skills).toEqual(["trailofbits/skills@differential-review", "obra/superpowers@verification-before-completion"]);
+    expect(agent!.skills).toEqual([
+      "trailofbits/skills@differential-review",
+      "obra/superpowers@verification-before-completion",
+    ]);
     expect(Array.isArray(agent!.handoff_to)).toBe(true);
   });
 

--- a/tests/agent-redesign.test.ts
+++ b/tests/agent-redesign.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
+
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { SignJWT } from "jose";
-import { randomUUID } from "crypto";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 // Integration tests for Agent Entity Redesign:
 // - Agent CRUD (update, delete)
@@ -32,7 +33,10 @@ async function applyMigrations(db: D1Database) {
   const files = ["0001_initial.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-    for (const stmt of sql.split(";").map((s) => s.trim()).filter(Boolean)) {
+    for (const stmt of sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       await db.prepare(stmt).run();
     }
   }
@@ -40,9 +44,12 @@ async function applyMigrations(db: D1Database) {
 
 async function seedUser(db: D1Database, id: string, email: string): Promise<string> {
   const now = new Date().toISOString();
-  await db.prepare(
-    "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)"
-  ).bind(id, "Test User", email, now, now).run();
+  await db
+    .prepare(
+      "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)",
+    )
+    .bind(id, "Test User", email, now, now)
+    .run();
   return id;
 }
 
@@ -53,22 +60,33 @@ async function createApiKeyForUser(userId: string): Promise<string> {
   return result.key;
 }
 
-async function apiRequest(method: string, path: string, body?: any, token?: string) {
+async function _apiRequest(method: string, path: string, body?: any, token?: string) {
   const { api } = await import("../apps/web/functions/api/routes");
-  const headers: Record<string, string> = { "Content-Type": "application/json", Host: "localhost:8788", "x-forwarded-proto": "http" };
-  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Host: "localhost:8788",
+    "x-forwarded-proto": "http",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
   const init: RequestInit = { method, headers };
   if (body) init.body = JSON.stringify(body);
   return api.request(path, init, env);
 }
 
 async function createSessionKeypair() {
-  const keypair = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, ["sign", "verify"]);
+  const keypair = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, [
+    "sign",
+    "verify",
+  ]);
   const pubJwk = await crypto.subtle.exportKey("jwk", (keypair as any).publicKey);
   return { publicKey: pubJwk.x!, privateKey: (keypair as any).privateKey };
 }
 
-async function signJWT(sessionId: string, agentId: string, privateKey: CryptoKey): Promise<string> {
+async function _signJWT(
+  sessionId: string,
+  agentId: string,
+  privateKey: CryptoKey,
+): Promise<string> {
   return new SignJWT({ sub: sessionId, aid: agentId, jti: randomUUID(), aud: BETTER_AUTH_URL })
     .setProtectedHeader({ alg: "EdDSA", typ: "agent+jwt" })
     .setIssuedAt()
@@ -97,7 +115,13 @@ describe("agent CRUD", () => {
   it("setup user", async () => {
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
     userId = await seedUser(env.DB, "user-crud", "crud@test.com");
-    const agent = await createAgent(env.DB, userId, { name: "CrudAgent", bio: "test bio", soul: "be helpful", runtime: "claude", model: "opus" });
+    const agent = await createAgent(env.DB, userId, {
+      name: "CrudAgent",
+      bio: "test bio",
+      soul: "be helpful",
+      runtime: "claude",
+      model: "opus",
+    });
     agentId = agent.id;
     expect(agent.name).toBe("CrudAgent");
     expect(agent.bio).toBe("test bio");
@@ -105,7 +129,11 @@ describe("agent CRUD", () => {
 
   it("updates agent fields", async () => {
     const { updateAgent, getAgent } = await import("../apps/web/functions/api/agentRepo");
-    await updateAgent(env.DB, agentId, { name: "UpdatedAgent", bio: "new bio", soul: "be precise" });
+    await updateAgent(env.DB, agentId, {
+      name: "UpdatedAgent",
+      bio: "new bio",
+      soul: "be precise",
+    });
     const agent = await getAgent(env.DB, agentId, userId);
     expect(agent!.name).toBe("UpdatedAgent");
     expect(agent!.bio).toBe("new bio");
@@ -135,14 +163,19 @@ describe("agent status computation", () => {
   let userId: string;
   let agentId: string;
   let machineId: string;
-  let apiKey: string;
+  let _apiKey: string;
 
   it("setup", async () => {
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
     const { createMachine } = await import("../apps/web/functions/api/machineRepo");
     userId = await seedUser(env.DB, "user-status", "status@test.com");
-    apiKey = await createApiKeyForUser(userId);
-    const machine = await createMachine(env.DB, userId, { name: "status-machine", os: "test", version: "1.0", runtimes: [] });
+    _apiKey = await createApiKeyForUser(userId);
+    const machine = await createMachine(env.DB, userId, {
+      name: "status-machine",
+      os: "test",
+      version: "1.0",
+      runtimes: [],
+    });
     machineId = machine.id;
 
     // Create BA agentHost
@@ -151,7 +184,15 @@ describe("agent status computation", () => {
     const authCtx = await auth.$context;
     await (authCtx.adapter.create as any)({
       model: "agentHost",
-      data: { id: machineId, name: "status-machine", userId, status: "active", activatedAt: new Date(), createdAt: new Date(), updatedAt: new Date() },
+      data: {
+        id: machineId,
+        name: "status-machine",
+        userId,
+        status: "active",
+        activatedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
       forceAllowId: true,
     });
 
@@ -189,7 +230,11 @@ describe("agent status computation", () => {
 
   it("agent goes offline when all sessions are closed", async () => {
     const { closeSession } = await import("../apps/web/functions/api/agentSessionRepo");
-    const sessions = await env.DB.prepare("SELECT id FROM agent_sessions WHERE agent_id = ? AND status = 'active'").bind(agentId).all();
+    const sessions = await env.DB.prepare(
+      "SELECT id FROM agent_sessions WHERE agent_id = ? AND status = 'active'",
+    )
+      .bind(agentId)
+      .all();
     for (const s of sessions.results as any[]) {
       await closeSession(env.DB, s.id);
     }
@@ -210,14 +255,27 @@ describe("session lifecycle", () => {
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
     const { createMachine } = await import("../apps/web/functions/api/machineRepo");
     userId = await seedUser(env.DB, "user-session", "session@test.com");
-    const machine = await createMachine(env.DB, userId, { name: "session-machine", os: "test", version: "1.0", runtimes: [] });
+    const machine = await createMachine(env.DB, userId, {
+      name: "session-machine",
+      os: "test",
+      version: "1.0",
+      runtimes: [],
+    });
     machineId = machine.id;
 
     const { createAuth } = await import("../apps/web/functions/api/betterAuth");
-    const authCtx = await (createAuth(env)).$context;
+    const authCtx = await createAuth(env).$context;
     await (authCtx.adapter.create as any)({
       model: "agentHost",
-      data: { id: machineId, name: "session-machine", userId, status: "active", activatedAt: new Date(), createdAt: new Date(), updatedAt: new Date() },
+      data: {
+        id: machineId,
+        name: "session-machine",
+        userId,
+        status: "active",
+        activatedAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
       forceAllowId: true,
     });
 
@@ -226,7 +284,9 @@ describe("session lifecycle", () => {
   });
 
   it("close session sets status and closed_at", async () => {
-    const { createSession, closeSession, getSession } = await import("../apps/web/functions/api/agentSessionRepo");
+    const { createSession, closeSession, getSession } = await import(
+      "../apps/web/functions/api/agentSessionRepo"
+    );
     const { publicKey } = await createSessionKeypair();
     sessionId = randomUUID();
     await createSession(env.DB, env, agentId, machineId, sessionId, publicKey, userId);
@@ -238,7 +298,9 @@ describe("session lifecycle", () => {
   });
 
   it("list sessions shows full history", async () => {
-    const { createSession, listSessions } = await import("../apps/web/functions/api/agentSessionRepo");
+    const { createSession, listSessions } = await import(
+      "../apps/web/functions/api/agentSessionRepo"
+    );
     const { publicKey } = await createSessionKeypair();
     await createSession(env.DB, env, agentId, machineId, randomUUID(), publicKey, userId);
 
@@ -251,12 +313,30 @@ describe("session lifecycle", () => {
 
   it("session usage accumulates", async () => {
     const { updateSessionUsage } = await import("../apps/web/functions/api/agentSessionRepo");
-    const active = await env.DB.prepare("SELECT id FROM agent_sessions WHERE agent_id = ? AND status = 'active'").bind(agentId).first<{ id: string }>();
+    const active = await env.DB.prepare(
+      "SELECT id FROM agent_sessions WHERE agent_id = ? AND status = 'active'",
+    )
+      .bind(agentId)
+      .first<{ id: string }>();
 
-    await updateSessionUsage(env.DB, active!.id, { input_tokens: 100, output_tokens: 50, cache_read_tokens: 10, cache_creation_tokens: 5, cost_micro_usd: 500 });
-    await updateSessionUsage(env.DB, active!.id, { input_tokens: 200, output_tokens: 100, cache_read_tokens: 20, cache_creation_tokens: 10, cost_micro_usd: 1000 });
+    await updateSessionUsage(env.DB, active!.id, {
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_read_tokens: 10,
+      cache_creation_tokens: 5,
+      cost_micro_usd: 500,
+    });
+    await updateSessionUsage(env.DB, active!.id, {
+      input_tokens: 200,
+      output_tokens: 100,
+      cache_read_tokens: 20,
+      cache_creation_tokens: 10,
+      cost_micro_usd: 1000,
+    });
 
-    const session = await env.DB.prepare("SELECT * FROM agent_sessions WHERE id = ?").bind(active!.id).first<any>();
+    const session = await env.DB.prepare("SELECT * FROM agent_sessions WHERE id = ?")
+      .bind(active!.id)
+      .first<any>();
     expect(session.input_tokens).toBe(300);
     expect(session.output_tokens).toBe(150);
     expect(session.cost_micro_usd).toBe(1500);
@@ -316,20 +396,24 @@ describe("message sender model", () => {
 
 describe("delegation proof security", () => {
   it("tampered proof is rejected", async () => {
-    const { generateKeypair, computeFingerprint, signDelegation, verifyDelegation } = await import("@agent-kanban/shared");
+    const { generateKeypair, signDelegation, verifyDelegation } = await import(
+      "@agent-kanban/shared"
+    );
 
     const agent = await generateKeypair();
     const session = await generateKeypair();
     const proof = await signDelegation(agent.privateKeyJwk, session.publicKeyBase64);
 
     // Tamper with the proof
-    const tampered = proof.slice(0, -2) + "XX";
+    const tampered = `${proof.slice(0, -2)}XX`;
     const valid = await verifyDelegation(agent.publicKeyBase64, session.publicKeyBase64, tampered);
     expect(valid).toBe(false);
   });
 
   it("wrong agent key rejects proof", async () => {
-    const { generateKeypair, signDelegation, verifyDelegation } = await import("@agent-kanban/shared");
+    const { generateKeypair, signDelegation, verifyDelegation } = await import(
+      "@agent-kanban/shared"
+    );
 
     const agent1 = await generateKeypair();
     const agent2 = await generateKeypair();
@@ -342,7 +426,9 @@ describe("delegation proof security", () => {
   });
 
   it("wrong session key rejects proof", async () => {
-    const { generateKeypair, signDelegation, verifyDelegation } = await import("@agent-kanban/shared");
+    const { generateKeypair, signDelegation, verifyDelegation } = await import(
+      "@agent-kanban/shared"
+    );
 
     const agent = await generateKeypair();
     const session1 = await generateKeypair();
@@ -380,7 +466,11 @@ describe("user assigns task to agent", () => {
   });
 
   it("task logs record assignment with persistent agent ID", async () => {
-    const logs = await env.DB.prepare("SELECT * FROM task_logs WHERE task_id = ? AND action = 'assigned'").bind(taskId).all();
+    const logs = await env.DB.prepare(
+      "SELECT * FROM task_logs WHERE task_id = ? AND action = 'assigned'",
+    )
+      .bind(taskId)
+      .all();
     expect(logs.results.length).toBe(1);
     expect((logs.results[0] as any).agent_id).toBe(agentId);
   });

--- a/tests/agents/agent-detail-activity-tab.spec.ts
+++ b/tests/agents/agent-detail-activity-tab.spec.ts
@@ -1,26 +1,26 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.16 Agent detail — Activity tab lists logs or empty state
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agent detail — Activity tab lists logs or empty state', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agent detail — Activity tab lists logs or empty state", async ({ page }) => {
     // 1. Sign in, navigate to an agent detail page, and click the 'Activity' tab
     await signUpAndGetBoard(page, `agent_activity_${Date.now()}@example.com`);
-    await page.goto('/agents');
+    await page.goto("/agents");
 
-    await page.getByText('Quality Goalkeeper').first().waitFor({ state: 'visible' });
-    await page.getByRole('link', { name: /Quality Goalkeeper/ }).click();
+    await page.getByText("Quality Goalkeeper").first().waitFor({ state: "visible" });
+    await page.getByRole("link", { name: /Quality Goalkeeper/ }).click();
     await expect(page).toHaveURL(/\/agents\/.+/);
 
-    await page.getByText('← Agents').first().waitFor({ state: 'visible' });
+    await page.getByText("← Agents").first().waitFor({ state: "visible" });
 
     // Click the Activity tab
-    await page.getByRole('button', { name: 'Activity' }).click();
+    await page.getByRole("button", { name: "Activity" }).click();
 
     // expect: If no logs exist, the text 'No activity yet.' is displayed
     // (For a fresh agent, there are no logs)
-    await expect(page.getByText('No activity yet.')).toBeVisible();
+    await expect(page.getByText("No activity yet.")).toBeVisible();
   });
 });

--- a/tests/agents/agent-detail-identity-modal-close.spec.ts
+++ b/tests/agents/agent-detail-identity-modal-close.spec.ts
@@ -1,35 +1,35 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.14 Agent detail — close identity modal
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agent detail — close identity modal', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agent detail — close identity modal", async ({ page }) => {
     // 1. Sign in, navigate to an agent detail page, open the identity modal
     await signUpAndGetBoard(page, `agent_fp_close_${Date.now()}@example.com`);
-    await page.goto('/agents');
+    await page.goto("/agents");
 
-    await page.getByText('Quality Goalkeeper').first().waitFor({ state: 'visible' });
-    await page.getByRole('link', { name: /Quality Goalkeeper/ }).click();
+    await page.getByText("Quality Goalkeeper").first().waitFor({ state: "visible" });
+    await page.getByRole("link", { name: /Quality Goalkeeper/ }).click();
     await expect(page).toHaveURL(/\/agents\/.+/);
 
-    await page.getByText('← Agents').first().waitFor({ state: 'visible' });
+    await page.getByText("← Agents").first().waitFor({ state: "visible" });
 
     // Open the identity modal
-    const fingerprintButton = page.getByRole('button', { name: /^[0-9a-f:]+$/ }).first();
+    const fingerprintButton = page.getByRole("button", { name: /^[0-9a-f:]+$/ }).first();
     await fingerprintButton.click();
 
     // expect: Identity modal is displayed
-    await expect(page.getByRole('heading', { name: 'Cryptographic Identity' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Cryptographic Identity" })).toBeVisible();
 
     // 2. Click the close button in the modal header
-    await page.getByRole('button', { name: 'Close' }).click();
+    await page.getByRole("button", { name: "Close" }).click();
 
     // expect: The modal closes
-    await expect(page.getByRole('heading', { name: 'Cryptographic Identity' })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Cryptographic Identity" })).not.toBeVisible();
 
     // expect: The agent detail page is visible behind it
-    await expect(page.getByRole('heading', { name: 'Quality Goalkeeper' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Quality Goalkeeper" })).toBeVisible();
   });
 });

--- a/tests/agents/agent-detail-identity-modal.spec.ts
+++ b/tests/agents/agent-detail-identity-modal.spec.ts
@@ -1,37 +1,37 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.13 Agent detail — click fingerprint watermark opens identity modal
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agent detail — click fingerprint watermark opens identity modal', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agent detail — click fingerprint watermark opens identity modal", async ({ page }) => {
     // 1. Sign in, navigate to an agent detail page, and click the fingerprint watermark icon
     await signUpAndGetBoard(page, `agent_fp_modal_${Date.now()}@example.com`);
-    await page.goto('/agents');
+    await page.goto("/agents");
 
-    await page.getByText('Quality Goalkeeper').first().waitFor({ state: 'visible' });
-    await page.getByRole('link', { name: /Quality Goalkeeper/ }).click();
+    await page.getByText("Quality Goalkeeper").first().waitFor({ state: "visible" });
+    await page.getByRole("link", { name: /Quality Goalkeeper/ }).click();
     await expect(page).toHaveURL(/\/agents\/.+/);
 
-    await page.getByText('← Agents').first().waitFor({ state: 'visible' });
+    await page.getByText("← Agents").first().waitFor({ state: "visible" });
 
     // Click the fingerprint watermark button (it shows the fingerprint short code as its label)
-    const fingerprintButton = page.getByRole('button', { name: /^[0-9a-f:]+$/ }).first();
+    const fingerprintButton = page.getByRole("button", { name: /^[0-9a-f:]+$/ }).first();
     await fingerprintButton.click();
 
     // expect: The 'Cryptographic Identity' modal opens
-    await expect(page.getByRole('heading', { name: 'Cryptographic Identity' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Cryptographic Identity" })).toBeVisible();
 
     // expect: The modal displays the Fingerprint with a 'Copy' button
-    await expect(page.getByText('Fingerprint')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Copy' }).first()).toBeVisible();
+    await expect(page.getByText("Fingerprint")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Copy" }).first()).toBeVisible();
 
     // expect: The modal displays the Ed25519 Public Key with a 'Copy' button
-    await expect(page.getByText('Ed25519 Public Key')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Copy' }).nth(1)).toBeVisible();
+    await expect(page.getByText("Ed25519 Public Key")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Copy" }).nth(1)).toBeVisible();
 
     // expect: A close button is visible in the modal header
-    await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Close" })).toBeVisible();
   });
 });

--- a/tests/agents/agent-detail-mission-tab.spec.ts
+++ b/tests/agents/agent-detail-mission-tab.spec.ts
@@ -1,25 +1,25 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.15 Agent detail — Mission tab shows active task or 'No active mission'
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
+test.describe("Agents Page", () => {
   test("Agent detail — Mission tab shows 'No active mission'", async ({ page }) => {
     // 1. Sign in and navigate to an agent that has no active task assigned
     await signUpAndGetBoard(page, `agent_mission_${Date.now()}@example.com`);
-    await page.goto('/agents');
+    await page.goto("/agents");
 
-    await page.getByText('Quality Goalkeeper').first().waitFor({ state: 'visible' });
-    await page.getByRole('link', { name: /Quality Goalkeeper/ }).click();
+    await page.getByText("Quality Goalkeeper").first().waitFor({ state: "visible" });
+    await page.getByRole("link", { name: /Quality Goalkeeper/ }).click();
     await expect(page).toHaveURL(/\/agents\/.+/);
 
-    await page.getByText('← Agents').first().waitFor({ state: 'visible' });
+    await page.getByText("← Agents").first().waitFor({ state: "visible" });
 
     // Mission tab is active by default
-    await expect(page.getByRole('button', { name: 'Mission' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Mission" })).toBeVisible();
 
     // expect: The Mission tab content shows 'No active mission.'
-    await expect(page.getByText('No active mission.')).toBeVisible();
+    await expect(page.getByText("No active mission.")).toBeVisible();
   });
 });

--- a/tests/agents/agent-detail-not-found.spec.ts
+++ b/tests/agents/agent-detail-not-found.spec.ts
@@ -1,21 +1,21 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.18 Agent not found shows graceful error state
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agent not found shows graceful error state', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agent not found shows graceful error state", async ({ page }) => {
     // 1. Sign in and navigate to /agents/nonexistent-id
     await signUpAndGetBoard(page, `agent_notfound_${Date.now()}@example.com`);
-    await page.goto('/agents/nonexistent-id');
+    await page.goto("/agents/nonexistent-id");
 
     // expect: The page shows 'Agent not found.' text in the content area
-    await page.getByText('Agent not found.').first().waitFor({ state: 'visible' });
-    await expect(page.getByText('Agent not found.')).toBeVisible();
+    await page.getByText("Agent not found.").first().waitFor({ state: "visible" });
+    await expect(page.getByText("Agent not found.")).toBeVisible();
 
     // expect: The header is still rendered correctly
-    await expect(page.getByRole('link', { name: /Agent Kanban/ })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Agents' })).toBeVisible();
+    await expect(page.getByRole("link", { name: /Agent Kanban/ })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Agents" })).toBeVisible();
   });
 });

--- a/tests/agents/agent-detail-render.spec.ts
+++ b/tests/agents/agent-detail-render.spec.ts
@@ -1,47 +1,47 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.12 Agent detail page renders identity hero
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agent detail page renders identity hero', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agent detail page renders identity hero", async ({ page }) => {
     // 1. Sign in and navigate to an agent's detail page at /agents/:id
     await signUpAndGetBoard(page, `agent_detail_${Date.now()}@example.com`);
-    await page.goto('/agents');
+    await page.goto("/agents");
 
-    await page.getByText('Quality Goalkeeper').first().waitFor({ state: 'visible' });
+    await page.getByText("Quality Goalkeeper").first().waitFor({ state: "visible" });
 
     // Navigate to the agent detail page via card click
-    await page.getByRole('link', { name: /Quality Goalkeeper/ }).click();
+    await page.getByRole("link", { name: /Quality Goalkeeper/ }).click();
     await expect(page).toHaveURL(/\/agents\/.+/);
 
-    await page.getByText('← Agents').first().waitFor({ state: 'visible' });
+    await page.getByText("← Agents").first().waitFor({ state: "visible" });
 
     // expect: A '← Agents' back link is visible
-    await expect(page.getByRole('link', { name: '← Agents' })).toBeVisible();
+    await expect(page.getByRole("link", { name: "← Agents" })).toBeVisible();
 
     // expect: The identity hero card shows the agent name
-    await expect(page.getByRole('heading', { name: 'Quality Goalkeeper' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Quality Goalkeeper" })).toBeVisible();
 
     // expect: Bio is visible
-    await expect(page.getByText('Establishes quality standards')).toBeVisible();
+    await expect(page.getByText("Establishes quality standards")).toBeVisible();
 
     // expect: Metadata (runtime, model, created time) is visible
-    await expect(page.getByText('claude-code')).toBeVisible();
-    await expect(page.getByText('claude-opus-4-6')).toBeVisible();
+    await expect(page.getByText("claude-code")).toBeVisible();
+    await expect(page.getByText("claude-opus-4-6")).toBeVisible();
     await expect(page.getByText(/Created/)).toBeVisible();
 
     // expect: A telemetry strip shows TASKS, INPUT, OUTPUT, CACHE, COST stats
-    await expect(page.getByText('TASKS', { exact: true })).toBeVisible();
-    await expect(page.getByText('INPUT', { exact: true })).toBeVisible();
-    await expect(page.getByText('OUTPUT', { exact: true })).toBeVisible();
-    await expect(page.getByText('CACHE', { exact: true })).toBeVisible();
-    await expect(page.getByText('COST', { exact: true })).toBeVisible();
+    await expect(page.getByText("TASKS", { exact: true })).toBeVisible();
+    await expect(page.getByText("INPUT", { exact: true })).toBeVisible();
+    await expect(page.getByText("OUTPUT", { exact: true })).toBeVisible();
+    await expect(page.getByText("CACHE", { exact: true })).toBeVisible();
+    await expect(page.getByText("COST", { exact: true })).toBeVisible();
 
     // expect: Tabs for 'Mission', 'Activity', and 'Sessions' are displayed below the hero card
-    await expect(page.getByRole('button', { name: 'Mission' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Activity' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Sessions' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Mission" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Activity" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sessions" })).toBeVisible();
   });
 });

--- a/tests/agents/agent-detail-sessions-tab.spec.ts
+++ b/tests/agents/agent-detail-sessions-tab.spec.ts
@@ -1,25 +1,25 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.17 Agent detail — Sessions tab lists sessions or empty state
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agent detail — Sessions tab lists sessions or empty state', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agent detail — Sessions tab lists sessions or empty state", async ({ page }) => {
     // 1. Sign in, navigate to an agent detail page, and click the 'Sessions' tab
     await signUpAndGetBoard(page, `agent_sessions_${Date.now()}@example.com`);
-    await page.goto('/agents');
+    await page.goto("/agents");
 
-    await page.getByText('Quality Goalkeeper').first().waitFor({ state: 'visible' });
-    await page.getByRole('link', { name: /Quality Goalkeeper/ }).click();
+    await page.getByText("Quality Goalkeeper").first().waitFor({ state: "visible" });
+    await page.getByRole("link", { name: /Quality Goalkeeper/ }).click();
     await expect(page).toHaveURL(/\/agents\/.+/);
 
-    await page.getByText('← Agents').first().waitFor({ state: 'visible' });
+    await page.getByText("← Agents").first().waitFor({ state: "visible" });
 
     // Click the Sessions tab
-    await page.getByRole('button', { name: 'Sessions' }).click();
+    await page.getByRole("button", { name: "Sessions" }).click();
 
     // expect: If no sessions exist, the text 'No sessions yet.' is displayed
-    await expect(page.getByText('No sessions yet.')).toBeVisible();
+    await expect(page.getByText("No sessions yet.")).toBeVisible();
   });
 });

--- a/tests/agents/agents-card-link.spec.ts
+++ b/tests/agents/agents-card-link.spec.ts
@@ -1,25 +1,25 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.3 Agent card links to agent detail page
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agent card links to agent detail page', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agent card links to agent detail page", async ({ page }) => {
     // 1. Sign in, navigate to /agents, and click on an agent card
     await signUpAndGetBoard(page, `agents_card_${Date.now()}@example.com`);
-    await page.goto('/agents');
+    await page.goto("/agents");
 
-    await page.getByText('Quality Goalkeeper').first().waitFor({ state: 'visible' });
+    await page.getByText("Quality Goalkeeper").first().waitFor({ state: "visible" });
 
     // Click the agent card
-    await page.getByRole('link', { name: /Quality Goalkeeper/ }).click();
+    await page.getByRole("link", { name: /Quality Goalkeeper/ }).click();
 
     // expect: The browser navigates to /agents/:id
     await expect(page).toHaveURL(/\/agents\/.+/);
 
     // expect: The agent detail page is displayed
-    await page.getByText('← Agents').first().waitFor({ state: 'visible' });
-    await expect(page.getByRole('heading', { name: 'Quality Goalkeeper' })).toBeVisible();
+    await page.getByText("← Agents").first().waitFor({ state: "visible" });
+    await expect(page.getByRole("heading", { name: "Quality Goalkeeper" })).toBeVisible();
   });
 });

--- a/tests/agents/agents-empty-state.spec.ts
+++ b/tests/agents/agents-empty-state.spec.ts
@@ -5,24 +5,24 @@
 // This test verifies the agents page heading, "New agent" button, and the grid of agent cards
 // that is shown for a fresh user (with only the built-in agent present).
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agents page renders empty state when no agents exist', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agents page renders empty state when no agents exist", async ({ page }) => {
     // 1. Sign in as a user with no agents and navigate to /agents
     await signUpAndGetBoard(page, `agents_empty_${Date.now()}@example.com`);
-    await page.goto('/agents');
+    await page.goto("/agents");
 
     // expect: Heading 'Agents' is displayed
-    await expect(page.getByRole('heading', { name: 'Agents' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Agents" })).toBeVisible();
 
     // expect: A 'New agent' button is visible
-    await expect(page.getByRole('link', { name: 'New agent' })).toBeVisible();
+    await expect(page.getByRole("link", { name: "New agent" })).toBeVisible();
 
     // NOTE: A built-in agent always exists, so we verify the page loads correctly.
     // The "No agents yet." state cannot be reached in the current implementation.
-    await page.getByText('Quality Goalkeeper').first().waitFor({ state: 'visible' });
-    await expect(page.getByText('Quality Goalkeeper').first()).toBeVisible();
+    await page.getByText("Quality Goalkeeper").first().waitFor({ state: "visible" });
+    await expect(page.getByText("Quality Goalkeeper").first()).toBeVisible();
   });
 });

--- a/tests/agents/agents-grid.spec.ts
+++ b/tests/agents/agents-grid.spec.ts
@@ -1,24 +1,24 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.2 Agents page renders agent cards in a grid
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agents page renders agent cards in a grid', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agents page renders agent cards in a grid", async ({ page }) => {
     // 1. Sign in as a user with at least one agent and navigate to /agents
     await signUpAndGetBoard(page, `agents_grid_${Date.now()}@example.com`);
-    await page.goto('/agents');
+    await page.goto("/agents");
 
     // Wait for the agent card grid to load
-    await page.getByText('Quality Goalkeeper').first().waitFor({ state: 'visible' });
+    await page.getByText("Quality Goalkeeper").first().waitFor({ state: "visible" });
 
     // expect: Agents are displayed in a 3-column card grid
-    const agentCard = page.getByRole('link', { name: /Quality Goalkeeper/ });
+    const agentCard = page.getByRole("link", { name: /Quality Goalkeeper/ });
     await expect(agentCard).toBeVisible();
 
     // expect: Each card shows the agent identicon (img), agent name, fingerprint badge, status indicator
-    await expect(agentCard.getByRole('heading', { name: 'Quality Goalkeeper' })).toBeVisible();
+    await expect(agentCard.getByRole("heading", { name: "Quality Goalkeeper" })).toBeVisible();
     await expect(agentCard.getByText(/Offline|Online/)).toBeVisible();
 
     // expect: Stats strip with task count, token count, and cost

--- a/tests/agents/agents-new-back-from-form.spec.ts
+++ b/tests/agents/agents-new-back-from-form.spec.ts
@@ -1,27 +1,27 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.11 Agent creation — back navigation from form step
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agent creation — back navigation from form step', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agent creation — back navigation from form step", async ({ page }) => {
     // 1. Sign in, navigate to /agents/new, click 'Custom' to reach the form step
     await signUpAndGetBoard(page, `agents_back_${Date.now()}@example.com`);
-    await page.goto('/agents/new');
-    await page.getByRole('button', { name: 'Custom Build your own from' }).click();
+    await page.goto("/agents/new");
+    await page.getByRole("button", { name: "Custom Build your own from" }).click();
 
     // expect: Form step is displayed with a 'Back' button
-    await expect(page.getByRole('heading', { name: 'Create agent' })).toBeVisible();
-    const backButton = page.getByRole('button', { name: 'Back' });
+    await expect(page.getByRole("heading", { name: "Create agent" })).toBeVisible();
+    const backButton = page.getByRole("button", { name: "Back" });
     await expect(backButton).toBeVisible();
 
     // 2. Click the 'Back' button
     await backButton.click();
 
     // expect: The user returns to the 'Choose path' step showing 'Recruit' and 'Custom' cards
-    await expect(page.getByRole('heading', { name: 'New agent' })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Recruit/ })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Custom/ })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "New agent" })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Recruit/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Custom/ })).toBeVisible();
   });
 });

--- a/tests/agents/agents-new-button.spec.ts
+++ b/tests/agents/agents-new-button.spec.ts
@@ -1,26 +1,26 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.4 'New agent' button navigates to agent creation page
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
+test.describe("Agents Page", () => {
   test("'New agent' button navigates to agent creation page", async ({ page }) => {
     // 1. Sign in, navigate to /agents, and click the 'New agent' button
     await signUpAndGetBoard(page, `agents_newbtn_${Date.now()}@example.com`);
-    await page.goto('/agents');
+    await page.goto("/agents");
 
-    await expect(page.getByRole('link', { name: 'New agent' })).toBeVisible();
-    await page.getByRole('link', { name: 'New agent' }).click();
+    await expect(page.getByRole("link", { name: "New agent" })).toBeVisible();
+    await page.getByRole("link", { name: "New agent" }).click();
 
     // expect: The browser navigates to /agents/new
     await expect(page).toHaveURL(/\/agents\/new/);
 
     // expect: The AgentNewPage is displayed with the 'New agent' heading
-    await expect(page.getByRole('heading', { name: 'New agent' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "New agent" })).toBeVisible();
 
     // expect: 'Recruit' and 'Custom' option cards are shown
-    await expect(page.getByRole('button', { name: /Recruit/ })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Custom/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Recruit/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Custom/ })).toBeVisible();
   });
 });

--- a/tests/agents/agents-new-custom.spec.ts
+++ b/tests/agents/agents-new-custom.spec.ts
@@ -1,42 +1,42 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.5 Agent creation — choose 'Custom' path goes to form
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
+test.describe("Agents Page", () => {
   test("Agent creation — choose 'Custom' path goes to form", async ({ page }) => {
     // 1. Sign in and navigate to /agents/new
     await signUpAndGetBoard(page, `agents_custom_${Date.now()}@example.com`);
-    await page.goto('/agents/new');
+    await page.goto("/agents/new");
 
     // expect: The 'Choose path' step is displayed with 'Recruit' and 'Custom' cards
-    await expect(page.getByRole('button', { name: /Recruit/ })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Custom/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Recruit/ })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Custom/ })).toBeVisible();
 
     // 2. Click the 'Custom' card
-    await page.getByRole('button', { name: 'Custom Build your own from' }).click();
+    await page.getByRole("button", { name: "Custom Build your own from" }).click();
 
     // expect: The form step is displayed with the heading 'Create agent'
-    await expect(page.getByRole('heading', { name: 'Create agent' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Create agent" })).toBeVisible();
 
     // expect: Identity fieldset with Name, Role, Bio, Soul inputs is visible
-    await expect(page.getByRole('group', { name: 'Identity' })).toBeVisible();
-    await expect(page.getByRole('textbox', { name: 'Name' })).toBeVisible();
-    await expect(page.getByRole('textbox', { name: 'Role' })).toBeVisible();
-    await expect(page.getByRole('textbox', { name: 'Bio' })).toBeVisible();
-    await expect(page.getByRole('textbox', { name: 'Soul' })).toBeVisible();
+    await expect(page.getByRole("group", { name: "Identity" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Name" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Role" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Bio" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Soul" })).toBeVisible();
 
     // expect: Runtime fieldset with Runtime dropdown and Model input is visible
-    await expect(page.getByRole('group', { name: 'Runtime' })).toBeVisible();
-    await expect(page.getByRole('textbox', { name: 'Model' })).toBeVisible();
+    await expect(page.getByRole("group", { name: "Runtime" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Model" })).toBeVisible();
 
     // expect: Workflow fieldset with 'Handoff to' and 'Skills' fields is visible
-    await expect(page.getByRole('group', { name: 'Workflow' })).toBeVisible();
-    await expect(page.getByRole('textbox', { name: 'Type a skill and press Enter' })).toBeVisible();
+    await expect(page.getByRole("group", { name: "Workflow" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "Type a skill and press Enter" })).toBeVisible();
 
     // expect: A live preview card is shown on the right side
-    await expect(page.getByText('Preview')).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Agent', exact: true })).toBeVisible();
+    await expect(page.getByText("Preview")).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Agent", exact: true })).toBeVisible();
   });
 });

--- a/tests/agents/agents-new-disabled-button.spec.ts
+++ b/tests/agents/agents-new-disabled-button.spec.ts
@@ -1,18 +1,18 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.7 Agent creation — 'Create agent' button disabled when name is empty
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
+test.describe("Agents Page", () => {
   test("Agent creation — 'Create agent' button disabled when name is empty", async ({ page }) => {
     // 1. Sign in, navigate to /agents/new, click 'Custom'
     await signUpAndGetBoard(page, `agents_disabled_${Date.now()}@example.com`);
-    await page.goto('/agents/new');
-    await page.getByRole('button', { name: 'Custom Build your own from' }).click();
+    await page.goto("/agents/new");
+    await page.getByRole("button", { name: "Custom Build your own from" }).click();
 
     // expect: The 'Create agent' button is visible
-    const createButton = page.getByRole('button', { name: 'Create agent' });
+    const createButton = page.getByRole("button", { name: "Create agent" });
     await expect(createButton).toBeVisible();
 
     // 2. Leave the Name field empty
@@ -20,7 +20,7 @@ test.describe('Agents Page', () => {
     await expect(createButton).toBeDisabled();
 
     // 3. Type any name in the Name field
-    await page.getByRole('textbox', { name: 'Name' }).fill('TestAgent');
+    await page.getByRole("textbox", { name: "Name" }).fill("TestAgent");
 
     // expect: The 'Create agent' button becomes enabled
     await expect(createButton).toBeEnabled();

--- a/tests/agents/agents-new-preview.spec.ts
+++ b/tests/agents/agents-new-preview.spec.ts
@@ -1,26 +1,26 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.6 Agent creation — live preview updates as name is typed
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agent creation — live preview updates as name is typed', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agent creation — live preview updates as name is typed", async ({ page }) => {
     // 1. Sign in, navigate to /agents/new, click 'Custom', and look at the preview card on the right
     await signUpAndGetBoard(page, `agents_preview_${Date.now()}@example.com`);
-    await page.goto('/agents/new');
-    await page.getByRole('button', { name: 'Custom Build your own from' }).click();
+    await page.goto("/agents/new");
+    await page.getByRole("button", { name: "Custom Build your own from" }).click();
 
     // expect: Preview shows 'Agent' as the placeholder name
-    await expect(page.getByRole('heading', { name: 'Agent', exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Agent", exact: true })).toBeVisible();
 
     // 2. Type 'Bolt' in the Name field
-    await page.getByRole('textbox', { name: 'Name' }).fill('Bolt');
+    await page.getByRole("textbox", { name: "Name" }).fill("Bolt");
 
     // expect: The preview card name updates to 'Bolt' in real time
-    await expect(page.getByRole('heading', { name: 'Bolt', exact: true })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Bolt", exact: true })).toBeVisible();
 
     // expect: The preview no longer shows 'Agent'
-    await expect(page.getByRole('heading', { name: 'Agent', exact: true })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Agent", exact: true })).not.toBeVisible();
   });
 });

--- a/tests/agents/agents-new-recruit.spec.ts
+++ b/tests/agents/agents-new-recruit.spec.ts
@@ -1,27 +1,27 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.10 Agent creation — choose 'Recruit' path shows template grid
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
+test.describe("Agents Page", () => {
   test("Agent creation — choose 'Recruit' path shows template grid", async ({ page }) => {
     // 1. Sign in, navigate to /agents/new, click the 'Recruit' card
     await signUpAndGetBoard(page, `agents_recruit_${Date.now()}@example.com`);
-    await page.goto('/agents/new');
-    await page.getByRole('button', { name: 'Recruit Choose from battle-' }).click();
+    await page.goto("/agents/new");
+    await page.getByRole("button", { name: "Recruit Choose from battle-" }).click();
 
     // expect: The 'Recruit an agent' step is shown with the heading and subtitle
-    await expect(page.getByRole('heading', { name: 'Recruit an agent' })).toBeVisible();
-    await expect(page.getByText('Select a role template to get started')).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Recruit an agent" })).toBeVisible();
+    await expect(page.getByText("Select a role template to get started")).toBeVisible();
 
     // expect: A grid of agent template cards is loaded
     // Wait for at least one template card to appear (fetched from remote)
-    await page.getByRole('button', { name: /backend-developer/i }).waitFor({ state: 'visible' });
+    await page.getByRole("button", { name: /backend-developer/i }).waitFor({ state: "visible" });
 
     // expect: Each template card shows an identicon, name, and slug badge
-    const backendCard = page.getByRole('button', { name: /Backend Developer/ });
+    const backendCard = page.getByRole("button", { name: /Backend Developer/ });
     await expect(backendCard).toBeVisible();
-    await expect(backendCard.getByText('backend-developer')).toBeVisible();
+    await expect(backendCard.getByText("backend-developer")).toBeVisible();
   });
 });

--- a/tests/agents/agents-new-skills-remove.spec.ts
+++ b/tests/agents/agents-new-skills-remove.spec.ts
@@ -1,30 +1,30 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.9 Agent creation — remove a skill tag
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agent creation — remove a skill tag', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agent creation — remove a skill tag", async ({ page }) => {
     // 1. Sign in, navigate to /agents/new, click 'Custom', add the skill 'python' using the Skills field
     await signUpAndGetBoard(page, `agents_rmskill_${Date.now()}@example.com`);
-    await page.goto('/agents/new');
-    await page.getByRole('button', { name: 'Custom Build your own from' }).click();
+    await page.goto("/agents/new");
+    await page.getByRole("button", { name: "Custom Build your own from" }).click();
 
-    const skillsInput = page.getByRole('textbox', { name: 'Type a skill and press Enter' });
+    const skillsInput = page.getByRole("textbox", { name: "Type a skill and press Enter" });
     await skillsInput.click();
-    await skillsInput.fill('python');
-    await page.keyboard.press('Enter');
+    await skillsInput.fill("python");
+    await page.keyboard.press("Enter");
 
     // expect: A 'python' skill tag is shown
-    const workflowGroup = page.getByRole('group', { name: 'Workflow' });
-    await expect(workflowGroup.getByText('python')).toBeVisible();
+    const workflowGroup = page.getByRole("group", { name: "Workflow" });
+    await expect(workflowGroup.getByText("python")).toBeVisible();
 
     // 2. Click the '×' button on the 'python' tag chip
-    await workflowGroup.getByRole('button').click();
+    await workflowGroup.getByRole("button").click();
 
     // expect: The 'python' tag is removed from the Skills field
-    await expect(workflowGroup.getByText('python')).not.toBeVisible();
+    await expect(workflowGroup.getByText("python")).not.toBeVisible();
 
     // expect: The skills input placeholder is visible again
     await expect(skillsInput).toBeVisible();

--- a/tests/agents/agents-new-skills-tag.spec.ts
+++ b/tests/agents/agents-new-skills-tag.spec.ts
@@ -1,41 +1,45 @@
 // spec: specs/agent-kanban.plan.md
 // section: 7.8 Agent creation — add a skill tag with Enter key
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Agents Page', () => {
-  test('Agent creation — add a skill tag with Enter key', async ({ page }) => {
+test.describe("Agents Page", () => {
+  test("Agent creation — add a skill tag with Enter key", async ({ page }) => {
     // 1. Sign in, navigate to /agents/new, click 'Custom', scroll to the Skills field in the Workflow section
     await signUpAndGetBoard(page, `agents_skills_${Date.now()}@example.com`);
-    await page.goto('/agents/new');
-    await page.getByRole('button', { name: 'Custom Build your own from' }).click();
+    await page.goto("/agents/new");
+    await page.getByRole("button", { name: "Custom Build your own from" }).click();
 
     // expect: Skills tag input is visible with placeholder text
-    const workflowGroup = page.getByRole('group', { name: 'Workflow' });
-    const skillsInput = workflowGroup.getByRole('textbox', { name: 'Type a skill and press Enter' });
+    const workflowGroup = page.getByRole("group", { name: "Workflow" });
+    const skillsInput = workflowGroup.getByRole("textbox", {
+      name: "Type a skill and press Enter",
+    });
     await expect(skillsInput).toBeVisible();
 
     // 2. Click the Skills field, type 'typescript', and press Enter
     await skillsInput.click();
-    await skillsInput.fill('typescript');
-    await page.keyboard.press('Enter');
+    await skillsInput.fill("typescript");
+    await page.keyboard.press("Enter");
 
     // expect: A 'typescript' tag chip appears in the input
-    await expect(workflowGroup.getByText('typescript')).toBeVisible();
+    await expect(workflowGroup.getByText("typescript")).toBeVisible();
 
     // expect: The text input clears for the next entry
     // After a tag is added, the placeholder is hidden but the input is still present
-    const skillsInputAfterFirstTag = workflowGroup.locator('input[type="text"], input:not([type])').last();
-    await expect(skillsInputAfterFirstTag).toHaveValue('');
+    const skillsInputAfterFirstTag = workflowGroup
+      .locator('input[type="text"], input:not([type])')
+      .last();
+    await expect(skillsInputAfterFirstTag).toHaveValue("");
 
     // 3. Type 'react' and press Enter
-    await skillsInputAfterFirstTag.fill('react');
-    await page.keyboard.press('Enter');
+    await skillsInputAfterFirstTag.fill("react");
+    await page.keyboard.press("Enter");
 
     // expect: A 'react' tag chip also appears
     // expect: Two skill tags are now visible: 'typescript' and 'react'
-    await expect(workflowGroup.getByText('typescript')).toBeVisible();
-    await expect(workflowGroup.getByText('react')).toBeVisible();
+    await expect(workflowGroup.getByText("typescript")).toBeVisible();
+    await expect(workflowGroup.getByText("react")).toBeVisible();
   });
 });

--- a/tests/auth/auth-callback-loading.spec.ts
+++ b/tests/auth/auth-callback-loading.spec.ts
@@ -1,20 +1,20 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.12 Auth callback page shows loading state
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
+test.describe("Authentication", () => {
   // fixme: The AuthCallbackPage renders 'Signing in...' only transiently — the getSession()
   // call resolves almost immediately and redirects away before the text can be asserted.
   // The loading state is real but not reliably catchable in an automated test without
   // intercepting the network to delay the session request.
-  test.fixme('Auth callback page shows loading state', async ({ page }) => {
+  test.fixme("Auth callback page shows loading state", async ({ page }) => {
     // 1. Navigate directly to /auth/callback
-    await page.goto('/auth/callback');
+    await page.goto("/auth/callback");
 
     // expect: The page shows the text 'Signing in...' centered on screen
     // The AuthCallbackPage renders 'Signing in...' while session is being resolved
-    await expect(page.getByText('Signing in...')).toBeVisible();
+    await expect(page.getByText("Signing in...")).toBeVisible();
 
     // 2. Wait for the session resolution to complete
     // expect: The user is redirected either to '/' (valid session) or back to '/auth' (no session)

--- a/tests/auth/auth-error-clears-on-mode-switch.spec.ts
+++ b/tests/auth/auth-error-clears-on-mode-switch.spec.ts
@@ -1,31 +1,31 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.11 Error is cleared when switching auth modes
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
-  test('Error is cleared when switching auth modes', async ({ page }) => {
+test.describe("Authentication", () => {
+  test("Error is cleared when switching auth modes", async ({ page }) => {
     // 1. Navigate to /auth
-    await page.goto('/auth');
+    await page.goto("/auth");
 
     // expect: Sign-in form is displayed
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
 
     // 2. Attempt to sign in with 'bad@example.com' and 'badpassword' to produce an error message
-    await page.locator('input[type="email"]').fill('bad@example.com');
-    await page.locator('input[type="password"]').fill('badpassword');
-    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.locator('input[type="email"]').fill("bad@example.com");
+    await page.locator('input[type="password"]').fill("badpassword");
+    await page.getByRole("button", { name: "Sign In" }).click();
 
     // expect: An error message is displayed in the form
-    await expect(page.locator('p.text-error')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator("p.text-error")).toBeVisible({ timeout: 10000 });
 
     // 3. Click the 'Sign up' toggle link to switch to sign-up mode
-    await page.getByRole('button', { name: 'Sign up' }).click();
+    await page.getByRole("button", { name: "Sign up" }).click();
 
     // expect: The error message is no longer visible (setError(null) is called on mode switch)
-    await expect(page.locator('p.text-error')).not.toBeVisible();
+    await expect(page.locator("p.text-error")).not.toBeVisible();
 
     // Confirm we are now in sign-up mode
-    await expect(page.getByText('Create a new account')).toBeVisible();
+    await expect(page.getByText("Create a new account")).toBeVisible();
   });
 });

--- a/tests/auth/auth-github-oauth-button.spec.ts
+++ b/tests/auth/auth-github-oauth-button.spec.ts
@@ -1,19 +1,19 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.10 GitHub OAuth button is present and interactive
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
-  test('GitHub OAuth button is present and interactive', async ({ page }) => {
+test.describe("Authentication", () => {
+  test("GitHub OAuth button is present and interactive", async ({ page }) => {
     // 1. Navigate to /auth
-    await page.goto('/auth');
+    await page.goto("/auth");
 
     // expect: The 'Continue with GitHub' button is visible with the GitHub SVG icon
-    const githubButton = page.getByRole('button', { name: 'Continue with GitHub' });
+    const githubButton = page.getByRole("button", { name: "Continue with GitHub" });
     await expect(githubButton).toBeVisible();
 
     // expect: The button contains the GitHub SVG icon
-    await expect(githubButton.locator('svg')).toBeVisible();
+    await expect(githubButton.locator("svg")).toBeVisible();
 
     // 2. Observe the button — it is clickable (not disabled)
     // expect: The button is not disabled

--- a/tests/auth/auth-mode-toggle.spec.ts
+++ b/tests/auth/auth-mode-toggle.spec.ts
@@ -1,43 +1,43 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.2 Switch between sign-in and sign-up modes
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
-  test('Switch between sign-in and sign-up modes', async ({ page }) => {
+test.describe("Authentication", () => {
+  test("Switch between sign-in and sign-up modes", async ({ page }) => {
     // 1. Navigate to /auth
-    await page.goto('/auth');
+    await page.goto("/auth");
 
     // expect: Page is in sign-in mode, subtitle reads 'Sign in to your account'
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
 
     // 2. Click the 'Sign up' toggle link at the bottom of the form
-    await page.getByRole('button', { name: 'Sign up' }).click();
+    await page.getByRole("button", { name: "Sign up" }).click();
 
     // expect: The form switches to sign-up mode
     // expect: Subtitle changes to 'Create a new account'
-    await expect(page.getByText('Create a new account')).toBeVisible();
+    await expect(page.getByText("Create a new account")).toBeVisible();
 
     // expect: A 'Name' input field appears above the email field
     await expect(page.locator('input[placeholder="Name"]')).toBeVisible();
 
     // expect: The submit button label changes to 'Sign Up'
-    await expect(page.getByRole('button', { name: 'Sign Up' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign Up" })).toBeVisible();
 
     // expect: The toggle link at the bottom changes to 'Sign in'
-    await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
 
     // 3. Click the 'Sign in' toggle link at the bottom
-    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.getByRole("button", { name: "Sign in" }).click();
 
     // expect: The form switches back to sign-in mode
     // expect: The Name field disappears
     await expect(page.locator('input[placeholder="Name"]')).not.toBeVisible();
 
     // expect: Subtitle returns to 'Sign in to your account'
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
 
     // expect: Submit button label returns to 'Sign In'
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
   });
 });

--- a/tests/auth/auth-page-default-state.spec.ts
+++ b/tests/auth/auth-page-default-state.spec.ts
@@ -1,19 +1,19 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.1 Auth page renders sign-in form by default
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
-  test('Auth page renders sign-in form by default', async ({ page }) => {
+test.describe("Authentication", () => {
+  test("Auth page renders sign-in form by default", async ({ page }) => {
     // 1. Navigate to /auth
-    await page.goto('/auth');
+    await page.goto("/auth");
 
     // expect: The page title 'Agent Kanban' is visible with 'Kanban' in accent color
-    await expect(page.getByRole('heading', { name: /Agent\s+Kanban/i })).toBeVisible();
-    await expect(page.locator('h1 span.text-accent')).toHaveText('Kanban');
+    await expect(page.getByRole("heading", { name: /Agent\s+Kanban/i })).toBeVisible();
+    await expect(page.locator("h1 span.text-accent")).toHaveText("Kanban");
 
     // expect: The subtitle 'Sign in to your account' is visible
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
 
     // expect: An email input field is present
     await expect(page.locator('input[type="email"]')).toBeVisible();
@@ -22,13 +22,13 @@ test.describe('Authentication', () => {
     await expect(page.locator('input[type="password"]')).toBeVisible();
 
     // expect: A 'Sign In' submit button is visible
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
 
     // expect: A 'Continue with GitHub' button is visible
-    await expect(page.getByRole('button', { name: 'Continue with GitHub' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Continue with GitHub" })).toBeVisible();
 
     // expect: A 'Sign up' toggle link is visible
-    await expect(page.getByRole('button', { name: 'Sign up' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign up" })).toBeVisible();
 
     // expect: The Name field is NOT present (sign-up only field)
     await expect(page.locator('input[placeholder="Name"]')).not.toBeVisible();

--- a/tests/auth/auth-signin-empty-validation.spec.ts
+++ b/tests/auth/auth-signin-empty-validation.spec.ts
@@ -1,18 +1,18 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.3 Sign-in form validation — empty fields
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
-  test('Sign-in form validation — empty fields', async ({ page }) => {
+test.describe("Authentication", () => {
+  test("Sign-in form validation — empty fields", async ({ page }) => {
     // 1. Navigate to /auth
-    await page.goto('/auth');
+    await page.goto("/auth");
 
     // expect: Sign-in form is displayed
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
 
     // 2. Click the 'Sign In' button without entering any credentials
-    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.getByRole("button", { name: "Sign In" }).click();
 
     // expect: The form does not submit
     // expect: Browser native validation prevents submission (email field is required)
@@ -23,6 +23,6 @@ test.describe('Authentication', () => {
     const emailInput = page.locator('input[type="email"]');
     await expect(emailInput).toBeVisible();
     // Native validation: the form is not submitted when required fields are empty
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
   });
 });

--- a/tests/auth/auth-signin-invalid-email.spec.ts
+++ b/tests/auth/auth-signin-invalid-email.spec.ts
@@ -1,26 +1,26 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.4 Sign-in form validation — invalid email format
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
-  test('Sign-in form validation — invalid email format', async ({ page }) => {
+test.describe("Authentication", () => {
+  test("Sign-in form validation — invalid email format", async ({ page }) => {
     // 1. Navigate to /auth
-    await page.goto('/auth');
+    await page.goto("/auth");
 
     // expect: Sign-in form is displayed
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
 
     // 2. Type 'notanemail' into the email field and 'password123' into the password field
-    await page.locator('input[type="email"]').fill('notanemail');
-    await page.locator('input[type="password"]').fill('password123');
+    await page.locator('input[type="email"]').fill("notanemail");
+    await page.locator('input[type="password"]').fill("password123");
 
     // Click 'Sign In'
-    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.getByRole("button", { name: "Sign In" }).click();
 
     // expect: The form does not submit (browser native email validation blocks it)
     // expect: Page remains on /auth
     await expect(page).toHaveURL(/\/auth/);
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
   });
 });

--- a/tests/auth/auth-signin-loading-state.spec.ts
+++ b/tests/auth/auth-signin-loading-state.spec.ts
@@ -1,32 +1,34 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.9 Loading state is displayed during sign-in submission
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
-  test('Loading state is displayed during sign-in submission', async ({ page }) => {
+test.describe("Authentication", () => {
+  test("Loading state is displayed during sign-in submission", async ({ page }) => {
     // 1. Navigate to /auth
-    await page.goto('/auth');
+    await page.goto("/auth");
 
     // expect: Sign-in form is displayed with the 'Sign In' button
-    const submitButton = page.getByRole('button', { name: /Sign In|\.\.\./ });
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    const submitButton = page.getByRole("button", { name: /Sign In|\.\.\./ });
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
 
     // 2. Enter any email and password, then click 'Sign In'
-    await page.locator('input[type="email"]').fill('test@example.com');
-    await page.locator('input[type="password"]').fill('testpassword');
+    await page.locator('input[type="email"]').fill("test@example.com");
+    await page.locator('input[type="password"]').fill("testpassword");
 
     // expect: The submit button immediately changes its text to '...' and becomes disabled
-    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.getByRole("button", { name: "Sign In" }).click();
 
     // The button should show '...' while the request is in flight
     // and then return to 'Sign In' or show an error once resolved
-    await expect(submitButton).toHaveText('...').catch(async () => {
-      // If we missed the loading state (too fast), the button should be back to 'Sign In'
-      await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
-    });
+    await expect(submitButton)
+      .toHaveText("...")
+      .catch(async () => {
+        // If we missed the loading state (too fast), the button should be back to 'Sign In'
+        await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+      });
 
     // expect: The button re-enables once the response arrives
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeEnabled({ timeout: 10000 });
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeEnabled({ timeout: 10000 });
   });
 });

--- a/tests/auth/auth-signin-wrong-credentials.spec.ts
+++ b/tests/auth/auth-signin-wrong-credentials.spec.ts
@@ -1,32 +1,32 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.5 Sign-in with wrong credentials shows error
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
-  test('Sign-in with wrong credentials shows error', async ({ page }) => {
+test.describe("Authentication", () => {
+  test("Sign-in with wrong credentials shows error", async ({ page }) => {
     // 1. Navigate to /auth
-    await page.goto('/auth');
+    await page.goto("/auth");
 
     // expect: Sign-in form is displayed
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
 
     // 2. Enter 'wrong@example.com' in the email field and 'wrongpassword' in the password field
-    await page.locator('input[type="email"]').fill('wrong@example.com');
-    await page.locator('input[type="password"]').fill('wrongpassword');
+    await page.locator('input[type="email"]').fill("wrong@example.com");
+    await page.locator('input[type="password"]').fill("wrongpassword");
 
     // 3. Click the 'Sign In' button
-    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.getByRole("button", { name: "Sign In" }).click();
 
     // expect: The submit button changes to '...' during loading, then returns
     // expect: An error message is displayed (styled with text-error class)
-    await expect(page.locator('p.text-error')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator("p.text-error")).toBeVisible({ timeout: 10000 });
 
     // expect: The user remains on the /auth page
     await expect(page).toHaveURL(/\/auth/);
 
     // expect: The submit button returns from loading state back to 'Sign In'
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeEnabled();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeEnabled();
   });
 });

--- a/tests/auth/auth-signup-duplicate-email.spec.ts
+++ b/tests/auth/auth-signup-duplicate-email.spec.ts
@@ -1,45 +1,45 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.8 Sign-up with existing email shows error
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
-  test('Sign-up with existing email shows error', async ({ page }) => {
+test.describe("Authentication", () => {
+  test("Sign-up with existing email shows error", async ({ page }) => {
     // Use a unique email per test run so the first sign-up always succeeds
     const uniqueEmail = `duplicate-test-${Date.now()}@example.com`;
-    const password = 'validpassword123';
+    const password = "validpassword123";
 
     // --- Step 1: Register the email for the first time ---
-    await page.goto('/auth');
-    await page.getByRole('button', { name: 'Sign up' }).click();
-    await expect(page.getByText('Create a new account')).toBeVisible();
+    await page.goto("/auth");
+    await page.getByRole("button", { name: "Sign up" }).click();
+    await expect(page.getByText("Create a new account")).toBeVisible();
 
-    await page.locator('input[placeholder="Name"]').fill('First User');
+    await page.locator('input[placeholder="Name"]').fill("First User");
     await page.locator('input[type="email"]').fill(uniqueEmail);
     await page.locator('input[type="password"]').fill(password);
-    await page.getByRole('button', { name: 'Sign Up' }).click();
+    await page.getByRole("button", { name: "Sign Up" }).click();
 
     // Wait for first registration to succeed and navigate away from /auth
-    await page.waitForURL('**/*', { timeout: 10000 });
+    await page.waitForURL("**/*", { timeout: 10000 });
 
     // Clear session so we can return to /auth as unauthenticated
     await page.context().clearCookies();
-    await page.goto('/auth');
+    await page.goto("/auth");
 
     // --- Step 2: Switch to sign-up mode for the duplicate attempt ---
-    await page.getByRole('button', { name: 'Sign up' }).click();
+    await page.getByRole("button", { name: "Sign up" }).click();
 
     // expect: Sign-up form is displayed
-    await expect(page.getByText('Create a new account')).toBeVisible();
+    await expect(page.getByText("Create a new account")).toBeVisible();
 
     // --- Step 3: Enter the same email again to trigger duplicate error ---
-    await page.locator('input[placeholder="Name"]').fill('Existing User');
+    await page.locator('input[placeholder="Name"]').fill("Existing User");
     await page.locator('input[type="email"]').fill(uniqueEmail);
     await page.locator('input[type="password"]').fill(password);
-    await page.getByRole('button', { name: 'Sign Up' }).click();
+    await page.getByRole("button", { name: "Sign Up" }).click();
 
     // expect: An error message is displayed indicating the email is already in use or sign-up failed
-    await expect(page.locator('p.text-error')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator("p.text-error")).toBeVisible({ timeout: 10000 });
 
     // expect: The user remains on the /auth page
     await expect(page).toHaveURL(/\/auth/);

--- a/tests/auth/auth-signup-empty-name.spec.ts
+++ b/tests/auth/auth-signup-empty-name.spec.ts
@@ -1,27 +1,27 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.7 Sign-up form validation — empty name field
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
-  test('Sign-up form validation — empty name field', async ({ page }) => {
+test.describe("Authentication", () => {
+  test("Sign-up form validation — empty name field", async ({ page }) => {
     // 1. Navigate to /auth and switch to sign-up mode
-    await page.goto('/auth');
-    await page.getByRole('button', { name: 'Sign up' }).click();
+    await page.goto("/auth");
+    await page.getByRole("button", { name: "Sign up" }).click();
 
     // expect: Sign-up form is displayed
-    await expect(page.getByText('Create a new account')).toBeVisible();
+    await expect(page.getByText("Create a new account")).toBeVisible();
 
     // 2. Leave Name blank, enter 'test@example.com' in Email and 'validpassword' in Password
-    await page.locator('input[type="email"]').fill('test@example.com');
-    await page.locator('input[type="password"]').fill('validpassword');
+    await page.locator('input[type="email"]').fill("test@example.com");
+    await page.locator('input[type="password"]').fill("validpassword");
 
     // Click 'Sign Up'
-    await page.getByRole('button', { name: 'Sign Up' }).click();
+    await page.getByRole("button", { name: "Sign Up" }).click();
 
     // expect: The form does not submit because the Name field is required
     // expect: Browser native validation prevents the action
     await expect(page).toHaveURL(/\/auth/);
-    await expect(page.getByText('Create a new account')).toBeVisible();
+    await expect(page.getByText("Create a new account")).toBeVisible();
   });
 });

--- a/tests/auth/auth-signup-password-minlength.spec.ts
+++ b/tests/auth/auth-signup-password-minlength.spec.ts
@@ -1,13 +1,13 @@
 // spec: specs/agent-kanban.plan.md
 // section: 1.6 Sign-up form validation — password minimum length
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Authentication', () => {
-  test('Sign-up form validation — password minimum length', async ({ page }) => {
+test.describe("Authentication", () => {
+  test("Sign-up form validation — password minimum length", async ({ page }) => {
     // 1. Navigate to /auth and click the 'Sign up' link to switch to sign-up mode
-    await page.goto('/auth');
-    await page.getByRole('button', { name: 'Sign up' }).click();
+    await page.goto("/auth");
+    await page.getByRole("button", { name: "Sign up" }).click();
 
     // expect: Sign-up form is displayed with Name, Email, and Password fields
     await expect(page.locator('input[placeholder="Name"]')).toBeVisible();
@@ -15,14 +15,14 @@ test.describe('Authentication', () => {
     await expect(page.locator('input[type="password"]')).toBeVisible();
 
     // 2. Enter 'Test User' in Name, 'test@example.com' in Email, 'short' in Password, then click 'Sign Up'
-    await page.locator('input[placeholder="Name"]').fill('Test User');
-    await page.locator('input[type="email"]').fill('test@example.com');
-    await page.locator('input[type="password"]').fill('short');
-    await page.getByRole('button', { name: 'Sign Up' }).click();
+    await page.locator('input[placeholder="Name"]').fill("Test User");
+    await page.locator('input[type="email"]').fill("test@example.com");
+    await page.locator('input[type="password"]').fill("short");
+    await page.getByRole("button", { name: "Sign Up" }).click();
 
     // expect: The form does not submit
     // expect: Browser native minlength validation fires (password has minLength=8)
     await expect(page).toHaveURL(/\/auth/);
-    await expect(page.getByText('Create a new account')).toBeVisible();
+    await expect(page.getByText("Create a new account")).toBeVisible();
   });
 });

--- a/tests/board-repo.test.ts
+++ b/tests/board-repo.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
-import { createTestEnv, setupMiniflare, seedUser } from "./helpers/db";
+
+import type { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestEnv, seedUser, setupMiniflare } from "./helpers/db";
 
 const env = createTestEnv();
 let mf: Miniflare;
@@ -71,8 +72,15 @@ describe("boardRepo", () => {
     const { createBoard, getBoard } = await import("../apps/web/functions/api/boardRepo");
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     const board = await createBoard(env.DB, "board-test-user", "Blocked Board");
-    const taskA = await createTask(env.DB, "board-test-user", { title: "Task A", board_id: board.id });
-    await createTask(env.DB, "board-test-user", { title: "Task B", board_id: board.id, depends_on: [taskA.id] });
+    const taskA = await createTask(env.DB, "board-test-user", {
+      title: "Task A",
+      board_id: board.id,
+    });
+    await createTask(env.DB, "board-test-user", {
+      title: "Task B",
+      board_id: board.id,
+      depends_on: [taskA.id],
+    });
     const result = await getBoard(env.DB, board.id);
     const taskB = result!.tasks.find((t: any) => t.title === "Task B");
     expect(taskB!.blocked).toBe(true);
@@ -108,7 +116,10 @@ describe("boardRepo", () => {
   it("updateBoard updates both name and description", async () => {
     const { createBoard, updateBoard } = await import("../apps/web/functions/api/boardRepo");
     const board = await createBoard(env.DB, "board-test-user", "Update Both Board");
-    const updated = await updateBoard(env.DB, board.id, { name: "Both Name", description: "Both Desc" });
+    const updated = await updateBoard(env.DB, board.id, {
+      name: "Both Name",
+      description: "Both Desc",
+    });
     expect(updated!.name).toBe("Both Name");
     expect(updated!.description).toBe("Both Desc");
   });
@@ -127,7 +138,9 @@ describe("boardRepo", () => {
   });
 
   it("deleteBoard removes a board", async () => {
-    const { createBoard, deleteBoard, getBoard } = await import("../apps/web/functions/api/boardRepo");
+    const { createBoard, deleteBoard, getBoard } = await import(
+      "../apps/web/functions/api/boardRepo"
+    );
     const board = await createBoard(env.DB, "board-test-user", "Delete Board");
     const deleted = await deleteBoard(env.DB, board.id);
     expect(deleted).toBe(true);

--- a/tests/board/board-five-columns.spec.ts
+++ b/tests/board/board-five-columns.spec.ts
@@ -1,11 +1,11 @@
 // spec: specs/agent-kanban.plan.md
 // section: 3.1 Board page renders five kanban columns
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Board Page', () => {
-  test('Board page renders five kanban columns', async ({ page }) => {
+test.describe("Board Page", () => {
+  test("Board page renders five kanban columns", async ({ page }) => {
     // 1. Sign in with valid credentials and navigate to a board at /boards/:boardId
     await signUpAndGetBoard(page, `boardcolumns_${Date.now()}@example.com`);
 
@@ -14,23 +14,23 @@ test.describe('Board Page', () => {
 
     // expect: Five columns are visible: Todo, In Progress, In Review, Done, Cancelled
     // Desktop view - columns are visible in the hidden.md:grid container
-    const columnGrid = page.locator('.hidden.md\\:grid');
+    const columnGrid = page.locator(".hidden.md\\:grid");
     await expect(columnGrid).toBeVisible();
 
     // Column headers are inside the desktop grid
-    await expect(columnGrid.getByText('Todo')).toBeVisible();
-    await expect(columnGrid.getByText('In Progress')).toBeVisible();
-    await expect(columnGrid.getByText('In Review')).toBeVisible();
-    await expect(columnGrid.getByText('Done')).toBeVisible();
-    await expect(columnGrid.getByText('Cancelled')).toBeVisible();
+    await expect(columnGrid.getByText("Todo")).toBeVisible();
+    await expect(columnGrid.getByText("In Progress")).toBeVisible();
+    await expect(columnGrid.getByText("In Review")).toBeVisible();
+    await expect(columnGrid.getByText("Done")).toBeVisible();
+    await expect(columnGrid.getByText("Cancelled")).toBeVisible();
 
     // Five column dividers should be present
-    const columns = columnGrid.locator('> div');
+    const columns = columnGrid.locator("> div");
     await expect(columns).toHaveCount(5);
 
     // Each column header has a task count badge (span directly in the column header row)
     // Column header structure: flex items-center justify-between > span.font-mono.text-[11px]
-    const countBadges = columnGrid.locator('> div > div.flex > span.font-mono');
+    const countBadges = columnGrid.locator("> div > div.flex > span.font-mono");
     await expect(countBadges).toHaveCount(5);
   });
 });

--- a/tests/board/board-loading-state.spec.ts
+++ b/tests/board/board-loading-state.spec.ts
@@ -1,11 +1,11 @@
 // spec: specs/agent-kanban.plan.md
 // section: 3.13 Board shows loading skeleton while data is fetching
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Board Page', () => {
-  test('Board shows loading skeleton while data is fetching', async ({ page }) => {
+test.describe("Board Page", () => {
+  test("Board shows loading skeleton while data is fetching", async ({ page }) => {
     // Sign in first to get a valid session and board ID
     await signUpAndGetBoard(page, `boardloading_${Date.now()}@example.com`);
 
@@ -13,7 +13,7 @@ test.describe('Board Page', () => {
     const boardUrl = page.url();
 
     // 1. Navigate to a board URL with network throttled to simulate slow loading
-    await page.route('**/api/boards/**', async (route) => {
+    await page.route("**/api/boards/**", async (route) => {
       await new Promise((resolve) => setTimeout(resolve, 1500));
       await route.continue();
     });
@@ -21,15 +21,15 @@ test.describe('Board Page', () => {
     await page.goto(boardUrl);
 
     // expect: Pulse-animated skeleton placeholders are shown before real data arrives
-    const skeletons = page.locator('.animate-pulse');
+    const skeletons = page.locator(".animate-pulse");
     await expect(skeletons.first()).toBeVisible();
 
     // expect: Once data loads, the skeleton is replaced by actual content
     await expect(skeletons.first()).not.toBeVisible({ timeout: 10000 });
 
     // expect: The board columns appear after data loads
-    const columnGrid = page.locator('.hidden.md\\:grid');
+    const columnGrid = page.locator(".hidden.md\\:grid");
     await expect(columnGrid).toBeVisible();
-    await expect(columnGrid.getByText('Todo')).toBeVisible();
+    await expect(columnGrid.getByText("Todo")).toBeVisible();
   });
 });

--- a/tests/board/board-no-task-creation.spec.ts
+++ b/tests/board/board-no-task-creation.spec.ts
@@ -1,17 +1,17 @@
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Board Page', () => {
-  test('Board columns have no task creation UI', async ({ page }) => {
+test.describe("Board Page", () => {
+  test("Board columns have no task creation UI", async ({ page }) => {
     await signUpAndGetBoard(page, `notaskcreate_${Date.now()}@example.com`);
 
     // expect: Board is loaded with columns
-    const columnGrid = page.locator('.hidden.md\\:grid');
+    const columnGrid = page.locator(".hidden.md\\:grid");
     await expect(columnGrid).toBeVisible();
-    await expect(columnGrid.getByText('Todo')).toBeVisible();
+    await expect(columnGrid.getByText("Todo")).toBeVisible();
 
     // expect: No "+ Task" button anywhere on the board
-    await expect(page.getByRole('button', { name: '+ Task' })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "+ Task" })).not.toBeVisible();
 
     // expect: No task creation input field
     await expect(page.locator('input[placeholder="Task title..."]')).not.toBeVisible();

--- a/tests/board/board-onboarding-flow.spec.ts
+++ b/tests/board/board-onboarding-flow.spec.ts
@@ -1,38 +1,38 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Board Page', () => {
-  test('Onboarding flow — 2 steps: create board then add machine', async ({ page }) => {
-    await page.goto('/auth');
-    await page.getByRole('button', { name: 'Sign up' }).click();
-    await page.locator('input[placeholder="Name"]').fill('New User');
+test.describe("Board Page", () => {
+  test("Onboarding flow — 2 steps: create board then add machine", async ({ page }) => {
+    await page.goto("/auth");
+    await page.getByRole("button", { name: "Sign up" }).click();
+    await page.locator('input[placeholder="Name"]').fill("New User");
     await page.locator('input[type="email"]').fill(`onboarding_${Date.now()}@example.com`);
-    await page.locator('input[type="password"]').fill('password123');
-    await page.getByRole('button', { name: 'Sign Up' }).click();
+    await page.locator('input[type="password"]').fill("password123");
+    await page.getByRole("button", { name: "Sign Up" }).click();
 
     await page.waitForURL(/\/boards\/_new/);
 
     // expect: Onboarding heading and tagline
-    await expect(page.getByRole('heading', { name: 'Agent Kanban' })).toBeVisible();
-    await expect(page.getByText('Your AI workforce starts here.')).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Agent Kanban" })).toBeVisible();
+    await expect(page.getByText("Your AI workforce starts here.")).toBeVisible();
 
     // expect: 2 step indicators (not 3)
-    const dots = page.locator('.rounded-full.w-2.h-2');
+    const dots = page.locator(".rounded-full.w-2.h-2");
     await expect(dots).toHaveCount(2);
 
     // expect: Board name input pre-filled with "My Board"
-    const boardNameInput = page.getByRole('textbox');
-    await expect(boardNameInput).toHaveValue('My Board');
+    const boardNameInput = page.getByRole("textbox");
+    await expect(boardNameInput).toHaveValue("My Board");
 
     // Create board
     await boardNameInput.clear();
-    await boardNameInput.fill('Sprint 1');
-    await page.getByRole('button', { name: 'Create Board' }).click();
+    await boardNameInput.fill("Sprint 1");
+    await page.getByRole("button", { name: "Create Board" }).click();
 
     // expect: Advances directly to Add Machine step (no "Create Task" step)
-    await expect(page.getByText('Waiting for connection...')).toBeVisible();
+    await expect(page.getByText("Waiting for connection...")).toBeVisible();
     await expect(page.getByText(/npx|ak start|install/i)).toBeVisible();
 
     // expect: No "Create Task" button anywhere
-    await expect(page.getByRole('button', { name: 'Create Task' })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Create Task" })).not.toBeVisible();
   });
 });

--- a/tests/board/board-task-review-actions.spec.ts
+++ b/tests/board/board-task-review-actions.spec.ts
@@ -1,22 +1,23 @@
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Board Page', () => {
-  test('Task detail shows only reject/complete in review state', async ({ page }) => {
+test.describe("Board Page", () => {
+  test("Task detail shows only reject/complete in review state", async ({ page }) => {
     await signUpAndGetBoard(page, `reviewactions_${Date.now()}@example.com`);
 
     // Create a task via API and move it to in_review status
     const taskTitle = `Review Task ${Date.now()}`;
-    const taskId = await page.evaluate(async (title) => {
-      const token = localStorage.getItem('auth-token');
-      const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
+    const _taskId = await page.evaluate(async (title) => {
+      const token = localStorage.getItem("auth-token");
+      const headers = { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
 
       // Create task
-      const createRes = await fetch('/api/tasks', {
-        method: 'POST', headers,
+      const createRes = await fetch("/api/tasks", {
+        method: "POST",
+        headers,
         body: JSON.stringify({ title }),
       });
-      const task = await createRes.json() as { id: string };
+      const task = (await createRes.json()) as { id: string };
 
       // Move to in_progress then in_review via direct DB manipulation isn't possible,
       // so use PATCH to set status indirectly — actually we need lifecycle endpoints.
@@ -28,7 +29,7 @@ test.describe('Board Page', () => {
 
     // Reload the board to see the new task
     await page.reload();
-    await expect(page.locator('.hidden.md\\:grid')).toBeVisible();
+    await expect(page.locator(".hidden.md\\:grid")).toBeVisible();
 
     // Click the task card to open detail
     await page.getByText(taskTitle).first().click();
@@ -38,16 +39,16 @@ test.describe('Board Page', () => {
     await expect(sheet).toBeVisible();
 
     // expect: In todo status, NO action buttons should be visible
-    await expect(sheet.getByRole('button', { name: 'Reject' })).not.toBeVisible();
-    await expect(sheet.getByRole('button', { name: 'Complete' })).not.toBeVisible();
-    await expect(sheet.getByRole('button', { name: 'Claim' })).not.toBeVisible();
-    await expect(sheet.getByRole('button', { name: 'Cancel' })).not.toBeVisible();
-    await expect(sheet.getByRole('button', { name: 'Release' })).not.toBeVisible();
+    await expect(sheet.getByRole("button", { name: "Reject" })).not.toBeVisible();
+    await expect(sheet.getByRole("button", { name: "Complete" })).not.toBeVisible();
+    await expect(sheet.getByRole("button", { name: "Claim" })).not.toBeVisible();
+    await expect(sheet.getByRole("button", { name: "Cancel" })).not.toBeVisible();
+    await expect(sheet.getByRole("button", { name: "Release" })).not.toBeVisible();
 
     // expect: No assign dropdown
-    await expect(sheet.getByText('Assign...')).not.toBeVisible();
+    await expect(sheet.getByText("Assign...")).not.toBeVisible();
 
     // expect: No delete button
-    await expect(sheet.getByRole('button', { name: 'Delete task' })).not.toBeVisible();
+    await expect(sheet.getByRole("button", { name: "Delete task" })).not.toBeVisible();
   });
 });

--- a/tests/builtin-agents.test.ts
+++ b/tests/builtin-agents.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
-import { readFileSync } from "fs";
-import { join } from "path";
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { BUILTIN_TEMPLATES } from "@agent-kanban/shared";
+import { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const MIGRATIONS_DIR = join(__dirname, "../apps/web/migrations");
 const AUTH_SECRET = "test-secret-32-chars-minimum-ok!!";
@@ -22,7 +23,10 @@ async function applyMigrations(db: D1Database) {
   const files = ["0001_initial.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-    for (const stmt of sql.split(";").map((s) => s.trim()).filter(Boolean)) {
+    for (const stmt of sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       await db.prepare(stmt).run();
     }
   }
@@ -30,9 +34,12 @@ async function applyMigrations(db: D1Database) {
 
 async function seedUser(db: D1Database, id: string, email: string): Promise<string> {
   const now = new Date().toISOString();
-  await db.prepare(
-    "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)"
-  ).bind(id, "Test User", email, now, now).run();
+  await db
+    .prepare(
+      "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)",
+    )
+    .bind(id, "Test User", email, now, now)
+    .run();
   return id;
 }
 

--- a/tests/cli-agent-jwt.test.ts
+++ b/tests/cli-agent-jwt.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
+
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Miniflare } from "miniflare";
-import { randomUUID } from "crypto";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 // Integration test: validates CLI AgentClient JWT passthrough with new session model
 // User creates agent → machine creates session → AgentClient uses session JWT
@@ -26,7 +27,10 @@ async function applyMigrations(db: D1Database) {
   const files = ["0001_initial.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-    for (const stmt of sql.split(";").map((s) => s.trim()).filter(Boolean)) {
+    for (const stmt of sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       await db.prepare(stmt).run();
     }
   }
@@ -35,9 +39,12 @@ async function applyMigrations(db: D1Database) {
 async function seedUser(db: D1Database): Promise<string> {
   const userId = "test-user-cli-jwt";
   const now = new Date().toISOString();
-  await db.prepare(
-    "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)"
-  ).bind(userId, "CLI JWT Test", "cli-jwt@example.com", now, now).run();
+  await db
+    .prepare(
+      "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)",
+    )
+    .bind(userId, "CLI JWT Test", "cli-jwt@example.com", now, now)
+    .run();
   return userId;
 }
 
@@ -50,8 +57,12 @@ async function createApiKeyForUser(db: D1Database, userId: string): Promise<stri
 
 async function honoRequest(method: string, path: string, body?: any, token?: string) {
   const { api } = await import("../apps/web/functions/api/routes");
-  const headers: Record<string, string> = { "Content-Type": "application/json", Host: "localhost:8788", "x-forwarded-proto": "http" };
-  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Host: "localhost:8788",
+    "x-forwarded-proto": "http",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
   const init: RequestInit = { method, headers };
   if (body) init.body = JSON.stringify(body);
   return api.request(path, init, testEnv);
@@ -75,7 +86,7 @@ afterAll(async () => {
 describe("CLI ApiClient agent JWT passthrough", () => {
   let userId: string;
   let apiKey: string;
-  let machineId: string;
+  let _machineId: string;
   let agentId: string;
   let sessionId: string;
   let boardId: string;
@@ -104,27 +115,47 @@ describe("CLI ApiClient agent JWT passthrough", () => {
     apiKey = await createApiKeyForUser(testEnv.DB, userId);
 
     // Create machine
-    const machineRes = await honoRequest("POST", "/api/machines", {
-      name: "jwt-test-machine", os: "test", version: "1.0.0", runtimes: ["claude"],
-    }, apiKey);
+    const machineRes = await honoRequest(
+      "POST",
+      "/api/machines",
+      {
+        name: "jwt-test-machine",
+        os: "test",
+        version: "1.0.0",
+        runtimes: ["claude"],
+      },
+      apiKey,
+    );
     expect(machineRes.status).toBe(201);
-    machineId = ((await machineRes.json()) as any).id;
+    _machineId = ((await machineRes.json()) as any).id;
 
     // Create persistent agent (user-only, use repo directly)
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
-    const agent = await createAgent(testEnv.DB, userId, { name: "JWT Test Agent", runtime: "claude" });
+    const agent = await createAgent(testEnv.DB, userId, {
+      name: "JWT Test Agent",
+      runtime: "claude",
+    });
     agentId = agent.id;
 
     // Create session keypair (CSR — daemon generates locally)
     sessionId = randomUUID();
-    const keypair = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, ["sign", "verify"]);
+    const keypair = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, [
+      "sign",
+      "verify",
+    ]);
     const pubJwk = await crypto.subtle.exportKey("jwk", (keypair as any).publicKey);
     sessionPrivKeyJwk = await crypto.subtle.exportKey("jwk", (keypair as any).privateKey);
 
     // Register session via API
-    const sessionRes = await honoRequest("POST", `/api/agents/${agentId}/sessions`, {
-      session_id: sessionId, session_public_key: pubJwk.x!,
-    }, apiKey);
+    const sessionRes = await honoRequest(
+      "POST",
+      `/api/agents/${agentId}/sessions`,
+      {
+        session_id: sessionId,
+        session_public_key: pubJwk.x!,
+      },
+      apiKey,
+    );
     expect(sessionRes.status).toBe(201);
 
     // Create board + task + assign
@@ -132,10 +163,18 @@ describe("CLI ApiClient agent JWT passthrough", () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     const board = await createBoard(testEnv.DB, userId, "jwt-test-board");
     boardId = board.id;
-    const task = await createTask(testEnv.DB, userId, { title: "JWT test task", board_id: boardId });
+    const task = await createTask(testEnv.DB, userId, {
+      title: "JWT test task",
+      board_id: boardId,
+    });
     taskId = task.id;
 
-    const assignRes = await honoRequest("POST", `/api/tasks/${taskId}/assign`, { agent_id: agentId }, apiKey);
+    const assignRes = await honoRequest(
+      "POST",
+      `/api/tasks/${taskId}/assign`,
+      { agent_id: agentId },
+      apiKey,
+    );
     expect(assignRes.status).toBe(200);
   });
 
@@ -153,13 +192,18 @@ describe("CLI ApiClient agent JWT passthrough", () => {
       const path = new URL(url).pathname;
       const headers = new Headers(init?.headers);
       capturedToken = headers.get("Authorization")?.replace("Bearer ", "") || null;
-      return honoRequest(init?.method || "GET", path, init?.body ? JSON.parse(init.body as string) : undefined, capturedToken!);
+      return honoRequest(
+        init?.method || "GET",
+        path,
+        init?.body ? JSON.parse(init.body as string) : undefined,
+        capturedToken!,
+      );
     });
 
     const { createClient } = await import("../packages/cli/src/client.js");
     const client = await createClient();
 
-    const claimed = await client.claimTask(taskId) as any;
+    const claimed = (await client.claimTask(taskId)) as any;
     expect(claimed.status).toBe("in_progress");
     expect(claimed.assigned_to).toBe(agentId);
     expect(capturedToken!.split(".")).toHaveLength(3);
@@ -179,18 +223,30 @@ describe("CLI ApiClient agent JWT passthrough", () => {
       const path = new URL(url).pathname;
       const headers = new Headers(init?.headers);
       capturedToken = headers.get("Authorization")?.replace("Bearer ", "") || null;
-      return honoRequest(init?.method || "GET", path, init?.body ? JSON.parse(init.body as string) : undefined, capturedToken!);
+      return honoRequest(
+        init?.method || "GET",
+        path,
+        init?.body ? JSON.parse(init.body as string) : undefined,
+        capturedToken!,
+      );
     });
 
     const { createClient } = await import("../packages/cli/src/client.js");
     const client = await createClient();
 
-    const reviewed = await client.reviewTask(taskId, { pr_url: "https://github.com/test/pull/1" }) as any;
+    const reviewed = (await client.reviewTask(taskId, {
+      pr_url: "https://github.com/test/pull/1",
+    })) as any;
     expect(reviewed.status).toBe("in_review");
   });
 
   it("machine API key is correctly rejected for claim (agent-only endpoint)", async () => {
-    const res = await honoRequest("POST", `/api/tasks/${taskId}/claim`, { agent_id: agentId }, apiKey);
+    const res = await honoRequest(
+      "POST",
+      `/api/tasks/${taskId}/claim`,
+      { agent_id: agentId },
+      apiKey,
+    );
     expect(res.status).toBe(403);
   });
 });

--- a/tests/client-methods.test.ts
+++ b/tests/client-methods.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 /**
  * Tests that the new ApiClient methods exist and have the correct arity.

--- a/tests/constants-completeness.test.ts
+++ b/tests/constants-completeness.test.ts
@@ -1,9 +1,21 @@
-import { describe, it, expect } from "vitest";
-import { TASK_ACTIONS, AGENT_STATUSES } from "@agent-kanban/shared";
+import { AGENT_STATUSES, TASK_ACTIONS } from "@agent-kanban/shared";
+import { describe, expect, it } from "vitest";
 
 describe("enum completeness", () => {
   it("TASK_ACTIONS matches the migration CHECK constraint", () => {
-    const migrationActions = ["created", "claimed", "moved", "commented", "completed", "assigned", "released", "timed_out", "cancelled", "rejected", "review_requested"];
+    const migrationActions = [
+      "created",
+      "claimed",
+      "moved",
+      "commented",
+      "completed",
+      "assigned",
+      "released",
+      "timed_out",
+      "cancelled",
+      "rejected",
+      "review_requested",
+    ];
     expect([...TASK_ACTIONS]).toEqual(migrationActions);
   });
 

--- a/tests/header/header-active-nav-link.spec.ts
+++ b/tests/header/header-active-nav-link.spec.ts
@@ -1,25 +1,25 @@
 // spec: specs/agent-kanban.plan.md
 // section: 4.10 Agents nav link is highlighted when on agents page
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Header and Navigation', () => {
-  test('Agents nav link is highlighted when on agents page', async ({ page }) => {
+test.describe("Header and Navigation", () => {
+  test("Agents nav link is highlighted when on agents page", async ({ page }) => {
     // 1. Sign in and navigate to /agents
     await signUpAndGetBoard(page, `headernavlink_${Date.now()}@example.com`);
-    await page.goto('/agents');
+    await page.goto("/agents");
 
-    const header = page.locator('header');
+    const header = page.locator("header");
 
     // expect: The 'Agents' nav link in the header is highlighted with accent color and accent-soft background
-    const agentsLink = header.getByRole('link', { name: 'Agents' });
+    const agentsLink = header.getByRole("link", { name: "Agents" });
     await expect(agentsLink).toBeVisible();
     await expect(agentsLink).toHaveClass(/text-accent/);
     await expect(agentsLink).toHaveClass(/bg-accent-soft/);
 
     // expect: The 'Machines' nav link is in the default tertiary color
-    const machinesLink = header.getByRole('link', { name: 'Machines' });
+    const machinesLink = header.getByRole("link", { name: "Machines" });
     await expect(machinesLink).toBeVisible();
     await expect(machinesLink).toHaveClass(/text-content-tertiary/);
     await expect(machinesLink).not.toHaveClass(/text-accent/);

--- a/tests/header/header-avatar-dropdown.spec.ts
+++ b/tests/header/header-avatar-dropdown.spec.ts
@@ -1,20 +1,20 @@
 // spec: specs/agent-kanban.plan.md
 // section: 4.3 User avatar dropdown menu opens
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Header and Navigation', () => {
-  test('User avatar dropdown menu opens', async ({ page }) => {
-    const userName = 'Avatar Dropdown Tester';
+test.describe("Header and Navigation", () => {
+  test("User avatar dropdown menu opens", async ({ page }) => {
+    const userName = "Avatar Dropdown Tester";
     // 1. Sign in and navigate to any page. Click the user avatar button in the header.
     await signUpAndGetBoard(page, `headeravatar_${Date.now()}@example.com`, userName);
-    await page.goto('/settings');
+    await page.goto("/settings");
 
-    const header = page.locator('header');
+    const header = page.locator("header");
 
     // Click the avatar button (the rounded button with Avatar inside)
-    const avatarButton = header.locator('button.rounded-full');
+    const avatarButton = header.locator("button.rounded-full");
     await avatarButton.click();
 
     // expect: A dropdown menu appears showing the user's name or email
@@ -23,8 +23,8 @@ test.describe('Header and Navigation', () => {
     await expect(dropdown.getByText(userName)).toBeVisible();
 
     // expect: Menu items include 'Settings', 'Repositories', and 'Sign out'
-    await expect(dropdown.getByText('Settings')).toBeVisible();
-    await expect(dropdown.getByText('Repositories')).toBeVisible();
-    await expect(dropdown.getByText('Sign out')).toBeVisible();
+    await expect(dropdown.getByText("Settings")).toBeVisible();
+    await expect(dropdown.getByText("Repositories")).toBeVisible();
+    await expect(dropdown.getByText("Sign out")).toBeVisible();
   });
 });

--- a/tests/header/header-board-switcher-cancel-create.spec.ts
+++ b/tests/header/header-board-switcher-cancel-create.spec.ts
@@ -1,39 +1,39 @@
 // spec: specs/agent-kanban.plan.md
 // section: 4.9 Board switcher — cancel board creation with Escape
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Header and Navigation', () => {
+test.describe("Header and Navigation", () => {
   // fixme: Pressing Escape in the board name input propagates to the Dialog and closes the entire
   // dialog rather than just dismissing the create input. The test assumes Escape only hides the
   // create input and leaves the dialog open, but the actual behavior closes the dialog entirely.
-  test.fixme('Board switcher — cancel board creation with Escape', async ({ page }) => {
+  test.fixme("Board switcher — cancel board creation with Escape", async ({ page }) => {
     await signUpAndGetBoard(page, `headerboardcancel_${Date.now()}@example.com`);
 
-    const header = page.locator('header');
-    const boardNameButton = header.getByRole('button', { name: 'My Board' });
+    const header = page.locator("header");
+    const boardNameButton = header.getByRole("button", { name: "My Board" });
     await boardNameButton.click();
 
     const dialog = page.locator('[data-slot="dialog-content"]');
     await expect(dialog).toBeVisible();
 
-    await dialog.getByRole('button', { name: 'New board' }).click();
+    await dialog.getByRole("button", { name: "New board" }).click();
 
     // expect: Create input is visible
     const boardNameInput = dialog.locator('input[placeholder="Board name"]');
     await expect(boardNameInput).toBeVisible();
 
     // 2. Press Escape — this closes the entire dialog (Escape propagates to Dialog)
-    await boardNameInput.press('Escape');
+    await boardNameInput.press("Escape");
 
     // expect: The create input is hidden
     await expect(boardNameInput).not.toBeVisible();
 
     // expect: The 'New board' button is shown again
-    await expect(dialog.getByRole('button', { name: 'New board' })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "New board" })).toBeVisible();
 
     // expect: No board is created (dialog still shows original board list)
-    await expect(dialog.getByText('My Board')).toBeVisible();
+    await expect(dialog.getByText("My Board")).toBeVisible();
   });
 });

--- a/tests/header/header-board-switcher-create.spec.ts
+++ b/tests/header/header-board-switcher-create.spec.ts
@@ -1,16 +1,16 @@
 // spec: specs/agent-kanban.plan.md
 // section: 4.8 Board switcher — create a new board
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Header and Navigation', () => {
-  test('Board switcher — create a new board', async ({ page }) => {
+test.describe("Header and Navigation", () => {
+  test("Board switcher — create a new board", async ({ page }) => {
     // 1. Sign in, navigate to a board, open the board switcher dialog
     await signUpAndGetBoard(page, `headerboardcreate_${Date.now()}@example.com`);
 
-    const header = page.locator('header');
-    const boardNameButton = header.getByRole('button', { name: 'My Board' });
+    const header = page.locator("header");
+    const boardNameButton = header.getByRole("button", { name: "My Board" });
     await boardNameButton.click();
 
     // expect: Board switcher is open
@@ -18,7 +18,7 @@ test.describe('Header and Navigation', () => {
     await expect(dialog).toBeVisible();
 
     // 2. Click the '+ New board' button
-    const newBoardButton = dialog.getByRole('button', { name: 'New board' });
+    const newBoardButton = dialog.getByRole("button", { name: "New board" });
     await newBoardButton.click();
 
     // expect: An input field and 'Create' button appear in place of the 'New board' button
@@ -26,11 +26,11 @@ test.describe('Header and Navigation', () => {
     await expect(boardNameInput).toBeVisible();
     await expect(boardNameInput).toBeFocused();
 
-    const createButton = dialog.getByRole('button', { name: 'Create' });
+    const createButton = dialog.getByRole("button", { name: "Create" });
     await expect(createButton).toBeVisible();
 
     // 3. Type 'My New Board' and click 'Create'
-    await boardNameInput.fill('My New Board');
+    await boardNameInput.fill("My New Board");
     await createButton.click();
 
     // expect: The browser navigates to the new board's URL (board creation triggers navigation)
@@ -38,9 +38,9 @@ test.describe('Header and Navigation', () => {
 
     // The dialog may stay open after navigation (Header's switcherOpen state persists).
     // Close the dialog via Escape to unblock the header.
-    await page.keyboard.press('Escape');
+    await page.keyboard.press("Escape");
 
     // expect: The header now shows the new board name
-    await expect(header.getByRole('button', { name: 'My New Board' })).toBeVisible();
+    await expect(header.getByRole("button", { name: "My New Board" })).toBeVisible();
   });
 });

--- a/tests/header/header-board-switcher.spec.ts
+++ b/tests/header/header-board-switcher.spec.ts
@@ -1,18 +1,18 @@
 // spec: specs/agent-kanban.plan.md
 // section: 4.7 Board name in header opens board switcher
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Header and Navigation', () => {
-  test('Board name in header opens board switcher', async ({ page }) => {
+test.describe("Header and Navigation", () => {
+  test("Board name in header opens board switcher", async ({ page }) => {
     // 1. Sign in and navigate to a board page. The header should show 'Agent Kanban / <board name>'.
     await signUpAndGetBoard(page, `headerboardsw_${Date.now()}@example.com`);
 
-    const header = page.locator('header');
+    const header = page.locator("header");
 
     // expect: The board name is displayed next to the logo as a ghost button
-    const boardNameButton = header.getByRole('button', { name: 'My Board' });
+    const boardNameButton = header.getByRole("button", { name: "My Board" });
     await expect(boardNameButton).toBeVisible();
 
     // 2. Click the board name button
@@ -21,13 +21,13 @@ test.describe('Header and Navigation', () => {
     // expect: A 'Switch Board' dialog opens listing all available boards
     const dialog = page.locator('[data-slot="dialog-content"]');
     await expect(dialog).toBeVisible();
-    await expect(dialog.getByText('Switch Board')).toBeVisible();
+    await expect(dialog.getByText("Switch Board")).toBeVisible();
 
     // expect: The active board is highlighted with an accent color and a dot indicator
-    const activeBoardBtn = dialog.locator('.bg-accent-soft');
+    const activeBoardBtn = dialog.locator(".bg-accent-soft");
     await expect(activeBoardBtn).toBeVisible();
 
     // expect: A 'New board' option is present at the bottom of the dialog
-    await expect(dialog.getByRole('button', { name: 'New board' })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "New board" })).toBeVisible();
   });
 });

--- a/tests/header/header-elements.spec.ts
+++ b/tests/header/header-elements.spec.ts
@@ -1,32 +1,34 @@
 // spec: specs/agent-kanban.plan.md
 // section: 4.1 Header renders logo, nav links, theme toggle, and user avatar
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Header and Navigation', () => {
-  test('Header renders logo, nav links, theme toggle, and user avatar', async ({ page }) => {
+test.describe("Header and Navigation", () => {
+  test("Header renders logo, nav links, theme toggle, and user avatar", async ({ page }) => {
     // 1. Sign in and navigate to any protected page (e.g. /settings)
     await signUpAndGetBoard(page, `headerelemts_${Date.now()}@example.com`);
-    await page.goto('/settings');
+    await page.goto("/settings");
 
     // expect: The header shows 'Agent Kanban' logo on the left
-    const header = page.locator('header');
+    const header = page.locator("header");
     await expect(header).toBeVisible();
-    await expect(header.getByRole('link', { name: 'Agent Kanban' })).toBeVisible();
+    await expect(header.getByRole("link", { name: "Agent Kanban" })).toBeVisible();
 
     // expect: Nav links 'Agents' and 'Machines' are visible on desktop
-    await expect(header.getByRole('link', { name: 'Agents' })).toBeVisible();
-    await expect(header.getByRole('link', { name: 'Machines' })).toBeVisible();
+    await expect(header.getByRole("link", { name: "Agents" })).toBeVisible();
+    await expect(header.getByRole("link", { name: "Machines" })).toBeVisible();
 
     // expect: A user avatar button is visible on the right
     // The avatar is inside a DropdownMenuTrigger button
-    const avatarButton = header.locator('button').filter({ has: page.locator('[data-slot="avatar"]') });
+    const avatarButton = header
+      .locator("button")
+      .filter({ has: page.locator('[data-slot="avatar"]') });
     await expect(avatarButton).toBeVisible();
 
     // expect: A theme toggle icon button is visible on the right
     // The theme toggle is the last button in the header (after the avatar)
-    const themeToggle = header.locator('button').last();
+    const themeToggle = header.locator("button").last();
     await expect(themeToggle).toBeVisible();
   });
 });

--- a/tests/header/header-nav-to-repos.spec.ts
+++ b/tests/header/header-nav-to-repos.spec.ts
@@ -1,21 +1,21 @@
 // spec: specs/agent-kanban.plan.md
 // section: 4.5 Navigate to repositories via avatar dropdown
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Header and Navigation', () => {
-  test('Navigate to repositories via avatar dropdown', async ({ page }) => {
+test.describe("Header and Navigation", () => {
+  test("Navigate to repositories via avatar dropdown", async ({ page }) => {
     // 1. Sign in, click the user avatar, and then click 'Repositories' in the dropdown
     await signUpAndGetBoard(page, `headerrepos_${Date.now()}@example.com`);
 
-    const header = page.locator('header');
-    const avatarButton = header.locator('button.rounded-full');
+    const header = page.locator("header");
+    const avatarButton = header.locator("button.rounded-full");
     await avatarButton.click();
 
     const dropdown = page.locator('[data-slot="dropdown-menu-content"]');
     await expect(dropdown).toBeVisible();
-    await dropdown.getByText('Repositories').click();
+    await dropdown.getByText("Repositories").click();
 
     // expect: The user is navigated to /repositories
     await expect(page).toHaveURL(/\/repositories/);

--- a/tests/header/header-nav-to-settings.spec.ts
+++ b/tests/header/header-nav-to-settings.spec.ts
@@ -1,28 +1,28 @@
 // spec: specs/agent-kanban.plan.md
 // section: 4.4 Navigate to settings via avatar dropdown
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Header and Navigation', () => {
-  test('Navigate to settings via avatar dropdown', async ({ page }) => {
+test.describe("Header and Navigation", () => {
+  test("Navigate to settings via avatar dropdown", async ({ page }) => {
     // 1. Sign in, click the user avatar, and then click 'Settings' in the dropdown
     await signUpAndGetBoard(page, `headersettings_${Date.now()}@example.com`);
 
-    const header = page.locator('header');
-    const avatarButton = header.locator('button.rounded-full');
+    const header = page.locator("header");
+    const avatarButton = header.locator("button.rounded-full");
     await avatarButton.click();
 
     const dropdown = page.locator('[data-slot="dropdown-menu-content"]');
     await expect(dropdown).toBeVisible();
-    await dropdown.getByRole('menuitem', { name: 'Settings' }).click();
+    await dropdown.getByRole("menuitem", { name: "Settings" }).click();
 
     // expect: The user is navigated to /settings
     await expect(page).toHaveURL(/\/settings/);
 
     // expect: The Settings page is displayed with Theme and Boards sections
-    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Theme' })).toBeVisible();
-    await expect(page.getByRole('heading', { name: 'Boards' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Theme" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Boards" })).toBeVisible();
   });
 });

--- a/tests/header/header-signout.spec.ts
+++ b/tests/header/header-signout.spec.ts
@@ -1,31 +1,31 @@
 // spec: specs/agent-kanban.plan.md
 // section: 4.6 Sign out via avatar dropdown
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Header and Navigation', () => {
-  test('Sign out via avatar dropdown', async ({ page }) => {
+test.describe("Header and Navigation", () => {
+  test("Sign out via avatar dropdown", async ({ page }) => {
     // 1. Sign in and navigate to any page
     await signUpAndGetBoard(page, `headersignout_${Date.now()}@example.com`);
 
-    const header = page.locator('header');
+    const header = page.locator("header");
 
     // Click the avatar button
-    const avatarButton = header.locator('button.rounded-full');
+    const avatarButton = header.locator("button.rounded-full");
     await avatarButton.click();
 
     const dropdown = page.locator('[data-slot="dropdown-menu-content"]');
     await expect(dropdown).toBeVisible();
 
     // Click 'Sign out'
-    await dropdown.getByText('Sign out').click();
+    await dropdown.getByText("Sign out").click();
 
     // expect: The user is signed out
     // expect: The browser navigates to /auth
     await expect(page).toHaveURL(/\/auth/);
 
     // expect: The sign-in form is displayed
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
   });
 });

--- a/tests/header/header-theme-toggle.spec.ts
+++ b/tests/header/header-theme-toggle.spec.ts
@@ -1,23 +1,23 @@
 // spec: specs/agent-kanban.plan.md
 // section: 4.2 Theme toggle cycles through dark, light, system
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Header and Navigation', () => {
-  test('Theme toggle cycles through dark, light, system', async ({ page }) => {
+test.describe("Header and Navigation", () => {
+  test("Theme toggle cycles through dark, light, system", async ({ page }) => {
     // 1. Sign in and navigate to any page.
     await signUpAndGetBoard(page, `headertheme_${Date.now()}@example.com`);
-    await page.goto('/settings');
+    await page.goto("/settings");
 
-    const header = page.locator('header');
+    const header = page.locator("header");
 
     // The theme toggle is the last button in the header
-    const themeButton = header.locator('button').last();
+    const themeButton = header.locator("button").last();
     await expect(themeButton).toBeVisible();
 
     // Get the initial HTML class state (may be null, empty, 'dark', 'light', etc.)
-    const htmlClass = await page.locator('html').getAttribute('class');
+    const htmlClass = await page.locator("html").getAttribute("class");
 
     // 2. Click the theme toggle button three times to cycle through all three states
     // Theme cycle: dark -> light -> system -> dark (cycleTheme function)
@@ -27,8 +27,8 @@ test.describe('Header and Navigation', () => {
 
     // expect: After three clicks, the theme state returns to the original
     // Both null and "" represent no explicit class (system theme), so normalize
-    const htmlClassAfter = await page.locator('html').getAttribute('class');
-    const normalize = (c: string | null) => c ?? '';
+    const htmlClassAfter = await page.locator("html").getAttribute("class");
+    const normalize = (c: string | null) => c ?? "";
     expect(normalize(htmlClassAfter)).toBe(normalize(htmlClass));
   });
 });

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -1,4 +1,4 @@
-import { Page, expect } from '@playwright/test';
+import { expect, type Page } from "@playwright/test";
 
 /**
  * Signs up a new user and completes the onboarding flow (2 steps),
@@ -14,38 +14,38 @@ import { Page, expect } from '@playwright/test';
 export async function signUpAndGetBoard(
   page: Page,
   email: string,
-  name = 'Test User',
+  name = "Test User",
 ): Promise<void> {
-  await page.goto('/auth');
-  await page.getByRole('button', { name: 'Sign up' }).click();
+  await page.goto("/auth");
+  await page.getByRole("button", { name: "Sign up" }).click();
   await page.locator('input[placeholder="Name"]').fill(name);
   await page.locator('input[type="email"]').fill(email);
-  await page.locator('input[type="password"]').fill('password123');
-  await page.getByRole('button', { name: 'Sign Up' }).click();
+  await page.locator('input[type="password"]').fill("password123");
+  await page.getByRole("button", { name: "Sign Up" }).click();
 
   // Wait to land on the onboarding page
   await page.waitForURL(/\/boards\/_new/);
 
   // Step 0: create the board (also creates API key, advances to step 1)
-  await page.getByRole('button', { name: 'Create Board' }).click();
+  await page.getByRole("button", { name: "Create Board" }).click();
 
   // Step 1 is now shown (AddMachineSteps / "Waiting for connection").
   // The board already exists in the DB — fetch the board ID and navigate directly.
-  await expect(page.getByText('Waiting for connection...')).toBeVisible();
+  await expect(page.getByText("Waiting for connection...")).toBeVisible();
 
   const boardId = await page.evaluate(async () => {
-    const token = localStorage.getItem('auth-token');
-    const res = await fetch('/api/boards', {
+    const token = localStorage.getItem("auth-token");
+    const res = await fetch("/api/boards", {
       headers: { Authorization: `Bearer ${token}` },
     });
-    const boards = await res.json() as { id: string }[];
+    const boards = (await res.json()) as { id: string }[];
     return boards[0]?.id ?? null;
   });
 
-  if (!boardId) throw new Error('No board found after onboarding');
+  if (!boardId) throw new Error("No board found after onboarding");
 
   await page.goto(`/boards/${boardId}`);
   await expect(page).toHaveURL(/\/boards\/.+/);
   // Wait for the board to be fully loaded (column grid visible)
-  await expect(page.locator('.hidden.md\\:grid')).toBeVisible();
+  await expect(page.locator(".hidden.md\\:grid")).toBeVisible();
 }

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -1,6 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Miniflare } from "miniflare";
-import { readFileSync } from "fs";
-import { join } from "path";
 
 const MIGRATIONS_DIR = join(__dirname, "../../apps/web/migrations");
 
@@ -18,7 +18,10 @@ export async function applyMigrations(db: D1Database) {
   const files = ["0001_initial.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-    for (const stmt of sql.split(";").map((s) => s.trim()).filter(Boolean)) {
+    for (const stmt of sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       await db.prepare(stmt).run();
     }
   }
@@ -28,7 +31,7 @@ export async function seedUser(db: D1Database, id: string, email: string) {
   const now = new Date().toISOString();
   await db
     .prepare(
-      "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)"
+      "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)",
     )
     .bind(id, "Test User", email, now, now)
     .run();

--- a/tests/machine-agent-flow.test.ts
+++ b/tests/machine-agent-flow.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
+
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { SignJWT } from "jose";
-import { randomUUID } from "crypto";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 // Integration test: full flow — user creates agent → machine creates session → agent claims task
 // Tests the actual Hono routes with auth middleware.
@@ -27,7 +28,10 @@ async function applyMigrations(db: D1Database) {
   const files = ["0001_initial.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-    for (const stmt of sql.split(";").map((s) => s.trim()).filter(Boolean)) {
+    for (const stmt of sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       await db.prepare(stmt).run();
     }
   }
@@ -36,9 +40,12 @@ async function applyMigrations(db: D1Database) {
 async function seedUser(db: D1Database): Promise<string> {
   const userId = "test-user-flow";
   const now = new Date().toISOString();
-  await db.prepare(
-    "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)"
-  ).bind(userId, "Flow Test User", "flow@example.com", now, now).run();
+  await db
+    .prepare(
+      "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)",
+    )
+    .bind(userId, "Flow Test User", "flow@example.com", now, now)
+    .run();
   return userId;
 }
 
@@ -76,8 +83,12 @@ describe("machine → agent session flow", () => {
 
   async function apiRequest(method: string, path: string, body?: any, token?: string) {
     const { api } = await import("../apps/web/functions/api/routes");
-    const headers: Record<string, string> = { "Content-Type": "application/json", Host: "localhost:8788", "x-forwarded-proto": "http" };
-    if (token) headers["Authorization"] = `Bearer ${token}`;
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Host: "localhost:8788",
+      "x-forwarded-proto": "http",
+    };
+    if (token) headers.Authorization = `Bearer ${token}`;
     const init: RequestInit = { method, headers };
     if (body) init.body = JSON.stringify(body);
     return api.request(path, init, env);
@@ -98,11 +109,19 @@ describe("machine → agent session flow", () => {
   });
 
   it("creates a machine via API", async () => {
-    const res = await apiRequest("POST", "/api/machines", {
-      name: "test-machine-01", os: "darwin arm64", version: "1.0.0", runtimes: ["Claude Code"],
-    }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      "/api/machines",
+      {
+        name: "test-machine-01",
+        os: "darwin arm64",
+        version: "1.0.0",
+        runtimes: ["Claude Code"],
+      },
+      apiKey,
+    );
     expect(res.status).toBe(201);
-    const machine = await res.json() as any;
+    const machine = (await res.json()) as any;
     machineId = machine.id;
   });
 
@@ -114,7 +133,11 @@ describe("machine → agent session flow", () => {
   it("user creates a persistent agent", async () => {
     // Create agent directly via repo (user-only route, no API key auth in test)
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
-    const agent = await createAgent(env.DB, userId, { name: "Test Agent", runtime: "Claude Code", model: "claude-sonnet-4-20250514" });
+    const agent = await createAgent(env.DB, userId, {
+      name: "Test Agent",
+      runtime: "Claude Code",
+      model: "claude-sonnet-4-20250514",
+    });
     agentId = agent.id;
     expect(agent.fingerprint).toBeTruthy();
     expect(agent.public_key).toBeTruthy();
@@ -122,19 +145,30 @@ describe("machine → agent session flow", () => {
 
   it("machine creates a session for the agent (CSR)", async () => {
     sessionId = randomUUID();
-    const keypair = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, ["sign", "verify"]);
+    const keypair = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, [
+      "sign",
+      "verify",
+    ]);
     sessionPrivateKey = (keypair as any).privateKey;
     const pubJwk = await crypto.subtle.exportKey("jwk", (keypair as any).publicKey);
 
-    const res = await apiRequest("POST", `/api/agents/${agentId}/sessions`, {
-      session_id: sessionId, session_public_key: pubJwk.x!,
-    }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      `/api/agents/${agentId}/sessions`,
+      {
+        session_id: sessionId,
+        session_public_key: pubJwk.x!,
+      },
+      apiKey,
+    );
     expect(res.status).toBe(201);
-    const result = await res.json() as any;
+    const result = (await res.json()) as any;
     expect(result.delegation_proof).toBeTruthy();
 
     // Verify BA agent was created for this session
-    const baAgent = await env.DB.prepare("SELECT * FROM agent WHERE id = ?").bind(sessionId).first();
+    const baAgent = await env.DB.prepare("SELECT * FROM agent WHERE id = ?")
+      .bind(sessionId)
+      .first();
     expect(baAgent).toBeTruthy();
   });
 
@@ -145,18 +179,32 @@ describe("machine → agent session flow", () => {
   });
 
   it("creates a board and task", async () => {
-    const board = await (await import("../apps/web/functions/api/boardRepo")).createBoard(env.DB, userId, "test-board");
+    const board = await (await import("../apps/web/functions/api/boardRepo")).createBoard(
+      env.DB,
+      userId,
+      "test-board",
+    );
     boardId = board.id;
-    const task = await (await import("../apps/web/functions/api/taskRepo")).createTask(env.DB, userId, {
-      title: "Test task for agent", board_id: boardId,
-    });
+    const task = await (await import("../apps/web/functions/api/taskRepo")).createTask(
+      env.DB,
+      userId,
+      {
+        title: "Test task for agent",
+        board_id: boardId,
+      },
+    );
     taskId = task.id;
   });
 
   it("machine assigns task to persistent agent", async () => {
-    const res = await apiRequest("POST", `/api/tasks/${taskId}/assign`, { agent_id: agentId }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      `/api/tasks/${taskId}/assign`,
+      { agent_id: agentId },
+      apiKey,
+    );
     expect(res.status).toBe(200);
-    const task = await res.json() as any;
+    const task = (await res.json()) as any;
     expect(task.assigned_to).toBe(agentId);
   });
 
@@ -164,32 +212,55 @@ describe("machine → agent session flow", () => {
     const jwt = await signSessionJWT();
     const res = await apiRequest("POST", `/api/tasks/${taskId}/claim`, { agent_id: agentId }, jwt);
     expect(res.status).toBe(200);
-    const task = await res.json() as any;
+    const task = (await res.json()) as any;
     expect(task.status).toBe("in_progress");
   });
 
   it("agent adds a task log", async () => {
     const jwt = await signSessionJWT();
-    const res = await apiRequest("POST", `/api/tasks/${taskId}/logs`, { detail: "Working on it" }, jwt);
+    const res = await apiRequest(
+      "POST",
+      `/api/tasks/${taskId}/logs`,
+      { detail: "Working on it" },
+      jwt,
+    );
     expect(res.status).toBe(201);
   });
 
   it("agent submits task for review", async () => {
     const jwt = await signSessionJWT();
-    const res = await apiRequest("POST", `/api/tasks/${taskId}/review`, { pr_url: "https://github.com/test/repo/pull/1" }, jwt);
+    const res = await apiRequest(
+      "POST",
+      `/api/tasks/${taskId}/review`,
+      { pr_url: "https://github.com/test/repo/pull/1" },
+      jwt,
+    );
     expect(res.status).toBe(200);
-    const task = await res.json() as any;
+    const task = (await res.json()) as any;
     expect(task.status).toBe("in_review");
   });
 
   it("agent reports session usage", async () => {
     const jwt = await signSessionJWT();
-    const res = await apiRequest("PATCH", `/api/agents/${agentId}/sessions/${sessionId}/usage`, {
-      input_tokens: 1500, output_tokens: 800, cache_read_tokens: 0, cache_creation_tokens: 0, cost_micro_usd: 0,
-    }, jwt);
+    const res = await apiRequest(
+      "PATCH",
+      `/api/agents/${agentId}/sessions/${sessionId}/usage`,
+      {
+        input_tokens: 1500,
+        output_tokens: 800,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+        cost_micro_usd: 0,
+      },
+      jwt,
+    );
     expect(res.status).toBe(200);
 
-    const session = await env.DB.prepare("SELECT input_tokens, output_tokens FROM agent_sessions WHERE id = ?").bind(sessionId).first();
+    const session = await env.DB.prepare(
+      "SELECT input_tokens, output_tokens FROM agent_sessions WHERE id = ?",
+    )
+      .bind(sessionId)
+      .first();
     expect(session!.input_tokens).toBe(1500);
     expect(session!.output_tokens).toBe(800);
   });
@@ -197,7 +268,7 @@ describe("machine → agent session flow", () => {
   it("GET /api/machines/:id returns agents with correct fields", async () => {
     const res = await apiRequest("GET", `/api/machines/${machineId}`, undefined, apiKey);
     expect(res.status).toBe(200);
-    const machine = await res.json() as any;
+    const machine = (await res.json()) as any;
     expect(machine.agents).toHaveLength(1);
     const agent = machine.agents[0];
     expect(agent.id).toBe(agentId);
@@ -207,21 +278,33 @@ describe("machine → agent session flow", () => {
   });
 
   it("final state is consistent", async () => {
-    const machine = await env.DB.prepare("SELECT status FROM machines WHERE id = ?").bind(machineId).first();
+    const machine = await env.DB.prepare("SELECT status FROM machines WHERE id = ?")
+      .bind(machineId)
+      .first();
     expect(machine!.status).toBe("online");
 
-    const agent = await env.DB.prepare("SELECT * FROM agents WHERE id = ?").bind(agentId).first() as any;
+    const agent = (await env.DB.prepare("SELECT * FROM agents WHERE id = ?")
+      .bind(agentId)
+      .first()) as any;
     expect(agent.owner_id).toBe(userId);
 
-    const session = await env.DB.prepare("SELECT * FROM agent_sessions WHERE id = ?").bind(sessionId).first() as any;
+    const session = (await env.DB.prepare("SELECT * FROM agent_sessions WHERE id = ?")
+      .bind(sessionId)
+      .first()) as any;
     expect(session.agent_id).toBe(agentId);
     expect(session.machine_id).toBe(machineId);
 
-    const task = await env.DB.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first() as any;
+    const task = (await env.DB.prepare("SELECT * FROM tasks WHERE id = ?")
+      .bind(taskId)
+      .first()) as any;
     expect(task.status).toBe("in_review");
     expect(task.assigned_to).toBe(agentId);
 
-    const logs = await env.DB.prepare("SELECT action FROM task_logs WHERE task_id = ? ORDER BY created_at").bind(taskId).all();
+    const logs = await env.DB.prepare(
+      "SELECT action FROM task_logs WHERE task_id = ? ORDER BY created_at",
+    )
+      .bind(taskId)
+      .all();
     const actions = logs.results.map((r: any) => r.action);
     expect(actions).toContain("created");
     expect(actions).toContain("assigned");

--- a/tests/machine-usage.test.ts
+++ b/tests/machine-usage.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
-import { readFileSync } from "fs";
-import { join } from "path";
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { UsageInfo } from "@agent-kanban/shared";
+import { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const MIGRATIONS_DIR = join(__dirname, "../apps/web/migrations");
 
@@ -14,7 +15,10 @@ async function applyMigrations(db: D1Database) {
   const files = ["0001_initial.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-    for (const stmt of sql.split(";").map(s => s.trim()).filter(Boolean)) {
+    for (const stmt of sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       await db.prepare(stmt).run();
     }
   }
@@ -40,7 +44,10 @@ describe("machine usage tracking", () => {
   it("createMachine stores os/version/runtimes and returns usage_info as null", async () => {
     const { createMachine } = await import("../apps/web/functions/api/machineRepo");
     const machine = await createMachine(db, "user-001", {
-      name: "test-machine", os: "darwin arm64", version: "1.0.0", runtimes: ["Claude Code"],
+      name: "test-machine",
+      os: "darwin arm64",
+      version: "1.0.0",
+      runtimes: ["Claude Code"],
     });
     machineId = machine.id;
     expect(machine.os).toBe("darwin arm64");
@@ -86,7 +93,7 @@ describe("machine usage tracking", () => {
     const machines = await listMachines(db, "user-001");
 
     expect(machines.length).toBeGreaterThan(0);
-    const m = machines.find(m => m.id === machineId)!;
+    const m = machines.find((m) => m.id === machineId)!;
     expect(typeof m.usage_info).toBe("object");
     expect(m.usage_info!.five_hour!.utilization).toBe(23.5);
   });
@@ -108,7 +115,8 @@ describe("machine usage tracking", () => {
   it("heartbeat updates version and runtimes", async () => {
     const { updateMachine: heartbeat } = await import("../apps/web/functions/api/machineRepo");
     const machine = await heartbeat(db, machineId, "user-001", {
-      version: "2.0.0", runtimes: ["Claude Code", "Codex"],
+      version: "2.0.0",
+      runtimes: ["Claude Code", "Codex"],
     });
 
     expect(machine.version).toBe("2.0.0");
@@ -131,7 +139,7 @@ describe("machine usage tracking", () => {
     expect(single!.runtimes).toEqual(["Claude Code", "Codex"]);
 
     const list = await listMachines(db, "user-001");
-    const m = list.find(m => m.id === machineId)!;
+    const m = list.find((m) => m.id === machineId)!;
     expect(Array.isArray(m.runtimes)).toBe(true);
   });
 });

--- a/tests/machines/machine-detail-agent-link.spec.ts
+++ b/tests/machines/machine-detail-agent-link.spec.ts
@@ -1,16 +1,16 @@
 // spec: specs/agent-kanban.plan.md
 // section: 6.10 Machine detail — agent list links to agent detail page
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Machines Page', () => {
+test.describe("Machines Page", () => {
   // This test requires a machine with at least one agent listed.
   // Since a running agent daemon is required, this test is marked fixme.
-  test.fixme('Machine detail — agent list links to agent detail page', async ({ page }) => {
+  test.fixme("Machine detail — agent list links to agent detail page", async ({ page }) => {
     // 1. Sign in and navigate to a machine detail page that has at least one agent listed
     await signUpAndGetBoard(page, `machine_agentlink_${Date.now()}@example.com`);
-    await page.goto('/machines');
+    await page.goto("/machines");
     const machineLink = page.locator('a[href^="/machines/"]').first();
     await expect(machineLink).toBeVisible();
     await machineLink.click();
@@ -27,6 +27,6 @@ test.describe('Machines Page', () => {
     await expect(page).toHaveURL(/\/agents\/.+/);
 
     // expect: The agent detail page is displayed
-    await expect(page.getByText('← Agents')).toBeVisible();
+    await expect(page.getByText("← Agents")).toBeVisible();
   });
 });

--- a/tests/machines/machine-detail-delete.spec.ts
+++ b/tests/machines/machine-detail-delete.spec.ts
@@ -1,45 +1,45 @@
 // spec: specs/agent-kanban.plan.md
 // section: 6.9 Machine detail — delete machine with confirmation dialog
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Machines Page', () => {
+test.describe("Machines Page", () => {
   // This test requires a machine to be registered.
   // Since a connected machine daemon is required, this test is marked fixme.
-  test.fixme('Machine detail — delete machine with confirmation dialog', async ({ page }) => {
+  test.fixme("Machine detail — delete machine with confirmation dialog", async ({ page }) => {
     // 1. Sign in and navigate to a machine detail page, then click the 'Delete' button
     await signUpAndGetBoard(page, `machine_delete_${Date.now()}@example.com`);
-    await page.goto('/machines');
+    await page.goto("/machines");
     const machineLink = page.locator('a[href^="/machines/"]').first();
     await expect(machineLink).toBeVisible();
     await machineLink.click();
     await expect(page).toHaveURL(/\/machines\/.+/);
 
-    await page.getByRole('button', { name: 'Delete' }).click();
+    await page.getByRole("button", { name: "Delete" }).click();
 
     // expect: A confirmation dialog opens with the title 'Delete Machine'
     const dialog = page.locator('[data-slot="dialog-content"]');
     await expect(dialog).toBeVisible();
-    await expect(dialog.getByText('Delete Machine')).toBeVisible();
+    await expect(dialog.getByText("Delete Machine")).toBeVisible();
 
     // expect: The dialog body mentions the machine name
     await expect(dialog.getByText(/This will revoke the API key for/)).toBeVisible();
 
     // expect: Cancel and 'Delete' (destructive) buttons are shown
-    await expect(dialog.getByRole('button', { name: 'Cancel' })).toBeVisible();
-    await expect(dialog.getByRole('button', { name: 'Delete' })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Cancel" })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: "Delete" })).toBeVisible();
 
     // 2. Click 'Cancel'
-    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await dialog.getByRole("button", { name: "Cancel" }).click();
 
     // expect: The dialog closes without deleting the machine
     await expect(dialog).not.toBeVisible();
 
     // 3. Click 'Delete' again, then click the red 'Delete' button in the dialog
-    await page.getByRole('button', { name: 'Delete' }).click();
+    await page.getByRole("button", { name: "Delete" }).click();
     await expect(dialog).toBeVisible();
-    await dialog.getByRole('button', { name: 'Delete' }).click();
+    await dialog.getByRole("button", { name: "Delete" }).click();
 
     // expect: The machine is deleted
     // expect: The user is redirected to /machines

--- a/tests/machines/machine-detail-not-found.spec.ts
+++ b/tests/machines/machine-detail-not-found.spec.ts
@@ -1,20 +1,20 @@
 // spec: specs/agent-kanban.plan.md
 // section: 6.11 Machine not found shows graceful error state
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Machines Page', () => {
-  test('Machine not found shows graceful error state', async ({ page }) => {
+test.describe("Machines Page", () => {
+  test("Machine not found shows graceful error state", async ({ page }) => {
     // 1. Sign in and navigate to /machines/nonexistent-id
     await signUpAndGetBoard(page, `machine_notfound_${Date.now()}@example.com`);
-    await page.goto('/machines/nonexistent-id');
+    await page.goto("/machines/nonexistent-id");
 
     // expect: The page shows 'Machine not found.' text in the content area
-    await expect(page.getByText('Machine not found.')).toBeVisible();
+    await expect(page.getByText("Machine not found.")).toBeVisible();
 
     // expect: The header is still rendered correctly
-    await expect(page.getByRole('banner')).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Agent Kanban' })).toBeVisible();
+    await expect(page.getByRole("banner")).toBeVisible();
+    await expect(page.getByRole("link", { name: "Agent Kanban" })).toBeVisible();
   });
 });

--- a/tests/machines/machine-detail-offline.spec.ts
+++ b/tests/machines/machine-detail-offline.spec.ts
@@ -1,25 +1,25 @@
 // spec: specs/agent-kanban.plan.md
 // section: 6.8 Machine detail — offline machine shows reconnect instructions
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Machines Page', () => {
+test.describe("Machines Page", () => {
   // This test requires an offline machine registered in the database.
   // Since a real machine is needed, this test is marked fixme.
-  test.fixme('Machine detail — offline machine shows reconnect instructions', async ({ page }) => {
+  test.fixme("Machine detail — offline machine shows reconnect instructions", async ({ page }) => {
     // 1. Sign in and navigate to the detail page of an offline machine
     await signUpAndGetBoard(page, `machine_offline_${Date.now()}@example.com`);
 
     // Navigate to a machine detail page (requires a real machine ID)
-    await page.goto('/machines');
+    await page.goto("/machines");
     const machineLink = page.locator('a[href^="/machines/"]').first();
     await expect(machineLink).toBeVisible();
     await machineLink.click();
     await expect(page).toHaveURL(/\/machines\/.+/);
 
     // expect: A warning panel 'Machine is offline' is displayed with an amber/warning border
-    await expect(page.getByText('Machine is offline')).toBeVisible();
+    await expect(page.getByText("Machine is offline")).toBeVisible();
 
     // expect: A reconnect command is shown: 'ak start --api-url <origin>'
     await expect(page.getByText(/ak start --api-url/)).toBeVisible();

--- a/tests/machines/machine-detail-render.spec.ts
+++ b/tests/machines/machine-detail-render.spec.ts
@@ -1,47 +1,47 @@
 // spec: specs/agent-kanban.plan.md
 // section: 6.7 Machine detail page renders machine information
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Machines Page', () => {
+test.describe("Machines Page", () => {
   // This test requires a machine to be registered.
   // Since a connected machine daemon is required, this test is marked fixme.
-  test.fixme('Machine detail page renders machine information', async ({ page }) => {
+  test.fixme("Machine detail page renders machine information", async ({ page }) => {
     // 1. Sign in and navigate to a machine detail page at /machines/:id
     await signUpAndGetBoard(page, `machine_detail_${Date.now()}@example.com`);
-    await page.goto('/machines');
+    await page.goto("/machines");
 
     // Navigate to the first machine detail page
     const machineLink = page.locator('a[href^="/machines/"]').first();
     await expect(machineLink).toBeVisible();
-    const href = await machineLink.getAttribute('href');
+    const href = await machineLink.getAttribute("href");
     await page.goto(href!);
 
     // expect: A breadcrumb 'Machines / <machine-name>' is displayed
-    await expect(page.getByText('Machines')).toBeVisible();
-    await expect(page.locator('text=/Machines \\//i')).toBeVisible();
+    await expect(page.getByText("Machines")).toBeVisible();
+    await expect(page.locator("text=/Machines \\//i")).toBeVisible();
 
     // expect: Machine name is shown as a heading with a status dot and status label
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
     await expect(page.getByText(/online|offline/i)).toBeVisible();
 
     // expect: A details card shows OS, Version, Last Heartbeat, and Created date
-    await expect(page.getByText('OS')).toBeVisible();
-    await expect(page.getByText('Version')).toBeVisible();
-    await expect(page.getByText('Last Heartbeat')).toBeVisible();
-    await expect(page.getByText('Created')).toBeVisible();
+    await expect(page.getByText("OS")).toBeVisible();
+    await expect(page.getByText("Version")).toBeVisible();
+    await expect(page.getByText("Last Heartbeat")).toBeVisible();
+    await expect(page.getByText("Created")).toBeVisible();
 
     // expect: Session count and Active session count are displayed in stat cards
-    await expect(page.getByText('Sessions')).toBeVisible();
-    await expect(page.getByText('Active')).toBeVisible();
+    await expect(page.getByText("Sessions")).toBeVisible();
+    await expect(page.getByText("Active")).toBeVisible();
 
     // expect: A 'Delete' button is visible
-    await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Delete" })).toBeVisible();
 
     // expect: An 'Agents' section shows agents registered on the machine or 'No agents registered on this machine.'
     await expect(
-      page.getByText(/Agents \(\d+\)|No agents registered on this machine\./)
+      page.getByText(/Agents \(\d+\)|No agents registered on this machine\./),
     ).toBeVisible();
   });
 });

--- a/tests/machines/machines-add-dialog-cancel.spec.ts
+++ b/tests/machines/machines-add-dialog-cancel.spec.ts
@@ -1,37 +1,37 @@
 // spec: specs/agent-kanban.plan.md
 // section: 6.5 Closing Add Machine dialog before connecting revokes the API key
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Machines Page', () => {
-  test('Closing Add Machine dialog before connecting revokes the API key', async ({ page }) => {
+test.describe("Machines Page", () => {
+  test("Closing Add Machine dialog before connecting revokes the API key", async ({ page }) => {
     // 1. Sign in, open the Add Machine dialog, click 'Your Computer' to generate an API key
     await signUpAndGetBoard(page, `machines_cancel_${Date.now()}@example.com`);
-    await page.goto('/machines');
-    await expect(page.getByText('No machines registered.')).toBeVisible();
+    await page.goto("/machines");
+    await expect(page.getByText("No machines registered.")).toBeVisible();
 
-    await page.getByRole('button', { name: 'Add Machine' }).first().click();
+    await page.getByRole("button", { name: "Add Machine" }).first().click();
 
     const dialog = page.locator('[data-slot="dialog-content"]');
     await expect(dialog).toBeVisible();
 
     // Click 'Your Computer' to generate an API key
-    await dialog.getByRole('button', { name: /Your Computer/ }).click();
+    await dialog.getByRole("button", { name: /Your Computer/ }).click();
 
     // expect: The dialog shows the AddMachineSteps with an API key displayed
-    await expect(dialog.getByText('Waiting for connection...')).toBeVisible();
+    await expect(dialog.getByText("Waiting for connection...")).toBeVisible();
 
     // The API key command should be shown (contains --api-key)
     await expect(dialog.getByText(/--api-key/)).toBeVisible();
 
     // 2. Close the dialog by pressing Escape before the machine connects
-    await page.keyboard.press('Escape');
+    await page.keyboard.press("Escape");
 
     // expect: The dialog closes
     await expect(dialog).not.toBeVisible();
 
     // expect: The machines list does not show a new machine
-    await expect(page.getByText('No machines registered.')).toBeVisible();
+    await expect(page.getByText("No machines registered.")).toBeVisible();
   });
 });

--- a/tests/machines/machines-add-dialog-open.spec.ts
+++ b/tests/machines/machines-add-dialog-open.spec.ts
@@ -1,32 +1,32 @@
 // spec: specs/agent-kanban.plan.md
 // section: 6.3 Open Add Machine dialog
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Machines Page', () => {
-  test('Open Add Machine dialog', async ({ page }) => {
+test.describe("Machines Page", () => {
+  test("Open Add Machine dialog", async ({ page }) => {
     // 1. Sign in and navigate to /machines, then click 'Add Machine'
     await signUpAndGetBoard(page, `machines_dialog_${Date.now()}@example.com`);
-    await page.goto('/machines');
-    await expect(page.getByText('No machines registered.')).toBeVisible();
+    await page.goto("/machines");
+    await expect(page.getByText("No machines registered.")).toBeVisible();
 
-    await page.getByRole('button', { name: 'Add Machine' }).first().click();
+    await page.getByRole("button", { name: "Add Machine" }).first().click();
 
     const dialog = page.locator('[data-slot="dialog-content"]');
 
     // expect: A dialog opens with the title 'Add Machine'
     await expect(dialog).toBeVisible();
-    await expect(dialog.getByText('Add Machine')).toBeVisible();
+    await expect(dialog.getByText("Add Machine")).toBeVisible();
 
     // expect: Two options are presented: 'Your Computer' (enabled) and 'Cloud Sandbox' (disabled/coming soon)
-    await expect(dialog.getByRole('button', { name: /Your Computer/ })).toBeVisible();
-    await expect(dialog.getByRole('button', { name: /Your Computer/ })).toBeEnabled();
+    await expect(dialog.getByRole("button", { name: /Your Computer/ })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: /Your Computer/ })).toBeEnabled();
 
-    await expect(dialog.getByRole('button', { name: /Cloud Sandbox/ })).toBeVisible();
-    await expect(dialog.getByRole('button', { name: /Cloud Sandbox/ })).toBeDisabled();
+    await expect(dialog.getByRole("button", { name: /Cloud Sandbox/ })).toBeVisible();
+    await expect(dialog.getByRole("button", { name: /Cloud Sandbox/ })).toBeDisabled();
 
     // expect: The 'Cloud Sandbox' option is visually greyed out with 'Coming soon' text
-    await expect(dialog.getByText('Coming soon')).toBeVisible();
+    await expect(dialog.getByText("Coming soon")).toBeVisible();
   });
 });

--- a/tests/machines/machines-add-local.spec.ts
+++ b/tests/machines/machines-add-local.spec.ts
@@ -1,23 +1,23 @@
 // spec: specs/agent-kanban.plan.md
 // section: 6.4 Add Machine dialog — choose 'Your Computer' shows setup steps
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Machines Page', () => {
+test.describe("Machines Page", () => {
   test("Add Machine dialog — choose 'Your Computer' shows setup steps", async ({ page }) => {
     // 1. Sign in, navigate to /machines, click 'Add Machine', then click 'Your Computer'
     await signUpAndGetBoard(page, `machines_local_${Date.now()}@example.com`);
-    await page.goto('/machines');
-    await expect(page.getByText('No machines registered.')).toBeVisible();
+    await page.goto("/machines");
+    await expect(page.getByText("No machines registered.")).toBeVisible();
 
-    await page.getByRole('button', { name: 'Add Machine' }).first().click();
+    await page.getByRole("button", { name: "Add Machine" }).first().click();
 
     const dialog = page.locator('[data-slot="dialog-content"]');
     await expect(dialog).toBeVisible();
 
     // Click 'Your Computer'
-    await dialog.getByRole('button', { name: /Your Computer/ }).click();
+    await dialog.getByRole("button", { name: /Your Computer/ }).click();
 
     // expect: The dialog transitions to the 'waiting' step
     // expect: The AddMachineSteps component is displayed
@@ -25,9 +25,9 @@ test.describe('Machines Page', () => {
     await expect(dialog.getByText(/npx agent-kanban start/)).toBeVisible();
 
     // expect: A waiting indicator shows the system is waiting for the machine to connect
-    await expect(dialog.getByText('Waiting for connection...')).toBeVisible();
+    await expect(dialog.getByText("Waiting for connection...")).toBeVisible();
 
     // Close dialog after test
-    await page.keyboard.press('Escape');
+    await page.keyboard.press("Escape");
   });
 });

--- a/tests/machines/machines-empty-state.spec.ts
+++ b/tests/machines/machines-empty-state.spec.ts
@@ -1,31 +1,31 @@
 // spec: specs/agent-kanban.plan.md
 // section: 6.1 Machines page renders correctly with empty state
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Machines Page', () => {
-  test('Machines page renders correctly with empty state', async ({ page }) => {
+test.describe("Machines Page", () => {
+  test("Machines page renders correctly with empty state", async ({ page }) => {
     // 1. Sign in as a user with no machines registered and navigate to /machines
     await signUpAndGetBoard(page, `machines_empty_${Date.now()}@example.com`);
-    await page.goto('/machines');
+    await page.goto("/machines");
 
     // expect: Page heading 'Machines' is displayed
-    await expect(page.getByRole('heading', { name: 'Machines', level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Machines", level: 1 })).toBeVisible();
 
     // expect: A count of '0 online' is shown
-    await expect(page.getByText('0 online')).toBeVisible();
+    await expect(page.getByText("0 online")).toBeVisible();
 
     // expect: An 'Add Machine' button is present
-    await expect(page.getByRole('button', { name: 'Add Machine' }).first()).toBeVisible();
+    await expect(page.getByRole("button", { name: "Add Machine" }).first()).toBeVisible();
 
     // Wait for loading to complete
-    await expect(page.getByText('No machines registered.')).toBeVisible();
+    await expect(page.getByText("No machines registered.")).toBeVisible();
 
     // expect: The empty state text 'No machines registered.' is shown
-    await expect(page.getByText('No machines registered.')).toBeVisible();
+    await expect(page.getByText("No machines registered.")).toBeVisible();
 
     // expect: A link to 'Add Machine' in the empty state text is visible
-    await expect(page.getByRole('button', { name: 'Add Machine' }).nth(1)).toBeVisible();
+    await expect(page.getByRole("button", { name: "Add Machine" }).nth(1)).toBeVisible();
   });
 });

--- a/tests/machines/machines-list-link.spec.ts
+++ b/tests/machines/machines-list-link.spec.ts
@@ -1,16 +1,16 @@
 // spec: specs/agent-kanban.plan.md
 // section: 6.6 Machine list item links to machine detail page
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Machines Page', () => {
+test.describe("Machines Page", () => {
   // This test requires at least one machine to be present in the list.
   // Since a connected machine daemon is required, this test is marked fixme.
-  test.fixme('Machine list item links to machine detail page', async ({ page }) => {
+  test.fixme("Machine list item links to machine detail page", async ({ page }) => {
     // 1. Sign in and navigate to /machines. At least one machine must be present.
     await signUpAndGetBoard(page, `machines_link_${Date.now()}@example.com`);
-    await page.goto('/machines');
+    await page.goto("/machines");
 
     // expect: Machine cards are rendered as links
     const machineLink = page.locator('a[href^="/machines/"]').first();
@@ -23,6 +23,6 @@ test.describe('Machines Page', () => {
     await expect(page).toHaveURL(/\/machines\/.+/);
 
     // expect: The machine detail page is displayed with the machine's name and details
-    await expect(page.getByText('Machines')).toBeVisible();
+    await expect(page.getByText("Machines")).toBeVisible();
   });
 });

--- a/tests/machines/machines-list.spec.ts
+++ b/tests/machines/machines-list.spec.ts
@@ -1,17 +1,17 @@
 // spec: specs/agent-kanban.plan.md
 // section: 6.2 Machines page lists machines with status indicators
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Machines Page', () => {
+test.describe("Machines Page", () => {
   // This test requires at least one machine to be registered.
   // Since machines require a daemon to connect, this is tested conceptually here.
   // The test verifies that if machines exist, they are rendered with the correct structure.
-  test.fixme('Machines page lists machines with status indicators', async ({ page }) => {
+  test.fixme("Machines page lists machines with status indicators", async ({ page }) => {
     // 1. Sign in as a user with at least one machine registered and navigate to /machines
     await signUpAndGetBoard(page, `machines_list_${Date.now()}@example.com`);
-    await page.goto('/machines');
+    await page.goto("/machines");
 
     // expect: Each machine card shows machine name, status dot, session count, active session count
     // This test requires a real machine connected, which is not possible in a unit test environment
@@ -22,8 +22,8 @@ test.describe('Machines Page', () => {
     await expect(machineCard.getByText(/online|offline/i)).toBeVisible();
 
     // expect: Sessions and Active labels are shown
-    await expect(machineCard.getByText('Sessions:')).toBeVisible();
-    await expect(machineCard.getByText('Active:')).toBeVisible();
+    await expect(machineCard.getByText("Sessions:")).toBeVisible();
+    await expect(machineCard.getByText("Active:")).toBeVisible();
 
     // expect: The count in the header reflects the number of online machines
     await expect(page.getByText(/\d+ online/)).toBeVisible();

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -1,14 +1,14 @@
 // @vitest-environment node
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
-  formatTask,
-  formatTaskLogs,
   formatAgent,
-  formatTaskList,
   formatAgentList,
+  formatBoard,
   formatBoardList,
   formatRepositoryList,
-  formatBoard,
+  formatTask,
+  formatTaskList,
+  formatTaskLogs,
   getFormat,
   output,
 } from "../packages/cli/src/output";
@@ -57,7 +57,13 @@ describe("formatTask", () => {
   });
 
   it("includes labels when present", () => {
-    const task = { id: "t1", title: "T", status: "todo", priority: null, labels: ["bug", "urgent"] };
+    const task = {
+      id: "t1",
+      title: "T",
+      status: "todo",
+      priority: null,
+      labels: ["bug", "urgent"],
+    };
     const result = formatTask(task);
     expect(result).toContain("bug");
     expect(result).toContain("urgent");
@@ -82,7 +88,13 @@ describe("formatTask", () => {
   });
 
   it("includes repository_name when present", () => {
-    const task = { id: "t1", title: "T", status: "todo", priority: null, repository_name: "my-repo" };
+    const task = {
+      id: "t1",
+      title: "T",
+      status: "todo",
+      priority: null,
+      repository_name: "my-repo",
+    };
     const result = formatTask(task);
     expect(result).toContain("my-repo");
   });
@@ -94,7 +106,13 @@ describe("formatTask", () => {
   });
 
   it("includes depends_on IDs when present", () => {
-    const task = { id: "t1", title: "T", status: "todo", priority: null, depends_on: ["dep1", "dep2"] };
+    const task = {
+      id: "t1",
+      title: "T",
+      status: "todo",
+      priority: null,
+      depends_on: ["dep1", "dep2"],
+    };
     const result = formatTask(task);
     expect(result).toContain("dep1");
     expect(result).toContain("dep2");
@@ -107,7 +125,13 @@ describe("formatTask", () => {
   });
 
   it("includes pr_url when present", () => {
-    const task = { id: "t1", title: "T", status: "todo", priority: null, pr_url: "https://github.com/org/repo/pull/42" };
+    const task = {
+      id: "t1",
+      title: "T",
+      status: "todo",
+      priority: null,
+      pr_url: "https://github.com/org/repo/pull/42",
+    };
     const result = formatTask(task);
     expect(result).toContain("https://github.com/org/repo/pull/42");
   });
@@ -119,7 +143,13 @@ describe("formatTask", () => {
   });
 
   it("includes description when present", () => {
-    const task = { id: "t1", title: "T", status: "todo", priority: null, description: "A task description" };
+    const task = {
+      id: "t1",
+      title: "T",
+      status: "todo",
+      priority: null,
+      description: "A task description",
+    };
     const result = formatTask(task);
     expect(result).toContain("A task description");
   });
@@ -144,7 +174,13 @@ describe("formatTask", () => {
   });
 
   it("includes result when present", () => {
-    const task = { id: "t1", title: "T", status: "done", priority: null, result: "Completed successfully" };
+    const task = {
+      id: "t1",
+      title: "T",
+      status: "done",
+      priority: null,
+      result: "Completed successfully",
+    };
     const result = formatTask(task);
     expect(result).toContain("Completed successfully");
   });
@@ -163,7 +199,14 @@ describe("formatTaskLogs", () => {
 
   it("includes the action for each log entry", () => {
     const logs = [
-      { id: "l1", task_id: "t1", actor_id: null, action: "created", detail: null, created_at: "2024-01-01T00:00:00.000Z" },
+      {
+        id: "l1",
+        task_id: "t1",
+        actor_id: null,
+        action: "created",
+        detail: null,
+        created_at: "2024-01-01T00:00:00.000Z",
+      },
     ];
     const result = formatTaskLogs(logs);
     expect(result).toContain("created");
@@ -171,7 +214,14 @@ describe("formatTaskLogs", () => {
 
   it("includes the detail text when present", () => {
     const logs = [
-      { id: "l1", task_id: "t1", actor_id: null, action: "commented", detail: "This is the detail", created_at: "2024-01-01T00:00:00.000Z" },
+      {
+        id: "l1",
+        task_id: "t1",
+        actor_id: null,
+        action: "commented",
+        detail: "This is the detail",
+        created_at: "2024-01-01T00:00:00.000Z",
+      },
     ];
     const result = formatTaskLogs(logs);
     expect(result).toContain("This is the detail");
@@ -179,7 +229,14 @@ describe("formatTaskLogs", () => {
 
   it("includes actor_id when present", () => {
     const logs = [
-      { id: "l1", task_id: "t1", actor_id: "agent-5", action: "claimed", detail: null, created_at: "2024-01-01T00:00:00.000Z" },
+      {
+        id: "l1",
+        task_id: "t1",
+        actor_id: "agent-5",
+        action: "claimed",
+        detail: null,
+        created_at: "2024-01-01T00:00:00.000Z",
+      },
     ];
     const result = formatTaskLogs(logs);
     expect(result).toContain("agent-5");
@@ -187,7 +244,14 @@ describe("formatTaskLogs", () => {
 
   it("omits actor bracket when actor_id is absent", () => {
     const logs = [
-      { id: "l1", task_id: "t1", actor_id: null, action: "created", detail: null, created_at: "2024-01-01T00:00:00.000Z" },
+      {
+        id: "l1",
+        task_id: "t1",
+        actor_id: null,
+        action: "created",
+        detail: null,
+        created_at: "2024-01-01T00:00:00.000Z",
+      },
     ];
     const result = formatTaskLogs(logs);
     expect(result).not.toContain("[null]");
@@ -196,8 +260,22 @@ describe("formatTaskLogs", () => {
 
   it("formats multiple log entries each on its own line", () => {
     const logs = [
-      { id: "l1", task_id: "t1", actor_id: null, action: "created", detail: null, created_at: "2024-01-01T00:00:00.000Z" },
-      { id: "l2", task_id: "t1", actor_id: "ag1", action: "claimed", detail: null, created_at: "2024-01-02T00:00:00.000Z" },
+      {
+        id: "l1",
+        task_id: "t1",
+        actor_id: null,
+        action: "created",
+        detail: null,
+        created_at: "2024-01-01T00:00:00.000Z",
+      },
+      {
+        id: "l2",
+        task_id: "t1",
+        actor_id: "ag1",
+        action: "claimed",
+        detail: null,
+        created_at: "2024-01-02T00:00:00.000Z",
+      },
     ];
     const result = formatTaskLogs(logs);
     const lines = result.split("\n");
@@ -206,7 +284,14 @@ describe("formatTaskLogs", () => {
 
   it("formats the created_at timestamp", () => {
     const logs = [
-      { id: "l1", task_id: "t1", actor_id: null, action: "created", detail: null, created_at: "2024-06-15T10:30:00.000Z" },
+      {
+        id: "l1",
+        task_id: "t1",
+        actor_id: null,
+        action: "created",
+        detail: null,
+        created_at: "2024-06-15T10:30:00.000Z",
+      },
     ];
     const result = formatTaskLogs(logs);
     // The timestamp should be a recognisable date string (locale-formatted)
@@ -344,13 +429,17 @@ describe("formatTaskList", () => {
   });
 
   it("includes repository name when present", () => {
-    const tasks = [{ id: "t1", title: "T", status: "todo", priority: null, repository_name: "my-repo" }];
+    const tasks = [
+      { id: "t1", title: "T", status: "todo", priority: null, repository_name: "my-repo" },
+    ];
     const result = formatTaskList(tasks);
     expect(result).toContain("my-repo");
   });
 
   it("includes assigned_to agent when present", () => {
-    const tasks = [{ id: "t1", title: "T", status: "todo", priority: null, assigned_to: "agent-9" }];
+    const tasks = [
+      { id: "t1", title: "T", status: "todo", priority: null, assigned_to: "agent-9" },
+    ];
     const result = formatTaskList(tasks);
     expect(result).toContain("agent-9");
   });
@@ -371,26 +460,40 @@ describe("formatAgentList", () => {
   });
 
   it("includes agent ID and name", () => {
-    const agents = [{ id: "a1", name: "Claude", status: "idle", task_count: 0, last_active_at: null }];
+    const agents = [
+      { id: "a1", name: "Claude", status: "idle", task_count: 0, last_active_at: null },
+    ];
     const result = formatAgentList(agents);
     expect(result).toContain("a1");
     expect(result).toContain("Claude");
   });
 
   it("includes status", () => {
-    const agents = [{ id: "a1", name: "Claude", status: "working", task_count: 2, last_active_at: null }];
+    const agents = [
+      { id: "a1", name: "Claude", status: "working", task_count: 2, last_active_at: null },
+    ];
     const result = formatAgentList(agents);
     expect(result).toContain("[working]");
   });
 
   it("shows 'never active' when last_active_at is null", () => {
-    const agents = [{ id: "a1", name: "Claude", status: "idle", task_count: 0, last_active_at: null }];
+    const agents = [
+      { id: "a1", name: "Claude", status: "idle", task_count: 0, last_active_at: null },
+    ];
     const result = formatAgentList(agents);
     expect(result).toContain("never active");
   });
 
   it("includes last_active_at when present", () => {
-    const agents = [{ id: "a1", name: "Claude", status: "idle", task_count: 0, last_active_at: "2024-01-01T00:00:00Z" }];
+    const agents = [
+      {
+        id: "a1",
+        name: "Claude",
+        status: "idle",
+        task_count: 0,
+        last_active_at: "2024-01-01T00:00:00Z",
+      },
+    ];
     const result = formatAgentList(agents);
     expect(result).toContain("2024-01-01T00:00:00Z");
   });
@@ -458,9 +561,7 @@ describe("formatBoard", () => {
   it("renders task titles inside column cells", () => {
     const board = {
       name: "My Board",
-      columns: [
-        { name: "Todo", tasks: [{ title: "Build feature" }] },
-      ],
+      columns: [{ name: "Todo", tasks: [{ title: "Build feature" }] }],
     };
     const result = formatBoard(board);
     expect(result).toContain("Build feature");
@@ -470,9 +571,7 @@ describe("formatBoard", () => {
     const longTitle = "A".repeat(40);
     const board = {
       name: "My Board",
-      columns: [
-        { name: "Todo", tasks: [{ title: longTitle }] },
-      ],
+      columns: [{ name: "Todo", tasks: [{ title: longTitle }] }],
     };
     const result = formatBoard(board);
     expect(result).toContain("...");
@@ -528,7 +627,10 @@ describe("getFormat", () => {
 describe("output", () => {
   it("calls textFormatter in text mode when provided", () => {
     let called = false;
-    const formatter = (_data: any) => { called = true; return "formatted"; };
+    const formatter = (_data: any) => {
+      called = true;
+      return "formatted";
+    };
     // Redirect console.log to avoid test noise
     const original = console.log;
     console.log = () => {};
@@ -540,7 +642,9 @@ describe("output", () => {
   it("falls back to JSON.stringify in text mode when no formatter provided", () => {
     let logged = "";
     const original = console.log;
-    console.log = (v: string) => { logged = v; };
+    console.log = (v: string) => {
+      logged = v;
+    };
     output({ foo: "bar" }, "text");
     console.log = original;
     expect(logged).toContain('"foo"');
@@ -549,7 +653,9 @@ describe("output", () => {
   it("outputs pretty-printed JSON in json mode", () => {
     let logged = "";
     const original = console.log;
-    console.log = (v: string) => { logged = v; };
+    console.log = (v: string) => {
+      logged = v;
+    };
     output({ foo: "bar" }, "json");
     console.log = original;
     expect(JSON.parse(logged)).toEqual({ foo: "bar" });

--- a/tests/repositories/repos-add-dialog-close.spec.ts
+++ b/tests/repositories/repos-add-dialog-close.spec.ts
@@ -1,39 +1,39 @@
 // spec: specs/agent-kanban.plan.md
 // section: 8.6 Close Add Repository dialog without submitting
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Repositories Page', () => {
-  test('Close Add Repository dialog without submitting', async ({ page }) => {
+test.describe("Repositories Page", () => {
+  test("Close Add Repository dialog without submitting", async ({ page }) => {
     // 1. Sign in, navigate to /repositories, open the Add Repository dialog
     await signUpAndGetBoard(page, `repos_close_${Date.now()}@example.com`);
-    await page.goto('/repositories');
+    await page.goto("/repositories");
 
-    await page.getByText('Repositories').first().waitFor({ state: 'visible' });
-    await page.getByRole('button', { name: 'Add Repository' }).click();
+    await page.getByText("Repositories").first().waitFor({ state: "visible" });
+    await page.getByRole("button", { name: "Add Repository" }).click();
 
     // expect: Dialog is open
-    await expect(page.getByRole('heading', { name: 'Add Repository' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add Repository" })).toBeVisible();
 
     // 2. Click the close button in the dialog header
-    await page.getByRole('button', { name: 'Close' }).click();
+    await page.getByRole("button", { name: "Close" }).click();
 
     // expect: The dialog closes without adding a repository
-    await expect(page.getByRole('heading', { name: 'Add Repository' })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add Repository" })).not.toBeVisible();
 
     // expect: The repository list is unchanged (still empty)
-    await expect(page.getByText('0 total')).toBeVisible();
-    await expect(page.getByText('No repositories registered.')).toBeVisible();
+    await expect(page.getByText("0 total")).toBeVisible();
+    await expect(page.getByText("No repositories registered.")).toBeVisible();
 
     // 3. Open the dialog again and close it by clicking the backdrop (outside the dialog)
-    await page.getByRole('button', { name: 'Add Repository' }).click();
-    await expect(page.getByRole('heading', { name: 'Add Repository' })).toBeVisible();
+    await page.getByRole("button", { name: "Add Repository" }).click();
+    await expect(page.getByRole("heading", { name: "Add Repository" })).toBeVisible();
 
     // Click on the backdrop area outside the dialog content
     await page.locator('[data-slot="dialog-overlay"]').click({ position: { x: 10, y: 10 } });
 
     // expect: The dialog closes via backdrop click
-    await expect(page.getByRole('heading', { name: 'Add Repository' })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add Repository" })).not.toBeVisible();
   });
 });

--- a/tests/repositories/repos-add-dialog-open.spec.ts
+++ b/tests/repositories/repos-add-dialog-open.spec.ts
@@ -1,31 +1,35 @@
 // spec: specs/agent-kanban.plan.md
 // section: 8.3 Open Add Repository dialog
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Repositories Page', () => {
-  test('Open Add Repository dialog', async ({ page }) => {
+test.describe("Repositories Page", () => {
+  test("Open Add Repository dialog", async ({ page }) => {
     // 1. Sign in, navigate to /repositories, and click 'Add Repository'
     await signUpAndGetBoard(page, `repos_dialog_${Date.now()}@example.com`);
-    await page.goto('/repositories');
+    await page.goto("/repositories");
 
-    await page.getByText('Repositories').first().waitFor({ state: 'visible' });
-    await page.getByRole('button', { name: 'Add Repository' }).click();
+    await page.getByText("Repositories").first().waitFor({ state: "visible" });
+    await page.getByRole("button", { name: "Add Repository" }).click();
 
     // expect: A modal dialog appears with the title 'Add Repository'
-    await expect(page.getByRole('heading', { name: 'Add Repository' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add Repository" })).toBeVisible();
 
     // expect: A 'Name' input field is present with placeholder 'my-repo'
-    await expect(page.getByRole('textbox', { name: 'my-repo' })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "my-repo" })).toBeVisible();
 
     // expect: A 'Clone URL' input field is present with placeholder 'https://github.com/user/repo.git'
-    await expect(page.getByRole('textbox', { name: 'https://github.com/user/repo.' })).toBeVisible();
+    await expect(
+      page.getByRole("textbox", { name: "https://github.com/user/repo." }),
+    ).toBeVisible();
 
     // expect: An 'Add Repository' submit button is present inside the dialog
-    await expect(page.getByRole('dialog').getByRole('button', { name: 'Add Repository' })).toBeVisible();
+    await expect(
+      page.getByRole("dialog").getByRole("button", { name: "Add Repository" }),
+    ).toBeVisible();
 
     // expect: A close button is visible in the dialog header
-    await expect(page.getByRole('button', { name: 'Close' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Close" })).toBeVisible();
   });
 });

--- a/tests/repositories/repos-add-success.spec.ts
+++ b/tests/repositories/repos-add-success.spec.ts
@@ -1,34 +1,36 @@
 // spec: specs/agent-kanban.plan.md
 // section: 8.5 Add Repository — successfully add a new repository
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Repositories Page', () => {
-  test('Add Repository — successfully add a new repository', async ({ page }) => {
+test.describe("Repositories Page", () => {
+  test("Add Repository — successfully add a new repository", async ({ page }) => {
     // 1. Sign in, navigate to /repositories, and open the Add Repository dialog
     await signUpAndGetBoard(page, `repos_add_${Date.now()}@example.com`);
-    await page.goto('/repositories');
+    await page.goto("/repositories");
 
-    await page.getByText('Repositories').first().waitFor({ state: 'visible' });
-    await page.getByRole('button', { name: 'Add Repository' }).click();
+    await page.getByText("Repositories").first().waitFor({ state: "visible" });
+    await page.getByRole("button", { name: "Add Repository" }).click();
 
     // expect: Dialog is open
-    await expect(page.getByRole('heading', { name: 'Add Repository' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add Repository" })).toBeVisible();
 
     // 2. Type 'test-repo' in Name and 'https://github.com/user/test-repo.git' in Clone URL,
     //    then click 'Add Repository'
-    await page.getByRole('textbox', { name: 'my-repo' }).fill('test-repo');
-    await page.getByRole('textbox', { name: 'https://github.com/user/repo.' }).fill('https://github.com/user/test-repo.git');
-    await page.getByRole('dialog').getByRole('button', { name: 'Add Repository' }).click();
+    await page.getByRole("textbox", { name: "my-repo" }).fill("test-repo");
+    await page
+      .getByRole("textbox", { name: "https://github.com/user/repo." })
+      .fill("https://github.com/user/test-repo.git");
+    await page.getByRole("dialog").getByRole("button", { name: "Add Repository" }).click();
 
     // expect: The dialog closes
-    await expect(page.getByRole('heading', { name: 'Add Repository' })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add Repository" })).not.toBeVisible();
 
     // expect: The new repository 'test-repo' appears at the top of the repositories list
-    await expect(page.getByText('test-repo', { exact: true })).toBeVisible();
+    await expect(page.getByText("test-repo", { exact: true })).toBeVisible();
 
     // expect: The total count in the header increments by 1
-    await expect(page.getByText('1 total')).toBeVisible();
+    await expect(page.getByText("1 total")).toBeVisible();
   });
 });

--- a/tests/repositories/repos-add-validation.spec.ts
+++ b/tests/repositories/repos-add-validation.spec.ts
@@ -1,40 +1,40 @@
 // spec: specs/agent-kanban.plan.md
 // section: 8.4 Add Repository — submit button disabled when fields are empty
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Repositories Page', () => {
-  test('Add Repository — submit button disabled when fields are empty', async ({ page }) => {
+test.describe("Repositories Page", () => {
+  test("Add Repository — submit button disabled when fields are empty", async ({ page }) => {
     // 1. Sign in, navigate to /repositories, click 'Add Repository' to open the dialog
     await signUpAndGetBoard(page, `repos_valid_${Date.now()}@example.com`);
-    await page.goto('/repositories');
+    await page.goto("/repositories");
 
-    await page.getByText('Repositories').first().waitFor({ state: 'visible' });
-    await page.getByRole('button', { name: 'Add Repository' }).click();
+    await page.getByText("Repositories").first().waitFor({ state: "visible" });
+    await page.getByRole("button", { name: "Add Repository" }).click();
 
-    await expect(page.getByRole('heading', { name: 'Add Repository' })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add Repository" })).toBeVisible();
 
-    const submitButton = page.getByRole('dialog').getByRole('button', { name: 'Add Repository' });
-    const nameInput = page.getByRole('textbox', { name: 'my-repo' });
-    const urlInput = page.getByRole('textbox', { name: 'https://github.com/user/repo.' });
+    const submitButton = page.getByRole("dialog").getByRole("button", { name: "Add Repository" });
+    const nameInput = page.getByRole("textbox", { name: "my-repo" });
+    const urlInput = page.getByRole("textbox", { name: "https://github.com/user/repo." });
 
     // expect: Both Name and Clone URL fields are empty
-    await expect(nameInput).toHaveValue('');
-    await expect(urlInput).toHaveValue('');
+    await expect(nameInput).toHaveValue("");
+    await expect(urlInput).toHaveValue("");
 
     // 2. Observe the 'Add Repository' submit button state
     // expect: The submit button is disabled when either or both fields are empty
     await expect(submitButton).toBeDisabled();
 
     // 3. Enter 'my-repo' in Name but leave URL empty
-    await nameInput.fill('my-repo');
+    await nameInput.fill("my-repo");
 
     // expect: The submit button remains disabled
     await expect(submitButton).toBeDisabled();
 
     // 4. Enter a URL in the Clone URL field as well
-    await urlInput.fill('https://github.com/user/my-repo.git');
+    await urlInput.fill("https://github.com/user/my-repo.git");
 
     // expect: The submit button becomes enabled
     await expect(submitButton).toBeEnabled();

--- a/tests/repositories/repos-empty-state.spec.ts
+++ b/tests/repositories/repos-empty-state.spec.ts
@@ -1,32 +1,32 @@
 // spec: specs/agent-kanban.plan.md
 // section: 8.1 Repositories page renders empty state with CLI instructions
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Repositories Page', () => {
-  test('Repositories page renders empty state with CLI instructions', async ({ page }) => {
+test.describe("Repositories Page", () => {
+  test("Repositories page renders empty state with CLI instructions", async ({ page }) => {
     // 1. Sign in as a user with no repositories and navigate to /repositories
     await signUpAndGetBoard(page, `repos_empty_${Date.now()}@example.com`);
-    await page.goto('/repositories');
+    await page.goto("/repositories");
 
-    await page.getByText('Repositories').first().waitFor({ state: 'visible' });
+    await page.getByText("Repositories").first().waitFor({ state: "visible" });
 
     // expect: Page heading 'Repositories' is displayed with '0 total' count
-    await expect(page.getByRole('heading', { name: 'Repositories' })).toBeVisible();
-    await expect(page.getByText('0 total')).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Repositories" })).toBeVisible();
+    await expect(page.getByText("0 total")).toBeVisible();
 
     // expect: An 'Add Repository' button is present in the header
-    await expect(page.getByRole('button', { name: 'Add Repository' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Add Repository" })).toBeVisible();
 
     // expect: The empty state shows 'No repositories registered.'
-    await expect(page.getByText('No repositories registered.')).toBeVisible();
+    await expect(page.getByText("No repositories registered.")).toBeVisible();
 
     // expect: Instructions mention the 'ak link' CLI command with a code block
-    await expect(page.getByText('ak link')).toBeVisible();
-    await expect(page.getByText('npx agent-kanban link')).toBeVisible();
+    await expect(page.getByText("ak link")).toBeVisible();
+    await expect(page.getByText("npx agent-kanban link")).toBeVisible();
 
     // expect: An 'add manually' link is shown for manual addition
-    await expect(page.getByRole('button', { name: 'add manually' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "add manually" })).toBeVisible();
   });
 });

--- a/tests/repositories/repos-list.spec.ts
+++ b/tests/repositories/repos-list.spec.ts
@@ -1,33 +1,35 @@
 // spec: specs/agent-kanban.plan.md
 // section: 8.2 Repositories page lists repositories with metadata
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Repositories Page', () => {
-  test('Repositories page lists repositories with metadata', async ({ page }) => {
+test.describe("Repositories Page", () => {
+  test("Repositories page lists repositories with metadata", async ({ page }) => {
     // 1. Sign in as a user with at least one repository and navigate to /repositories
     await signUpAndGetBoard(page, `repos_list_${Date.now()}@example.com`);
-    await page.goto('/repositories');
+    await page.goto("/repositories");
 
-    await page.getByText('Repositories').first().waitFor({ state: 'visible' });
+    await page.getByText("Repositories").first().waitFor({ state: "visible" });
 
     // Add a repository first so we have something to list
-    await page.getByRole('button', { name: 'Add Repository' }).click();
-    await page.getByRole('textbox', { name: 'my-repo' }).fill('list-repo');
-    await page.getByRole('textbox', { name: 'https://github.com/user/repo.' }).fill('https://github.com/user/list-repo.git');
-    await page.getByRole('dialog').getByRole('button', { name: 'Add Repository' }).click();
+    await page.getByRole("button", { name: "Add Repository" }).click();
+    await page.getByRole("textbox", { name: "my-repo" }).fill("list-repo");
+    await page
+      .getByRole("textbox", { name: "https://github.com/user/repo." })
+      .fill("https://github.com/user/list-repo.git");
+    await page.getByRole("dialog").getByRole("button", { name: "Add Repository" }).click();
 
     // expect: Each repository card shows name, clone URL, task count, and added date
-    await expect(page.getByText('list-repo', { exact: true })).toBeVisible();
-    await expect(page.getByText('https://github.com/user/list-repo').first()).toBeVisible();
+    await expect(page.getByText("list-repo", { exact: true })).toBeVisible();
+    await expect(page.getByText("https://github.com/user/list-repo").first()).toBeVisible();
     await expect(page.getByText(/Tasks:/)).toBeVisible();
     await expect(page.getByText(/Added:/)).toBeVisible();
 
     // expect: The count in the header shows the total number of repositories
-    await expect(page.getByText('1 total')).toBeVisible();
+    await expect(page.getByText("1 total")).toBeVisible();
 
     // expect: A 'Remove' button is visible on each repository card
-    await expect(page.getByRole('button', { name: 'Remove' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Remove" })).toBeVisible();
   });
 });

--- a/tests/repositories/repos-remove.spec.ts
+++ b/tests/repositories/repos-remove.spec.ts
@@ -1,35 +1,37 @@
 // spec: specs/agent-kanban.plan.md
 // section: 8.7 Remove a repository
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Repositories Page', () => {
-  test('Remove a repository', async ({ page }) => {
+test.describe("Repositories Page", () => {
+  test("Remove a repository", async ({ page }) => {
     // 1. Sign in, navigate to /repositories with at least one repository present
     await signUpAndGetBoard(page, `repos_remove_${Date.now()}@example.com`);
-    await page.goto('/repositories');
+    await page.goto("/repositories");
 
-    await page.getByText('Repositories').first().waitFor({ state: 'visible' });
+    await page.getByText("Repositories").first().waitFor({ state: "visible" });
 
     // Add a repository so we have one to remove
-    await page.getByRole('button', { name: 'Add Repository' }).click();
-    await page.getByRole('textbox', { name: 'my-repo' }).fill('remove-me');
-    await page.getByRole('textbox', { name: 'https://github.com/user/repo.' }).fill('https://github.com/user/remove-me.git');
-    await page.getByRole('dialog').getByRole('button', { name: 'Add Repository' }).click();
+    await page.getByRole("button", { name: "Add Repository" }).click();
+    await page.getByRole("textbox", { name: "my-repo" }).fill("remove-me");
+    await page
+      .getByRole("textbox", { name: "https://github.com/user/repo." })
+      .fill("https://github.com/user/remove-me.git");
+    await page.getByRole("dialog").getByRole("button", { name: "Add Repository" }).click();
 
     // expect: Repository cards are shown, each with a 'Remove' button
-    await expect(page.getByText('remove-me', { exact: true })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Remove' })).toBeVisible();
-    await expect(page.getByText('1 total')).toBeVisible();
+    await expect(page.getByText("remove-me", { exact: true })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Remove" })).toBeVisible();
+    await expect(page.getByText("1 total")).toBeVisible();
 
     // 2. Click the 'Remove' button on a repository card
-    await page.getByRole('button', { name: 'Remove' }).click();
+    await page.getByRole("button", { name: "Remove" }).click();
 
     // expect: The repository card disappears from the list immediately
-    await expect(page.getByText('remove-me', { exact: true })).not.toBeVisible();
+    await expect(page.getByText("remove-me", { exact: true })).not.toBeVisible();
 
     // expect: The total count in the header decrements by 1
-    await expect(page.getByText('0 total')).toBeVisible();
+    await expect(page.getByText("0 total")).toBeVisible();
   });
 });

--- a/tests/repository-repo.test.ts
+++ b/tests/repository-repo.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
-import { createTestEnv, setupMiniflare, seedUser } from "./helpers/db";
+
+import type { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestEnv, seedUser, setupMiniflare } from "./helpers/db";
 
 const env = createTestEnv();
 let mf: Miniflare;
@@ -41,7 +42,10 @@ describe("normalizeGitUrl", () => {
 describe("repositoryRepo", () => {
   it("createRepository creates a repo", async () => {
     const { createRepository } = await import("../apps/web/functions/api/repositoryRepo");
-    const repo = await createRepository(env.DB, "repo-test-user", { name: "my-repo", url: "https://github.com/org/my-repo" });
+    const repo = await createRepository(env.DB, "repo-test-user", {
+      name: "my-repo",
+      url: "https://github.com/org/my-repo",
+    });
     expect(repo.name).toBe("my-repo");
     expect(repo.url).toBe("https://github.com/org/my-repo");
   });
@@ -54,29 +58,42 @@ describe("repositoryRepo", () => {
 
   it("listRepositories filters by URL", async () => {
     const { listRepositories } = await import("../apps/web/functions/api/repositoryRepo");
-    const repos = await listRepositories(env.DB, "repo-test-user", { url: "https://github.com/org/my-repo" });
+    const repos = await listRepositories(env.DB, "repo-test-user", {
+      url: "https://github.com/org/my-repo",
+    });
     expect(repos.length).toBe(1);
     expect(repos[0].url).toBe("https://github.com/org/my-repo");
   });
 
   it("listRepositories URL filter normalizes input", async () => {
     const { listRepositories } = await import("../apps/web/functions/api/repositoryRepo");
-    const repos = await listRepositories(env.DB, "repo-test-user", { url: "git@github.com:org/my-repo.git" });
+    const repos = await listRepositories(env.DB, "repo-test-user", {
+      url: "git@github.com:org/my-repo.git",
+    });
     expect(repos.length).toBe(1);
   });
 
   it("listRepositories returns empty for unknown URL", async () => {
     const { listRepositories } = await import("../apps/web/functions/api/repositoryRepo");
-    const repos = await listRepositories(env.DB, "repo-test-user", { url: "https://github.com/org/nonexistent" });
+    const repos = await listRepositories(env.DB, "repo-test-user", {
+      url: "https://github.com/org/nonexistent",
+    });
     expect(repos.length).toBe(0);
   });
 
   it("deleteRepository removes a repo", async () => {
-    const { createRepository, deleteRepository, listRepositories } = await import("../apps/web/functions/api/repositoryRepo");
-    const repo = await createRepository(env.DB, "repo-test-user", { name: "del-repo", url: "https://github.com/org/del-repo" });
+    const { createRepository, deleteRepository, listRepositories } = await import(
+      "../apps/web/functions/api/repositoryRepo"
+    );
+    const repo = await createRepository(env.DB, "repo-test-user", {
+      name: "del-repo",
+      url: "https://github.com/org/del-repo",
+    });
     const deleted = await deleteRepository(env.DB, repo.id);
     expect(deleted).toBe(true);
-    const repos = await listRepositories(env.DB, "repo-test-user", { url: "https://github.com/org/del-repo" });
+    const repos = await listRepositories(env.DB, "repo-test-user", {
+      url: "https://github.com/org/del-repo",
+    });
     expect(repos.length).toBe(0);
   });
 
@@ -88,14 +105,23 @@ describe("repositoryRepo", () => {
 
   it("findOrCreateRepository creates if not found", async () => {
     const { findOrCreateRepository } = await import("../apps/web/functions/api/repositoryRepo");
-    const repo = await findOrCreateRepository(env.DB, "repo-test-user", { name: "find-create", url: "https://github.com/org/find-create" });
+    const repo = await findOrCreateRepository(env.DB, "repo-test-user", {
+      name: "find-create",
+      url: "https://github.com/org/find-create",
+    });
     expect(repo.name).toBe("find-create");
   });
 
   it("findOrCreateRepository returns existing if found", async () => {
     const { findOrCreateRepository } = await import("../apps/web/functions/api/repositoryRepo");
-    const first = await findOrCreateRepository(env.DB, "repo-test-user", { name: "find-create-dup", url: "https://github.com/org/find-create-dup" });
-    const second = await findOrCreateRepository(env.DB, "repo-test-user", { name: "find-create-dup-2", url: "https://github.com/org/find-create-dup" });
+    const first = await findOrCreateRepository(env.DB, "repo-test-user", {
+      name: "find-create-dup",
+      url: "https://github.com/org/find-create-dup",
+    });
+    const second = await findOrCreateRepository(env.DB, "repo-test-user", {
+      name: "find-create-dup-2",
+      url: "https://github.com/org/find-create-dup",
+    });
     expect(second.id).toBe(first.id);
   });
 

--- a/tests/review-cancel.test.ts
+++ b/tests/review-cancel.test.ts
@@ -1,8 +1,5 @@
-import { describe, it, expect } from "vitest";
-import {
-  TASK_STATUSES,
-  TASK_ACTIONS,
-} from "@agent-kanban/shared";
+import { TASK_ACTIONS, TASK_STATUSES } from "@agent-kanban/shared";
+import { describe, expect, it } from "vitest";
 
 describe("task statuses", () => {
   it("TASK_STATUSES includes 'in_review' at position 2", () => {
@@ -14,13 +11,7 @@ describe("task statuses", () => {
   });
 
   it("TASK_STATUSES has the full ordered list", () => {
-    expect([...TASK_STATUSES]).toEqual([
-      "todo",
-      "in_progress",
-      "in_review",
-      "done",
-      "cancelled",
-    ]);
+    expect([...TASK_STATUSES]).toEqual(["todo", "in_progress", "in_review", "done", "cancelled"]);
   });
 
   it("'in_review' comes after 'in_progress' and before 'done'", () => {

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -1,18 +1,28 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
-import { randomUUID } from "crypto";
+
+import { randomUUID } from "node:crypto";
 import { SignJWT } from "jose";
-import { createTestEnv, setupMiniflare, seedUser } from "./helpers/db";
+import type { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestEnv, seedUser, setupMiniflare } from "./helpers/db";
 
 const BETTER_AUTH_URL = "http://localhost:8788";
 const env = createTestEnv();
 let mf: Miniflare;
 
-async function apiRequest(method: string, path: string, body?: Record<string, unknown>, token?: string) {
+async function apiRequest(
+  method: string,
+  path: string,
+  body?: Record<string, unknown>,
+  token?: string,
+) {
   const { api } = await import("../apps/web/functions/api/routes");
-  const headers: Record<string, string> = { "Content-Type": "application/json", Host: "localhost:8788", "x-forwarded-proto": "http" };
-  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Host: "localhost:8788",
+    "x-forwarded-proto": "http",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
   const init: RequestInit = { method, headers };
   if (body && method !== "GET") init.body = JSON.stringify(body);
   return api.request(path, init, env);
@@ -54,23 +64,43 @@ describe("routes", () => {
     await seedUser(env.DB, userId, "routes@test.com");
     apiKey = await createApiKeyForUser(userId);
 
-    const machineRes = await apiRequest("POST", "/api/machines", {
-      name: "routes-machine", os: "darwin", version: "1.0.0", runtimes: ["Claude Code"],
-    }, apiKey);
+    const machineRes = await apiRequest(
+      "POST",
+      "/api/machines",
+      {
+        name: "routes-machine",
+        os: "darwin",
+        version: "1.0.0",
+        runtimes: ["Claude Code"],
+      },
+      apiKey,
+    );
     expect(machineRes.status).toBe(201);
     machineId = ((await machineRes.json()) as { id: string }).id;
 
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
-    const agent = await createAgent(env.DB, userId, { name: "Routes Agent", runtime: "Claude Code" });
+    const agent = await createAgent(env.DB, userId, {
+      name: "Routes Agent",
+      runtime: "Claude Code",
+    });
     agentId = agent.id;
 
     sessionId = randomUUID();
-    const keypair = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, ["sign", "verify"]);
+    const keypair = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, [
+      "sign",
+      "verify",
+    ]);
     sessionPrivateKey = (keypair as any).privateKey;
     const pubJwk = await crypto.subtle.exportKey("jwk", (keypair as any).publicKey);
-    await apiRequest("POST", `/api/agents/${agentId}/sessions`, {
-      session_id: sessionId, session_public_key: pubJwk.x!,
-    }, apiKey);
+    await apiRequest(
+      "POST",
+      `/api/agents/${agentId}/sessions`,
+      {
+        session_id: sessionId,
+        session_public_key: pubJwk.x!,
+      },
+      apiKey,
+    );
 
     const { createBoard } = await import("../apps/web/functions/api/boardRepo");
     const board = await createBoard(env.DB, userId, "routes-board");
@@ -82,7 +112,7 @@ describe("routes", () => {
   it("returns 401 for missing token", async () => {
     const res = await apiRequest("GET", "/api/boards");
     expect(res.status).toBe(401);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.error.code).toBe("UNAUTHORIZED");
   });
 
@@ -98,7 +128,7 @@ describe("routes", () => {
   it("onError returns structured error for HTTPException", async () => {
     const res = await apiRequest("GET", "/api/boards/nonexistent", undefined, apiKey);
     expect(res.status).toBe(404);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.error).toBeDefined();
     expect(body.error.message).toBe("Board not found");
   });
@@ -106,9 +136,14 @@ describe("routes", () => {
   // ─── Boards ───
 
   it("POST /api/boards creates a board", async () => {
-    const res = await apiRequest("POST", "/api/boards", { name: "Route Board", description: "Test" }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      "/api/boards",
+      { name: "Route Board", description: "Test" },
+      apiKey,
+    );
     expect(res.status).toBe(201);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.name).toBe("Route Board");
     expect(body.description).toBe("Test");
   });
@@ -121,7 +156,7 @@ describe("routes", () => {
   it("GET /api/boards lists boards", async () => {
     const res = await apiRequest("GET", "/api/boards", undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(Array.isArray(body)).toBe(true);
     expect(body.length).toBeGreaterThanOrEqual(1);
   });
@@ -129,7 +164,7 @@ describe("routes", () => {
   it("GET /api/boards?name= finds board by name", async () => {
     const res = await apiRequest("GET", "/api/boards?name=Route Board", undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.name).toBe("Route Board");
   });
 
@@ -141,7 +176,7 @@ describe("routes", () => {
   it("GET /api/boards/:id returns board with tasks", async () => {
     const res = await apiRequest("GET", `/api/boards/${boardId}`, undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.id).toBe(boardId);
     expect(Array.isArray(body.tasks)).toBe(true);
   });
@@ -152,9 +187,14 @@ describe("routes", () => {
   });
 
   it("PATCH /api/boards/:id updates board", async () => {
-    const res = await apiRequest("PATCH", `/api/boards/${boardId}`, { name: "Updated Board" }, apiKey);
+    const res = await apiRequest(
+      "PATCH",
+      `/api/boards/${boardId}`,
+      { name: "Updated Board" },
+      apiKey,
+    );
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.name).toBe("Updated Board");
   });
 
@@ -168,7 +208,7 @@ describe("routes", () => {
     const board = await createBoard(env.DB, userId, "Delete Route Board");
     const res = await apiRequest("DELETE", `/api/boards/${board.id}`, undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.ok).toBe(true);
   });
 
@@ -180,9 +220,14 @@ describe("routes", () => {
   // ─── Repositories ───
 
   it("POST /api/repositories creates a repository", async () => {
-    const res = await apiRequest("POST", "/api/repositories", { name: "test-repo", url: "https://github.com/org/test-repo" }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      "/api/repositories",
+      { name: "test-repo", url: "https://github.com/org/test-repo" },
+      apiKey,
+    );
     expect(res.status).toBe(201);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.name).toBe("test-repo");
     expect(body.url).toBe("https://github.com/org/test-repo");
   });
@@ -195,24 +240,32 @@ describe("routes", () => {
   it("GET /api/repositories lists repositories", async () => {
     const res = await apiRequest("GET", "/api/repositories", undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(Array.isArray(body)).toBe(true);
     expect(body.length).toBeGreaterThanOrEqual(1);
   });
 
   it("GET /api/repositories?url= filters by URL", async () => {
-    const res = await apiRequest("GET", "/api/repositories?url=https://github.com/org/test-repo", undefined, apiKey);
+    const res = await apiRequest(
+      "GET",
+      "/api/repositories?url=https://github.com/org/test-repo",
+      undefined,
+      apiKey,
+    );
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.length).toBeGreaterThanOrEqual(1);
   });
 
   it("DELETE /api/repositories/:id deletes a repository", async () => {
     const { createRepository } = await import("../apps/web/functions/api/repositoryRepo");
-    const repo = await createRepository(env.DB, userId, { name: "del-repo", url: "https://github.com/org/del-repo" });
+    const repo = await createRepository(env.DB, userId, {
+      name: "del-repo",
+      url: "https://github.com/org/del-repo",
+    });
     const res = await apiRequest("DELETE", `/api/repositories/${repo.id}`, undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.ok).toBe(true);
   });
 
@@ -226,14 +279,14 @@ describe("routes", () => {
   it("GET /api/agents lists agents", async () => {
     const res = await apiRequest("GET", "/api/agents", undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(Array.isArray(body)).toBe(true);
   });
 
   it("GET /api/agents/:id returns agent with logs", async () => {
     const res = await apiRequest("GET", `/api/agents/${agentId}`, undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.id).toBe(agentId);
     expect(body).toHaveProperty("logs");
   });
@@ -246,7 +299,7 @@ describe("routes", () => {
   it("POST /api/agents creates an agent", async () => {
     const res = await apiRequest("POST", "/api/agents", { name: "New Route Agent" }, apiKey);
     expect(res.status).toBe(201);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.name).toBe("New Route Agent");
   });
 
@@ -256,16 +309,26 @@ describe("routes", () => {
   });
 
   it("POST /api/agents rejects reserved role", async () => {
-    const res = await apiRequest("POST", "/api/agents", { name: "Bad Role", role: "quality-goalkeeper" }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      "/api/agents",
+      { name: "Bad Role", role: "quality-goalkeeper" },
+      apiKey,
+    );
     expect(res.status).toBe(403);
   });
 
   // ─── Tasks ───
 
   it("POST /api/tasks creates a task", async () => {
-    const res = await apiRequest("POST", "/api/tasks", { title: "Route Task", board_id: boardId }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      "/api/tasks",
+      { title: "Route Task", board_id: boardId },
+      apiKey,
+    );
     expect(res.status).toBe(201);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.title).toBe("Route Task");
   });
 
@@ -275,14 +338,19 @@ describe("routes", () => {
   });
 
   it("POST /api/tasks rejects non-object input", async () => {
-    const res = await apiRequest("POST", "/api/tasks", { title: "Bad Input", board_id: boardId, input: "string" }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      "/api/tasks",
+      { title: "Bad Input", board_id: boardId, input: "string" },
+      apiKey,
+    );
     expect(res.status).toBe(400);
   });
 
   it("GET /api/tasks lists tasks", async () => {
     const res = await apiRequest("GET", "/api/tasks", undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(Array.isArray(body)).toBe(true);
   });
 
@@ -291,7 +359,7 @@ describe("routes", () => {
     const task = await createTask(env.DB, userId, { title: "Get Task", board_id: boardId });
     const res = await apiRequest("GET", `/api/tasks/${task.id}`, undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.id).toBe(task.id);
   });
 
@@ -305,7 +373,7 @@ describe("routes", () => {
     const task = await createTask(env.DB, userId, { title: "Patch Task", board_id: boardId });
     const res = await apiRequest("PATCH", `/api/tasks/${task.id}`, { title: "Patched" }, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.title).toBe("Patched");
   });
 
@@ -326,7 +394,7 @@ describe("routes", () => {
     const task = await createTask(env.DB, userId, { title: "Delete Task", board_id: boardId });
     const res = await apiRequest("DELETE", `/api/tasks/${task.id}`, undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.ok).toBe(true);
   });
 
@@ -340,9 +408,14 @@ describe("routes", () => {
   it("POST /api/tasks/:id/assign assigns a task", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Assign Task", board_id: boardId });
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/assign`, { agent_id: agentId }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      `/api/tasks/${task.id}/assign`,
+      { agent_id: agentId },
+      apiKey,
+    );
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.assigned_to).toBe(agentId);
   });
 
@@ -350,9 +423,14 @@ describe("routes", () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Complete Task", board_id: boardId });
     await env.DB.prepare("UPDATE tasks SET status = 'in_review' WHERE id = ?").bind(task.id).run();
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/complete`, { result: "done" }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      `/api/tasks/${task.id}/complete`,
+      { result: "done" },
+      apiKey,
+    );
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.status).toBe("done");
   });
 
@@ -360,7 +438,9 @@ describe("routes", () => {
     const { createTask, assignTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Release Task", board_id: boardId });
     await assignTask(env.DB, task.id, agentId);
-    await env.DB.prepare("UPDATE tasks SET status = 'in_progress' WHERE id = ?").bind(task.id).run();
+    await env.DB.prepare("UPDATE tasks SET status = 'in_progress' WHERE id = ?")
+      .bind(task.id)
+      .run();
     const res = await apiRequest("POST", `/api/tasks/${task.id}/release`, {}, apiKey);
     expect(res.status).toBe(200);
   });
@@ -368,10 +448,12 @@ describe("routes", () => {
   it("POST /api/tasks/:id/cancel cancels a task", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Cancel Task", board_id: boardId });
-    await env.DB.prepare("UPDATE tasks SET status = 'in_progress' WHERE id = ?").bind(task.id).run();
+    await env.DB.prepare("UPDATE tasks SET status = 'in_progress' WHERE id = ?")
+      .bind(task.id)
+      .run();
     const res = await apiRequest("POST", `/api/tasks/${task.id}/cancel`, {}, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.status).toBe("cancelled");
   });
 
@@ -381,7 +463,7 @@ describe("routes", () => {
     await env.DB.prepare("UPDATE tasks SET status = 'in_review' WHERE id = ?").bind(task.id).run();
     const res = await apiRequest("POST", `/api/tasks/${task.id}/reject`, {}, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.status).toBe("in_progress");
   });
 
@@ -390,9 +472,14 @@ describe("routes", () => {
   it("POST /api/tasks/:id/logs creates a log", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Log Task", board_id: boardId });
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/logs`, { detail: "A log entry" }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      `/api/tasks/${task.id}/logs`,
+      { detail: "A log entry" },
+      apiKey,
+    );
     expect(res.status).toBe(201);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.detail).toBe("A log entry");
   });
 
@@ -414,7 +501,7 @@ describe("routes", () => {
     await addTaskLog(env.DB, task.id, null, "commented", "Test log");
     const res = await apiRequest("GET", `/api/tasks/${task.id}/logs`, undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(Array.isArray(body)).toBe(true);
     expect(body.length).toBeGreaterThanOrEqual(1);
   });
@@ -429,11 +516,17 @@ describe("routes", () => {
   it("POST /api/tasks/:id/messages creates a message", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Msg Task", board_id: boardId });
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/messages`, {
-      sender_type: "user", content: "Hello",
-    }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      `/api/tasks/${task.id}/messages`,
+      {
+        sender_type: "user",
+        content: "Hello",
+      },
+      apiKey,
+    );
     expect(res.status).toBe(201);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.content).toBe("Hello");
     expect(body.sender_type).toBe("user");
   });
@@ -441,23 +534,40 @@ describe("routes", () => {
   it("POST /api/tasks/:id/messages requires sender_type and content", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Msg Task 2", board_id: boardId });
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/messages`, { content: "No sender" }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      `/api/tasks/${task.id}/messages`,
+      { content: "No sender" },
+      apiKey,
+    );
     expect(res.status).toBe(400);
   });
 
   it("POST /api/tasks/:id/messages rejects invalid sender_type", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Msg Task 3", board_id: boardId });
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/messages`, {
-      sender_type: "bot", content: "Bad type",
-    }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      `/api/tasks/${task.id}/messages`,
+      {
+        sender_type: "bot",
+        content: "Bad type",
+      },
+      apiKey,
+    );
     expect(res.status).toBe(400);
   });
 
   it("POST /api/tasks/:id/messages returns 404 for unknown task", async () => {
-    const res = await apiRequest("POST", "/api/tasks/nonexistent/messages", {
-      sender_type: "user", content: "X",
-    }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      "/api/tasks/nonexistent/messages",
+      {
+        sender_type: "user",
+        content: "X",
+      },
+      apiKey,
+    );
     expect(res.status).toBe(404);
   });
 
@@ -468,7 +578,7 @@ describe("routes", () => {
     await createMessage(env.DB, task.id, "user", userId, "Test msg");
     const res = await apiRequest("GET", `/api/tasks/${task.id}/messages`, undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(Array.isArray(body)).toBe(true);
     expect(body.length).toBeGreaterThanOrEqual(1);
   });
@@ -493,14 +603,14 @@ describe("routes", () => {
   it("GET /api/machines lists machines", async () => {
     const res = await apiRequest("GET", "/api/machines", undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(Array.isArray(body)).toBe(true);
   });
 
   it("GET /api/machines/:id returns a machine", async () => {
     const res = await apiRequest("GET", `/api/machines/${machineId}`, undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.id).toBe(machineId);
   });
 
@@ -510,12 +620,22 @@ describe("routes", () => {
   });
 
   it("POST /api/machines/:id/heartbeat updates machine", async () => {
-    const res = await apiRequest("POST", `/api/machines/${machineId}/heartbeat`, { version: "2.0.0" }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      `/api/machines/${machineId}/heartbeat`,
+      { version: "2.0.0" },
+      apiKey,
+    );
     expect(res.status).toBe(200);
   });
 
   it("POST /api/machines/:id/heartbeat returns 404 for unknown machine", async () => {
-    const res = await apiRequest("POST", "/api/machines/nonexistent/heartbeat", { version: "1.0.0" }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      "/api/machines/nonexistent/heartbeat",
+      { version: "1.0.0" },
+      apiKey,
+    );
     expect(res.status).toBe(404);
   });
 
@@ -529,7 +649,7 @@ describe("routes", () => {
   it("GET /api/agents/:agentId/sessions lists sessions", async () => {
     const res = await apiRequest("GET", `/api/agents/${agentId}/sessions`, undefined, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(Array.isArray(body)).toBe(true);
   });
 
@@ -539,12 +659,22 @@ describe("routes", () => {
   });
 
   it("DELETE /api/agents/:agentId/sessions/:sessionId closes session", async () => {
-    const res = await apiRequest("DELETE", `/api/agents/${agentId}/sessions/${sessionId}`, undefined, apiKey);
+    const res = await apiRequest(
+      "DELETE",
+      `/api/agents/${agentId}/sessions/${sessionId}`,
+      undefined,
+      apiKey,
+    );
     expect(res.status).toBe(200);
   });
 
   it("POST /api/agents/:agentId/sessions/:sessionId/reopen reopens session", async () => {
-    const res = await apiRequest("POST", `/api/agents/${agentId}/sessions/${sessionId}/reopen`, {}, apiKey);
+    const res = await apiRequest(
+      "POST",
+      `/api/agents/${agentId}/sessions/${sessionId}/reopen`,
+      {},
+      apiKey,
+    );
     expect(res.status).toBe(200);
   });
 
@@ -580,18 +710,23 @@ describe("routes", () => {
     const jwt = await signSessionJWT();
     const res = await apiRequest("POST", `/api/tasks/${task.id}/claim`, {}, jwt);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.status).toBe("in_progress");
   });
 
   it("POST /api/tasks/:id/review works with agent JWT", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, userId, { title: "Agent Review Task", board_id: boardId });
-    await env.DB.prepare("UPDATE tasks SET status = 'in_progress', assigned_to = ? WHERE id = ?").bind(agentId, task.id).run();
+    const task = await createTask(env.DB, userId, {
+      title: "Agent Review Task",
+      board_id: boardId,
+    });
+    await env.DB.prepare("UPDATE tasks SET status = 'in_progress', assigned_to = ? WHERE id = ?")
+      .bind(agentId, task.id)
+      .run();
     const jwt = await signSessionJWT();
     const res = await apiRequest("POST", `/api/tasks/${task.id}/review`, {}, jwt);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.status).toBe("in_review");
   });
 
@@ -599,8 +734,16 @@ describe("routes", () => {
 
   it("POST /api/tasks/:id/assign triggers stale detection", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, userId, { title: "Assign Stale Task", board_id: boardId });
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/assign`, { agent_id: agentId }, apiKey);
+    const task = await createTask(env.DB, userId, {
+      title: "Assign Stale Task",
+      board_id: boardId,
+    });
+    const res = await apiRequest(
+      "POST",
+      `/api/tasks/${task.id}/assign`,
+      { agent_id: agentId },
+      apiKey,
+    );
     expect(res.status).toBe(200);
   });
 });

--- a/tests/routing/unauthenticated-agents-redirect.spec.ts
+++ b/tests/routing/unauthenticated-agents-redirect.spec.ts
@@ -1,19 +1,22 @@
 // spec: specs/agent-kanban.plan.md
 // section: 2.4 Protected agents URL redirects unauthenticated user to /auth
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Routing and Navigation Guards', () => {
-  test('Protected agents URL redirects unauthenticated user to /auth', async ({ page, context }) => {
+test.describe("Routing and Navigation Guards", () => {
+  test("Protected agents URL redirects unauthenticated user to /auth", async ({
+    page,
+    context,
+  }) => {
     // 1. With no active session, navigate to /agents
     await context.clearCookies();
 
-    await page.goto('/agents');
+    await page.goto("/agents");
 
     // expect: The browser is redirected to /auth
     await expect(page).toHaveURL(/\/auth/, { timeout: 5000 });
 
     // The sign-in form should be displayed
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
   });
 });

--- a/tests/routing/unauthenticated-board-redirect.spec.ts
+++ b/tests/routing/unauthenticated-board-redirect.spec.ts
@@ -1,20 +1,20 @@
 // spec: specs/agent-kanban.plan.md
 // section: 2.2 Protected board URL redirects unauthenticated user to /auth
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Routing and Navigation Guards', () => {
-  test('Protected board URL redirects unauthenticated user to /auth', async ({ page, context }) => {
+test.describe("Routing and Navigation Guards", () => {
+  test("Protected board URL redirects unauthenticated user to /auth", async ({ page, context }) => {
     // 1. With no active session, navigate to /boards/some-board-id
     await context.clearCookies();
 
-    await page.goto('/boards/some-board-id');
+    await page.goto("/boards/some-board-id");
 
     // expect: The browser is redirected to /auth
     await expect(page).toHaveURL(/\/auth/, { timeout: 5000 });
 
     // expect: The sign-in form is displayed
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
   });
 });

--- a/tests/routing/unauthenticated-machines-redirect.spec.ts
+++ b/tests/routing/unauthenticated-machines-redirect.spec.ts
@@ -1,20 +1,23 @@
 // spec: specs/agent-kanban.plan.md
 // section: 2.3 Protected machines URL redirects unauthenticated user to /auth
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Routing and Navigation Guards', () => {
-  test('Protected machines URL redirects unauthenticated user to /auth', async ({ page, context }) => {
+test.describe("Routing and Navigation Guards", () => {
+  test("Protected machines URL redirects unauthenticated user to /auth", async ({
+    page,
+    context,
+  }) => {
     // 1. With no active session, navigate to /machines
     await context.clearCookies();
 
-    await page.goto('/machines');
+    await page.goto("/machines");
 
     // expect: The browser is redirected to /auth
     await expect(page).toHaveURL(/\/auth/, { timeout: 5000 });
 
     // expect: The sign-in form is displayed
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
   });
 });

--- a/tests/routing/unauthenticated-repos-redirect.spec.ts
+++ b/tests/routing/unauthenticated-repos-redirect.spec.ts
@@ -1,19 +1,22 @@
 // spec: specs/agent-kanban.plan.md
 // section: 2.6 Protected repositories URL redirects unauthenticated user to /auth
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Routing and Navigation Guards', () => {
-  test('Protected repositories URL redirects unauthenticated user to /auth', async ({ page, context }) => {
+test.describe("Routing and Navigation Guards", () => {
+  test("Protected repositories URL redirects unauthenticated user to /auth", async ({
+    page,
+    context,
+  }) => {
     // 1. With no active session, navigate to /repositories
     await context.clearCookies();
 
-    await page.goto('/repositories');
+    await page.goto("/repositories");
 
     // expect: The browser is redirected to /auth
     await expect(page).toHaveURL(/\/auth/, { timeout: 5000 });
 
     // The sign-in form should be displayed
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
   });
 });

--- a/tests/routing/unauthenticated-root-redirect.spec.ts
+++ b/tests/routing/unauthenticated-root-redirect.spec.ts
@@ -1,22 +1,22 @@
 // spec: specs/agent-kanban.plan.md
 // section: 2.1 Root URL redirects unauthenticated user to /auth
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Routing and Navigation Guards', () => {
-  test('Root URL redirects unauthenticated user to /auth', async ({ page, context }) => {
+test.describe("Routing and Navigation Guards", () => {
+  test("Root URL redirects unauthenticated user to /auth", async ({ page, context }) => {
     // 1. Clear all cookies and local storage to ensure no session exists
     await context.clearCookies();
     await context.clearPermissions();
 
     // Navigate to /
-    await page.goto('/');
+    await page.goto("/");
 
     // expect: The browser is redirected to /auth
     await expect(page).toHaveURL(/\/auth/, { timeout: 5000 });
 
     // expect: The sign-in form is displayed
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Sign In' })).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeVisible();
   });
 });

--- a/tests/routing/unauthenticated-settings-redirect.spec.ts
+++ b/tests/routing/unauthenticated-settings-redirect.spec.ts
@@ -1,19 +1,22 @@
 // spec: specs/agent-kanban.plan.md
 // section: 2.5 Protected settings URL redirects unauthenticated user to /auth
 
-import { test, expect } from '@playwright/test';
+import { expect, test } from "@playwright/test";
 
-test.describe('Routing and Navigation Guards', () => {
-  test('Protected settings URL redirects unauthenticated user to /auth', async ({ page, context }) => {
+test.describe("Routing and Navigation Guards", () => {
+  test("Protected settings URL redirects unauthenticated user to /auth", async ({
+    page,
+    context,
+  }) => {
     // 1. With no active session, navigate to /settings
     await context.clearCookies();
 
-    await page.goto('/settings');
+    await page.goto("/settings");
 
     // expect: The browser is redirected to /auth
     await expect(page).toHaveURL(/\/auth/, { timeout: 5000 });
 
     // The sign-in form should be displayed
-    await expect(page.getByText('Sign in to your account')).toBeVisible();
+    await expect(page.getByText("Sign in to your account")).toBeVisible();
   });
 });

--- a/tests/seed.spec.ts
+++ b/tests/seed.spec.ts
@@ -1,7 +1,8 @@
-import { test, expect } from '@playwright/test';
+import { test } from "@playwright/test";
 
-test.describe('Test group', () => {
-  test('seed', async ({ page }) => {
+test.describe("Test group", () => {
+  // biome-ignore lint/correctness/noUnusedFunctionParameters: Playwright test fixture
+  test("seed", async ({ page }) => {
     // generate code here.
   });
 });

--- a/tests/settings/settings-board-delete.spec.ts
+++ b/tests/settings/settings-board-delete.spec.ts
@@ -1,42 +1,42 @@
 // spec: specs/agent-kanban.plan.md
 // section: 5.8 Board item — delete with two-step confirmation
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Settings Page', () => {
-  test('Board item — delete with two-step confirmation', async ({ page }) => {
+test.describe("Settings Page", () => {
+  test("Board item — delete with two-step confirmation", async ({ page }) => {
     // 1. Sign in, navigate to /settings, and expand a board item
     await signUpAndGetBoard(page, `settings_delete_${Date.now()}@example.com`);
-    await page.goto('/settings');
-    await page.getByText('My BoardOpen').click();
+    await page.goto("/settings");
+    await page.getByText("My BoardOpen").click();
 
     // expect: A 'Delete' button is visible in the expanded area
-    const deleteButton = page.getByRole('button', { name: 'Delete' });
+    const deleteButton = page.getByRole("button", { name: "Delete" });
     await expect(deleteButton).toBeVisible();
 
     // 2. Click the 'Delete' button
     await deleteButton.click();
 
     // expect: The delete button is replaced by 'Delete?', 'Yes', and 'No' inline confirmation options
-    await expect(page.getByText('Delete?')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Yes' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'No' })).toBeVisible();
+    await expect(page.getByText("Delete?")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Yes" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "No" })).toBeVisible();
     await expect(deleteButton).not.toBeVisible();
 
     // 3. Click 'No'
-    await page.getByRole('button', { name: 'No' }).click();
+    await page.getByRole("button", { name: "No" }).click();
 
     // expect: The confirmation is dismissed and the 'Delete' button is shown again
-    await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
-    await expect(page.getByText('Delete?')).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Delete" })).toBeVisible();
+    await expect(page.getByText("Delete?")).not.toBeVisible();
 
     // 4. Click 'Delete' again, then click 'Yes'
-    await page.getByRole('button', { name: 'Delete' }).click();
-    await page.getByRole('button', { name: 'Yes' }).click();
+    await page.getByRole("button", { name: "Delete" }).click();
+    await page.getByRole("button", { name: "Yes" }).click();
 
     // expect: The board is deleted
     // expect: The board item disappears from the list
-    await expect(page.getByText('My Board')).not.toBeVisible();
+    await expect(page.getByText("My Board")).not.toBeVisible();
   });
 });

--- a/tests/settings/settings-board-expand.spec.ts
+++ b/tests/settings/settings-board-expand.spec.ts
@@ -1,29 +1,29 @@
 // spec: specs/agent-kanban.plan.md
 // section: 5.5 Board item — expand to edit details
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Settings Page', () => {
-  test('Board item — expand to edit details', async ({ page }) => {
+test.describe("Settings Page", () => {
+  test("Board item — expand to edit details", async ({ page }) => {
     // 1. Sign in and navigate to /settings. Verify at least one board is listed.
     await signUpAndGetBoard(page, `settings_expand_${Date.now()}@example.com`);
-    await page.goto('/settings');
+    await page.goto("/settings");
 
     // expect: Board items are in collapsed state by default, showing only the board name and an 'Open' link
-    const boardRow = page.getByText('My BoardOpen');
+    const boardRow = page.getByText("My BoardOpen");
     await expect(boardRow).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Open' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Open" })).toBeVisible();
 
     // The expanded content (Name input, Description textarea) should not be visible yet
-    await expect(page.locator('input')).not.toBeVisible();
+    await expect(page.locator("input")).not.toBeVisible();
 
     // 2. Click a board item row
     await boardRow.click();
 
     // expect: The board expands showing a Name input, a Description textarea, and a Delete button
-    await expect(page.locator('input')).toBeVisible();
-    await expect(page.getByPlaceholder('What is this board for?')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Delete' })).toBeVisible();
+    await expect(page.locator("input")).toBeVisible();
+    await expect(page.getByPlaceholder("What is this board for?")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Delete" })).toBeVisible();
   });
 });

--- a/tests/settings/settings-board-no-changes.spec.ts
+++ b/tests/settings/settings-board-no-changes.spec.ts
@@ -1,31 +1,31 @@
 // spec: specs/agent-kanban.plan.md
 // section: 5.7 Board item — save button hidden when no changes
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Settings Page', () => {
-  test('Board item — save button hidden when no changes', async ({ page }) => {
+test.describe("Settings Page", () => {
+  test("Board item — save button hidden when no changes", async ({ page }) => {
     // 1. Sign in, navigate to /settings, and expand a board item
     await signUpAndGetBoard(page, `settings_nochanges_${Date.now()}@example.com`);
-    await page.goto('/settings');
-    await page.getByText('My BoardOpen').click();
+    await page.goto("/settings");
+    await page.getByText("My BoardOpen").click();
 
     // expect: No 'Save' button is visible initially because no changes have been made
-    const saveButton = page.getByRole('button', { name: 'Save' });
+    const saveButton = page.getByRole("button", { name: "Save" });
     await expect(saveButton).not.toBeVisible();
 
     // 2. Change the name field, then revert it back to the original name
-    const nameInput = page.locator('input');
+    const nameInput = page.locator("input");
     await nameInput.click();
-    await page.keyboard.press('End');
-    await page.keyboard.type('X');
+    await page.keyboard.press("End");
+    await page.keyboard.type("X");
 
     // Save button should appear
     await expect(saveButton).toBeVisible();
 
     // Revert: delete the 'X' we typed
-    await page.keyboard.press('Backspace');
+    await page.keyboard.press("Backspace");
 
     // expect: The 'Save' button disappears again because hasChanges returns to false
     await expect(saveButton).not.toBeVisible();

--- a/tests/settings/settings-board-open-link.spec.ts
+++ b/tests/settings/settings-board-open-link.spec.ts
@@ -1,17 +1,17 @@
 // spec: specs/agent-kanban.plan.md
 // section: 5.9 Board item — Open link navigates to board
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Settings Page', () => {
-  test('Board item — Open link navigates to board', async ({ page }) => {
+test.describe("Settings Page", () => {
+  test("Board item — Open link navigates to board", async ({ page }) => {
     // 1. Sign in, navigate to /settings, find a board item in the list
     await signUpAndGetBoard(page, `settings_openlink_${Date.now()}@example.com`);
-    await page.goto('/settings');
+    await page.goto("/settings");
 
     // expect: An 'Open' link is visible on the right side of the collapsed board row
-    const openButton = page.getByRole('button', { name: 'Open' });
+    const openButton = page.getByRole("button", { name: "Open" });
     await expect(openButton).toBeVisible();
 
     // 2. Click 'Open'
@@ -21,6 +21,6 @@ test.describe('Settings Page', () => {
     await expect(page).toHaveURL(/\/boards\/.+/);
 
     // expect: The board page for that board is displayed
-    await expect(page.locator('.hidden.md\\:grid')).toBeVisible();
+    await expect(page.locator(".hidden.md\\:grid")).toBeVisible();
   });
 });

--- a/tests/settings/settings-board-save-name.spec.ts
+++ b/tests/settings/settings-board-save-name.spec.ts
@@ -1,34 +1,34 @@
 // spec: specs/agent-kanban.plan.md
 // section: 5.6 Board item — save updated name
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Settings Page', () => {
-  test('Board item — save updated name', async ({ page }) => {
+test.describe("Settings Page", () => {
+  test("Board item — save updated name", async ({ page }) => {
     // 1. Sign in, navigate to /settings, expand a board item
     await signUpAndGetBoard(page, `settings_savename_${Date.now()}@example.com`);
-    await page.goto('/settings');
+    await page.goto("/settings");
 
     // expect: The board Name input shows the current board name
-    await page.getByText('My BoardOpen').click();
-    const nameInput = page.locator('input');
+    await page.getByText("My BoardOpen").click();
+    const nameInput = page.locator("input");
     await expect(nameInput).toBeVisible();
-    await expect(nameInput).toHaveValue('My Board');
+    await expect(nameInput).toHaveValue("My Board");
 
     // 2. Clear the Name input and type 'Renamed Board'
     // expect: A 'Save' button appears because changes are detected
-    await nameInput.fill('Renamed Board');
-    await expect(page.getByRole('button', { name: 'Save' })).toBeVisible();
-    await expect(nameInput).toHaveValue('Renamed Board');
+    await nameInput.fill("Renamed Board");
+    await expect(page.getByRole("button", { name: "Save" })).toBeVisible();
+    await expect(nameInput).toHaveValue("Renamed Board");
 
     // 3. Click 'Save'
-    await page.getByRole('button', { name: 'Save' }).click();
+    await page.getByRole("button", { name: "Save" }).click();
 
     // expect: The board name updates to 'Renamed Board'
-    await expect(page.getByText('Renamed Board')).toBeVisible();
+    await expect(page.getByText("Renamed Board")).toBeVisible();
 
     // expect: The 'Save' button disappears after saving (no pending changes)
-    await expect(page.getByRole('button', { name: 'Save' })).not.toBeVisible();
+    await expect(page.getByRole("button", { name: "Save" })).not.toBeVisible();
   });
 });

--- a/tests/settings/settings-page-render.spec.ts
+++ b/tests/settings/settings-page-render.spec.ts
@@ -1,24 +1,24 @@
 // spec: specs/agent-kanban.plan.md
 // section: 5.1 Settings page displays theme switcher and boards list
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Settings Page', () => {
-  test('Settings page displays theme switcher and boards list', async ({ page }) => {
+test.describe("Settings Page", () => {
+  test("Settings page displays theme switcher and boards list", async ({ page }) => {
     // 1. Sign in and navigate to /settings
     await signUpAndGetBoard(page, `settings_render_${Date.now()}@example.com`);
-    await page.goto('/settings');
+    await page.goto("/settings");
 
     // expect: Page heading 'Settings' is displayed
-    await expect(page.getByRole('heading', { name: 'Settings', level: 1 })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Settings", level: 1 })).toBeVisible();
 
     // expect: A 'Theme' section is visible with three buttons: 'light', 'dark', 'system'
-    await expect(page.getByRole('button', { name: 'light' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'dark' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'system' })).toBeVisible();
+    await expect(page.getByRole("button", { name: "light" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "dark" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "system" })).toBeVisible();
 
     // expect: A 'Boards' section is visible listing all user boards
-    await expect(page.getByText('My Board')).toBeVisible();
+    await expect(page.getByText("My Board")).toBeVisible();
   });
 });

--- a/tests/settings/settings-theme-dark.spec.ts
+++ b/tests/settings/settings-theme-dark.spec.ts
@@ -1,21 +1,21 @@
 // spec: specs/agent-kanban.plan.md
 // section: 5.3 Theme switcher — select dark theme
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Settings Page', () => {
-  test('Theme switcher — select dark theme', async ({ page }) => {
+test.describe("Settings Page", () => {
+  test("Theme switcher — select dark theme", async ({ page }) => {
     // 1. Sign in and navigate to /settings. Click the 'dark' theme button.
     await signUpAndGetBoard(page, `settings_dark_${Date.now()}@example.com`);
-    await page.goto('/settings');
+    await page.goto("/settings");
 
-    const darkButton = page.getByRole('button', { name: 'dark' });
+    const darkButton = page.getByRole("button", { name: "dark" });
     await expect(darkButton).toBeVisible();
 
     await darkButton.click();
 
     // expect: The 'dark' button is highlighted as active
-    await expect(darkButton).toHaveAttribute('class', /border-accent/);
+    await expect(darkButton).toHaveAttribute("class", /border-accent/);
   });
 });

--- a/tests/settings/settings-theme-light.spec.ts
+++ b/tests/settings/settings-theme-light.spec.ts
@@ -1,23 +1,23 @@
 // spec: specs/agent-kanban.plan.md
 // section: 5.2 Theme switcher — select light theme
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Settings Page', () => {
-  test('Theme switcher — select light theme', async ({ page }) => {
+test.describe("Settings Page", () => {
+  test("Theme switcher — select light theme", async ({ page }) => {
     // 1. Sign in and navigate to /settings
     await signUpAndGetBoard(page, `settings_light_${Date.now()}@example.com`);
-    await page.goto('/settings');
+    await page.goto("/settings");
 
     // expect: Theme buttons are visible
-    const lightButton = page.getByRole('button', { name: 'light' });
+    const lightButton = page.getByRole("button", { name: "light" });
     await expect(lightButton).toBeVisible();
 
     // 2. Click the 'light' theme button
     await lightButton.click();
 
     // expect: The 'light' button becomes the active/selected button (shows accent border and accent text)
-    await expect(lightButton).toHaveAttribute('class', /border-accent/);
+    await expect(lightButton).toHaveAttribute("class", /border-accent/);
   });
 });

--- a/tests/settings/settings-theme-system.spec.ts
+++ b/tests/settings/settings-theme-system.spec.ts
@@ -1,21 +1,21 @@
 // spec: specs/agent-kanban.plan.md
 // section: 5.4 Theme switcher — select system theme
 
-import { test, expect } from '@playwright/test';
-import { signUpAndGetBoard } from '../helpers/auth';
+import { expect, test } from "@playwright/test";
+import { signUpAndGetBoard } from "../helpers/auth";
 
-test.describe('Settings Page', () => {
-  test('Theme switcher — select system theme', async ({ page }) => {
+test.describe("Settings Page", () => {
+  test("Theme switcher — select system theme", async ({ page }) => {
     // 1. Sign in and navigate to /settings. Click the 'system' theme button.
     await signUpAndGetBoard(page, `settings_system_${Date.now()}@example.com`);
-    await page.goto('/settings');
+    await page.goto("/settings");
 
-    const systemButton = page.getByRole('button', { name: 'system' });
+    const systemButton = page.getByRole("button", { name: "system" });
     await expect(systemButton).toBeVisible();
 
     await systemButton.click();
 
     // expect: The 'system' button is highlighted as active
-    await expect(systemButton).toHaveAttribute('class', /border-accent/);
+    await expect(systemButton).toHaveAttribute("class", /border-accent/);
   });
 });

--- a/tests/shared.test.ts
+++ b/tests/shared.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { TASK_ACTIONS, AGENT_STATUSES, STALE_TIMEOUT_MS, PRIORITIES } from "@agent-kanban/shared";
+import { AGENT_STATUSES, PRIORITIES, STALE_TIMEOUT_MS, TASK_ACTIONS } from "@agent-kanban/shared";
+import { describe, expect, it } from "vitest";
 
 describe("shared constants", () => {
   it("TASK_ACTIONS includes all v2 actions", () => {

--- a/tests/sse.test.ts
+++ b/tests/sse.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
-import { createTestEnv, setupMiniflare, seedUser } from "./helpers/db";
+
+import type { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestEnv, seedUser, setupMiniflare } from "./helpers/db";
 
 const env = createTestEnv();
 let mf: Miniflare;
@@ -29,7 +30,7 @@ async function readSSEUntil(
     const result = await Promise.race([
       reader.read(),
       new Promise<{ done: true; value: undefined }>((resolve) =>
-        setTimeout(() => resolve({ done: true, value: undefined }), readTimeoutMs)
+        setTimeout(() => resolve({ done: true, value: undefined }), readTimeoutMs),
       ),
     ]);
     if (result.value) {
@@ -111,7 +112,10 @@ describe("createSSEResponse", () => {
 
   it("returns stream for task with only creation log", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
-    const freshTask = await createTask(env.DB, "sse-user", { title: "Fresh SSE Task", board_id: boardId });
+    const freshTask = await createTask(env.DB, "sse-user", {
+      title: "Fresh SSE Task",
+      board_id: boardId,
+    });
 
     const { createSSEResponse } = await import("../apps/web/functions/api/sse");
     const response = await createSSEResponse(env as any, freshTask.id, null);
@@ -127,7 +131,10 @@ describe("createSSEResponse", () => {
   it("merges logs and messages by time order", async () => {
     const { createTask, addTaskLog } = await import("../apps/web/functions/api/taskRepo");
     const { createMessage } = await import("../apps/web/functions/api/messageRepo");
-    const mergeTask = await createTask(env.DB, "sse-user", { title: "Merge SSE Task", board_id: boardId });
+    const mergeTask = await createTask(env.DB, "sse-user", {
+      title: "Merge SSE Task",
+      board_id: boardId,
+    });
 
     await createMessage(env.DB, mergeTask.id, "user", "sse-user", "Message first");
     // Small delay to ensure distinct timestamp in D1 (millisecond resolution)
@@ -153,7 +160,10 @@ describe("createSSEResponse", () => {
 
   it("poll loop picks up new events after initial batch", async () => {
     const { createTask, addTaskLog } = await import("../apps/web/functions/api/taskRepo");
-    const pollTask = await createTask(env.DB, "sse-user", { title: "Poll SSE Task", board_id: boardId });
+    const pollTask = await createTask(env.DB, "sse-user", {
+      title: "Poll SSE Task",
+      board_id: boardId,
+    });
 
     setTimeout(async () => {
       await addTaskLog(env.DB, pollTask.id, null, "commented", "Polled event from loop");
@@ -184,7 +194,10 @@ describe("createSSEResponse", () => {
 
   it("limits initial events to 50 per type", async () => {
     const { createTask, addTaskLog } = await import("../apps/web/functions/api/taskRepo");
-    const bigTask = await createTask(env.DB, "sse-user", { title: "Big SSE Task", board_id: boardId });
+    const bigTask = await createTask(env.DB, "sse-user", {
+      title: "Big SSE Task",
+      board_id: boardId,
+    });
 
     for (let i = 0; i < 55; i++) {
       await addTaskLog(env.DB, bigTask.id, null, "commented", `Bulk log ${i}`);

--- a/tests/task-dependencies.test.ts
+++ b/tests/task-dependencies.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Miniflare } from "miniflare";
-import { randomUUID } from "crypto";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const MIGRATIONS_DIR = join(__dirname, "../apps/web/migrations");
 
@@ -21,7 +22,10 @@ async function applyMigrations(db: D1Database) {
   const files = ["0001_initial.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-    for (const stmt of sql.split(";").map((s) => s.trim()).filter(Boolean)) {
+    for (const stmt of sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       await db.prepare(stmt).run();
     }
   }
@@ -38,8 +42,10 @@ beforeAll(async () => {
 
   const now = new Date().toISOString();
   await env.DB.prepare(
-    "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)"
-  ).bind("test-user-deps", "Deps User", "deps@example.com", now, now).run();
+    "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)",
+  )
+    .bind("test-user-deps", "Deps User", "deps@example.com", now, now)
+    .run();
 });
 
 afterAll(async () => {

--- a/tests/task-json-fields.test.ts
+++ b/tests/task-json-fields.test.ts
@@ -1,8 +1,9 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { Miniflare } from "miniflare";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const MIGRATIONS_DIR = join(__dirname, "../apps/web/migrations");
 
@@ -13,7 +14,10 @@ async function applyMigrations(db: D1Database) {
   const files = ["0001_initial.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-    for (const stmt of sql.split(";").map(s => s.trim()).filter(Boolean)) {
+    for (const stmt of sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       await db.prepare(stmt).run();
     }
   }
@@ -74,7 +78,7 @@ describe("task JSON field parsing (labels, input)", () => {
   it("listTasks returns parsed labels and input", async () => {
     const { listTasks } = await import("../apps/web/functions/api/taskRepo");
     const tasks = await listTasks(db, { board_id: boardId });
-    const task = tasks.find(t => t.id === taskId)!;
+    const task = tasks.find((t) => t.id === taskId)!;
 
     expect(Array.isArray(task.labels)).toBe(true);
     expect(task.labels).toEqual(["bug", "urgent"]);
@@ -118,7 +122,7 @@ describe("task JSON field parsing (labels, input)", () => {
     const board = await getBoard(db, boardId);
 
     expect(board).toBeTruthy();
-    const task = board!.tasks.find(t => t.id === taskId)!;
+    const task = board!.tasks.find((t) => t.id === taskId)!;
     expect(Array.isArray(task.labels)).toBe(true);
     expect(task.labels).toEqual(["feature"]);
     expect(typeof task.input).toBe("object");
@@ -127,7 +131,9 @@ describe("task JSON field parsing (labels, input)", () => {
 
   it("lifecycle functions preserve parsed JSON fields", async () => {
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
-    const { assignTask, claimTask, reviewTask } = await import("../apps/web/functions/api/taskRepo");
+    const { assignTask, claimTask, reviewTask } = await import(
+      "../apps/web/functions/api/taskRepo"
+    );
 
     const agent = await createAgent(db, ownerId, { name: "worker" });
     const assigned = await assignTask(db, taskId, agent.id);

--- a/tests/task-repo-position.test.ts
+++ b/tests/task-repo-position.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
-import { createTestEnv, setupMiniflare, seedUser } from "./helpers/db";
+
+import type { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestEnv, seedUser, setupMiniflare } from "./helpers/db";
 
 const env = createTestEnv();
 let mf: Miniflare;
@@ -26,7 +27,10 @@ describe("updateTask position field", () => {
 
   it("updateTask accepts position and persists the new value", async () => {
     const { createTask, updateTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, "pos-test-user", { title: "Position Task", board_id: boardId });
+    const task = await createTask(env.DB, "pos-test-user", {
+      title: "Position Task",
+      board_id: boardId,
+    });
 
     const updated = await updateTask(env.DB, task.id, { position: 99 });
 
@@ -36,7 +40,11 @@ describe("updateTask position field", () => {
 
   it("updateTask preserves other fields when only position is updated", async () => {
     const { createTask, updateTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, "pos-test-user", { title: "Position Preserve", board_id: boardId, priority: "high" });
+    const task = await createTask(env.DB, "pos-test-user", {
+      title: "Position Preserve",
+      board_id: boardId,
+      priority: "high",
+    });
 
     const updated = await updateTask(env.DB, task.id, { position: 5 });
 
@@ -47,7 +55,10 @@ describe("updateTask position field", () => {
 
   it("updateTask with position zero persists zero", async () => {
     const { createTask, updateTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, "pos-test-user", { title: "Zero Position", board_id: boardId });
+    const task = await createTask(env.DB, "pos-test-user", {
+      title: "Zero Position",
+      board_id: boardId,
+    });
 
     const updated = await updateTask(env.DB, task.id, { position: 0 });
 
@@ -56,7 +67,10 @@ describe("updateTask position field", () => {
 
   it("updateTask position does not affect status", async () => {
     const { createTask, updateTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, "pos-test-user", { title: "Status Stable", board_id: boardId });
+    const task = await createTask(env.DB, "pos-test-user", {
+      title: "Status Stable",
+      board_id: boardId,
+    });
 
     const updated = await updateTask(env.DB, task.id, { position: 10 });
 
@@ -71,7 +85,10 @@ describe("updateTask position field", () => {
 
   it("updateTask can update position together with title", async () => {
     const { createTask, updateTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, "pos-test-user", { title: "Multi Update", board_id: boardId });
+    const task = await createTask(env.DB, "pos-test-user", {
+      title: "Multi Update",
+      board_id: boardId,
+    });
 
     const updated = await updateTask(env.DB, task.id, { title: "Renamed", position: 7 });
 
@@ -81,7 +98,10 @@ describe("updateTask position field", () => {
 
   it("updateTask persists position to DB and can be read back via getTask", async () => {
     const { createTask, updateTask, getTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, "pos-test-user", { title: "Persist Position", board_id: boardId });
+    const task = await createTask(env.DB, "pos-test-user", {
+      title: "Persist Position",
+      board_id: boardId,
+    });
 
     await updateTask(env.DB, task.id, { position: 42 });
     const fetched = await getTask(env.DB, task.id);

--- a/tests/task-state-machine.test.ts
+++ b/tests/task-state-machine.test.ts
@@ -1,10 +1,11 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { Miniflare } from "miniflare";
+
+import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { SignJWT } from "jose";
-import { randomUUID } from "crypto";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 const MIGRATIONS_DIR = join(__dirname, "../apps/web/migrations");
 const AUTH_SECRET = "test-secret-32-chars-minimum-ok!!";
@@ -24,7 +25,10 @@ async function applyMigrations(db: D1Database) {
   const files = ["0001_initial.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
-    for (const stmt of sql.split(";").map((s) => s.trim()).filter(Boolean)) {
+    for (const stmt of sql
+      .split(";")
+      .map((s) => s.trim())
+      .filter(Boolean)) {
       await db.prepare(stmt).run();
     }
   }
@@ -33,9 +37,12 @@ async function applyMigrations(db: D1Database) {
 async function seedUser(db: D1Database): Promise<string> {
   const userId = "test-user-sm";
   const now = new Date().toISOString();
-  await db.prepare(
-    "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)"
-  ).bind(userId, "SM Test User", "sm@example.com", now, now).run();
+  await db
+    .prepare(
+      "INSERT INTO user (id, name, email, emailVerified, createdAt, updatedAt) VALUES (?, ?, ?, 1, ?, ?)",
+    )
+    .bind(userId, "SM Test User", "sm@example.com", now, now)
+    .run();
   return userId;
 }
 
@@ -249,7 +256,10 @@ describe("task lifecycle repo functions", () => {
 
   async function createTestTask() {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
-    return createTask(env.DB, userId, { title: `Task ${randomUUID().slice(0, 8)}`, board_id: boardId });
+    return createTask(env.DB, userId, {
+      title: `Task ${randomUUID().slice(0, 8)}`,
+      board_id: boardId,
+    });
   }
 
   async function forceStatus(taskId: string, status: string) {
@@ -289,7 +299,9 @@ describe("task lifecycle repo functions", () => {
       const { claimTask, assignTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await assignTask(env.DB, task.id, testAgentId);
-      await expect(claimTask(env.DB, task.id, otherAgentId, "agent")).rejects.toThrow("not assigned");
+      await expect(claimTask(env.DB, task.id, otherAgentId, "agent")).rejects.toThrow(
+        "not assigned",
+      );
     });
   });
 
@@ -534,7 +546,7 @@ describe("task lifecycle repo functions", () => {
 describe("task lifecycle HTTP permissions", () => {
   let userId: string;
   let apiKey: string;
-  let machineId: string;
+  let _machineId: string;
   let agentId: string;
   let sessionId: string;
   let sessionPrivateKey: CryptoKey;
@@ -542,8 +554,12 @@ describe("task lifecycle HTTP permissions", () => {
 
   async function apiRequest(method: string, path: string, body?: any, token?: string) {
     const { api } = await import("../apps/web/functions/api/routes");
-    const headers: Record<string, string> = { "Content-Type": "application/json", Host: "localhost:8788", "x-forwarded-proto": "http" };
-    if (token) headers["Authorization"] = `Bearer ${token}`;
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+      Host: "localhost:8788",
+      "x-forwarded-proto": "http",
+    };
+    if (token) headers.Authorization = `Bearer ${token}`;
     const init: RequestInit = { method, headers };
     if (body) init.body = JSON.stringify(body);
     return api.request(path, init, env);
@@ -559,7 +575,10 @@ describe("task lifecycle HTTP permissions", () => {
 
   async function createTestTask() {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
-    return createTask(env.DB, userId, { title: `HTTP Task ${randomUUID().slice(0, 8)}`, board_id: boardId });
+    return createTask(env.DB, userId, {
+      title: `HTTP Task ${randomUUID().slice(0, 8)}`,
+      board_id: boardId,
+    });
   }
 
   async function forceStatus(taskId: string, status: string) {
@@ -572,10 +591,18 @@ describe("task lifecycle HTTP permissions", () => {
     apiKey = await createApiKeyForUser(env.DB, userId);
 
     // Create machine
-    const res = await apiRequest("POST", "/api/machines", {
-      name: "sm-machine", os: "darwin", version: "1.0.0", runtimes: ["Claude Code"],
-    }, apiKey);
-    machineId = ((await res.json()) as any).id;
+    const res = await apiRequest(
+      "POST",
+      "/api/machines",
+      {
+        name: "sm-machine",
+        os: "darwin",
+        version: "1.0.0",
+        runtimes: ["Claude Code"],
+      },
+      apiKey,
+    );
+    _machineId = ((await res.json()) as any).id;
 
     // Create agent
     const { createAgent } = await import("../apps/web/functions/api/agentRepo");
@@ -584,12 +611,21 @@ describe("task lifecycle HTTP permissions", () => {
 
     // Create session
     sessionId = randomUUID();
-    const keypair = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, ["sign", "verify"]);
+    const keypair = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, [
+      "sign",
+      "verify",
+    ]);
     sessionPrivateKey = (keypair as any).privateKey;
     const pubJwk = await crypto.subtle.exportKey("jwk", (keypair as any).publicKey);
-    await apiRequest("POST", `/api/agents/${agentId}/sessions`, {
-      session_id: sessionId, session_public_key: pubJwk.x!,
-    }, apiKey);
+    await apiRequest(
+      "POST",
+      `/api/agents/${agentId}/sessions`,
+      {
+        session_id: sessionId,
+        session_public_key: pubJwk.x!,
+      },
+      apiKey,
+    );
 
     // Create board
     const { createBoard } = await import("../apps/web/functions/api/boardRepo");
@@ -636,13 +672,18 @@ describe("task lifecycle HTTP permissions", () => {
     await forceStatus(task.id, "in_progress");
     const res = await apiRequest("POST", `/api/tasks/${task.id}/release`, {}, apiKey);
     expect(res.status).toBe(200);
-    const body = await res.json() as any;
+    const body = (await res.json()) as any;
     expect(body.status).toBe("todo");
   });
 
   it("machine cannot claim a task (403)", async () => {
     const task = await createTestTask();
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/claim`, { agent_id: agentId }, apiKey);
+    const res = await apiRequest(
+      "POST",
+      `/api/tasks/${task.id}/claim`,
+      { agent_id: agentId },
+      apiKey,
+    );
     expect(res.status).toBe(403);
   });
 


### PR DESCRIPTION
## Summary
- Auto-fixed ~210 files for formatting, import sorting, template literals, Node.js import protocols, and unused imports/variables via `biome check --write --unsafe`
- Manually added `type="button"` to 35 button elements missing explicit type props
- Associated 6 form labels with inputs via `htmlFor`/`id` attributes
- Added keyboard event handlers (`onKeyDown`) and ARIA roles to 7 interactive div elements
- Suppressed 4 legitimate biome-ignore cases (shadcn component, array index keys, semantic elements used as containers)
- Updated `biome.json` to exclude CSS files from linting/formatting (Tailwind v4 `@theme`/`@apply` directives unsupported by Biome)
- Removed unused imports, variables, and function parameters across the codebase

## Verification
- `pnpm check` — 0 errors, 0 warnings ✅
- `pnpm build` — clean build ✅
- `pnpm -r --parallel run lint` (tsc --noEmit) — all packages pass ✅
- `npx vitest run` — 388/388 tests pass ✅

## Test plan
- [x] `pnpm check` passes with zero violations
- [x] `pnpm build` succeeds
- [x] `pnpm -r --parallel run lint` typecheck passes
- [x] All 388 unit/integration tests pass
- [ ] Spot-check UI in browser for visual regressions (no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)