### PR TITLE
fix: replace ps-grep session alive check with PID-based detection

### DIFF
--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -10,7 +10,7 @@ import { generateSystemPrompt, writePromptFile, type AgentInfo } from './systemP
 import { getLinks, findPathForRepository, setLink } from './links.js';
 import { getConfigValue, setConfigValue, PID_FILE } from './config.js';
 import { getUsage } from './usage.js';
-import { REPOS_DIR, WORKTREES_DIR } from './paths.js';
+import { REPOS_DIR, WORKTREES_DIR, SESSION_PIDS_FILE } from './paths.js';
 
 // Daemon Lifecycle:
 //   STARTING → check PID lock → load config → load links
@@ -66,10 +66,12 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   const pm = new ProcessManager(
     client,
     opts.agentCli,
-    () => {
-      schedulePoll(baseInterval);
+    {
+      onSlotFreed: () => schedulePoll(baseInterval),
+      onRateLimited: pauseForRateLimit,
+      onProcessStarted: saveSessionPid,
+      onProcessExited: removeSessionPid,
     },
-    pauseForRateLimit,
     opts.taskTimeout,
   );
 
@@ -91,6 +93,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     if (pollTimer) clearTimeout(pollTimer);
     if (resumeTimer) clearTimeout(resumeTimer);
     await pm.killAll();
+    clearSessionPids();
     removePidFile();
     console.log('[INFO] Daemon stopped.');
     process.exit(0);
@@ -620,10 +623,44 @@ function detectRuntimes(): string[] {
   return found;
 }
 
-function isProcessAlive(sessionId: string): boolean {
+function loadSessionPids(): Map<string, number> {
   try {
-    const output = execSync(`ps ax -o args=`, { stdio: ['pipe', 'pipe', 'ignore'] }).toString();
-    return output.includes(sessionId);
+    const data = JSON.parse(readFileSync(SESSION_PIDS_FILE, 'utf-8'));
+    return new Map(Object.entries(data));
+  } catch {
+    return new Map();
+  }
+}
+
+function writeSessionPids(pids: Map<string, number>): void {
+  writeFileSync(SESSION_PIDS_FILE, JSON.stringify(Object.fromEntries(pids)));
+}
+
+function saveSessionPid(sessionId: string, pid: number): void {
+  const pids = loadSessionPids();
+  pids.set(sessionId, pid);
+  writeSessionPids(pids);
+}
+
+function removeSessionPid(sessionId: string): void {
+  const pids = loadSessionPids();
+  if (pids.delete(sessionId)) writeSessionPids(pids);
+}
+
+function clearSessionPids(): void {
+  try {
+    unlinkSync(SESSION_PIDS_FILE);
+  } catch {
+    /* ignore */
+  }
+}
+
+function isProcessAlive(sessionId: string): boolean {
+  const pid = loadSessionPids().get(sessionId);
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
   } catch {
     return false;
   }
@@ -632,18 +669,25 @@ function isProcessAlive(sessionId: string): boolean {
 async function cleanupStaleSessions(client: MachineClient, machineId: string): Promise<void> {
   try {
     const agents = (await client.listAgents()) as any[];
-    let closed = 0;
+    const closedSessionIds: string[] = [];
     for (const agent of agents) {
       const sessions = (await client.listSessions(agent.id)) as any[];
       for (const session of sessions) {
         if (session.status !== 'active' || session.machine_id !== machineId) continue;
         if (!isProcessAlive(session.id)) {
           await client.closeSession(agent.id, session.id).catch(() => {});
-          closed++;
+          closedSessionIds.push(session.id);
         }
       }
     }
-    if (closed > 0) console.log(`[INFO] Cleaned up ${closed} stale session(s) from previous run`);
+    if (closedSessionIds.length > 0) {
+      const pids = loadSessionPids();
+      for (const id of closedSessionIds) pids.delete(id);
+      writeSessionPids(pids);
+      console.log(
+        `[INFO] Cleaned up ${closedSessionIds.length} stale session(s) from previous run`,
+      );
+    }
   } catch (err: any) {
     console.warn(`[WARN] Session cleanup failed: ${err.message}`);
   }

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -1,19 +1,20 @@
-import { join } from "path";
-import { homedir } from "os";
+import { join } from 'path';
+import { homedir } from 'os';
 
 const home = homedir();
 
 export const CONFIG_DIR = process.env.XDG_CONFIG_HOME
-  ? join(process.env.XDG_CONFIG_HOME, "agent-kanban")
-  : join(home, ".config", "agent-kanban");
+  ? join(process.env.XDG_CONFIG_HOME, 'agent-kanban')
+  : join(home, '.config', 'agent-kanban');
 
 export const DATA_DIR = process.env.XDG_DATA_HOME
-  ? join(process.env.XDG_DATA_HOME, "agent-kanban")
-  : join(home, ".local", "share", "agent-kanban");
+  ? join(process.env.XDG_DATA_HOME, 'agent-kanban')
+  : join(home, '.local', 'share', 'agent-kanban');
 
-export const CONFIG_FILE = join(CONFIG_DIR, "config.json");
-export const PID_FILE = join(CONFIG_DIR, "daemon.pid");
-export const LINKS_FILE = join(DATA_DIR, "links.json");
-export const REPOS_DIR = join(DATA_DIR, "repos");
-export const WORKTREES_DIR = join(DATA_DIR, "worktrees");
-export const TRACKED_TASKS_FILE = join(DATA_DIR, "tracked-tasks.json");
+export const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
+export const PID_FILE = join(CONFIG_DIR, 'daemon.pid');
+export const LINKS_FILE = join(DATA_DIR, 'links.json');
+export const REPOS_DIR = join(DATA_DIR, 'repos');
+export const WORKTREES_DIR = join(DATA_DIR, 'worktrees');
+export const TRACKED_TASKS_FILE = join(DATA_DIR, 'tracked-tasks.json');
+export const SESSION_PIDS_FILE = join(DATA_DIR, 'session-pids.json');

--- a/packages/cli/src/processManager.ts
+++ b/packages/cli/src/processManager.ts
@@ -38,6 +38,13 @@ export interface AgentProcess {
 
 const RATE_LIMIT_CODES = new Set(['rate_limit_error', 'overloaded_error']);
 
+export interface ProcessManagerCallbacks {
+  onSlotFreed: () => void;
+  onRateLimited: (resetAt: string) => void;
+  onProcessStarted?: (sessionId: string, pid: number) => void;
+  onProcessExited?: (sessionId: string) => void;
+}
+
 export class ProcessManager {
   private agents = new Map<string, AgentProcess>();
   private suspended: SuspendedSession[] = [];
@@ -45,19 +52,22 @@ export class ProcessManager {
   private agentCli: string;
   private onSlotFreed: () => void;
   private onRateLimited: (resetAt: string) => void;
+  private onProcessStarted?: (sessionId: string, pid: number) => void;
+  private onProcessExited?: (sessionId: string) => void;
   private taskTimeoutMs: number;
 
   constructor(
     client: ApiClient,
     agentCli: string,
-    onSlotFreed: () => void,
-    onRateLimited: (resetAt: string) => void,
+    callbacks: ProcessManagerCallbacks,
     taskTimeoutMs = 2 * 60 * 60 * 1000,
   ) {
     this.client = client;
     this.agentCli = agentCli;
-    this.onSlotFreed = onSlotFreed;
-    this.onRateLimited = onRateLimited;
+    this.onSlotFreed = callbacks.onSlotFreed;
+    this.onRateLimited = callbacks.onRateLimited;
+    this.onProcessStarted = callbacks.onProcessStarted;
+    this.onProcessExited = callbacks.onProcessExited;
     this.taskTimeoutMs = taskTimeoutMs;
   }
 
@@ -141,6 +151,7 @@ export class ProcessManager {
       onCleanup,
     };
     this.agents.set(taskId, agent);
+    this.onProcessStarted?.(sessionId, proc.pid);
 
     if (this.taskTimeoutMs > 0) {
       agent.timeoutTimer = setTimeout(() => {
@@ -189,6 +200,7 @@ export class ProcessManager {
     proc.on('close', async (code) => {
       if (agent.timeoutTimer) clearTimeout(agent.timeoutTimer);
       cleanupPromptFile(sessionId);
+      this.onProcessExited?.(sessionId);
 
       // Already removed by killTask() — process was intentionally terminated
       if (!this.agents.has(taskId)) return;


### PR DESCRIPTION
## Summary
- Replace unreliable `ps ax` grep in `isProcessAlive` with `process.kill(pid, 0)` PID existence check
- Track session PIDs in `~/.local/share/agent-kanban/session-pids.json` — saved on spawn, removed on exit, cleared on shutdown
- Refactor `ProcessManager` constructor to accept a callbacks object, adding `onProcessStarted`/`onProcessExited` hooks
- Clean up stale PID entries in `cleanupStaleSessions` on daemon startup

## Test plan
- [x] Type check passes (`tsc --noEmit`)
- [x] All 389 tests pass (`vitest run`)
- [x] Pre-commit hooks pass (prettier + typecheck)
- [ ] Manual: start daemon, verify `session-pids.json` is created on agent spawn
- [ ] Manual: kill daemon, verify `session-pids.json` is cleaned up
- [ ] Manual: crash a session, restart daemon, verify stale sessions are detected and cleaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)