### PR TITLE
feat: reject-resume — preserve worktree and resume agent after rejection

### DIFF
--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -10,6 +10,7 @@ import { createLogger } from "./logger.js";
 import { REPOS_DIR, SESSION_PIDS_FILE, WORKTREES_DIR } from "./paths.js";
 import { PrMonitor } from "./prMonitor.js";
 import { ProcessManager } from "./processManager.js";
+import { loadReviewSessions, removeReviewSession } from "./reviewSessions.js";
 import { type AgentInfo, generateSystemPrompt, writePromptFile } from "./systemPrompt.js";
 import { getUsage } from "./usage.js";
 
@@ -205,6 +206,83 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     }
   }
 
+  async function checkReviewSessions() {
+    const apiUrl = getConfigValue("api-url")!;
+    const reviewSessions = loadReviewSessions();
+    for (const rs of reviewSessions) {
+      const task = (await client.getTask(rs.taskId)) as any;
+      if (!task) {
+        removeReviewSession(rs.taskId);
+        continue;
+      }
+
+      if (task.status === "done" || task.status === "cancelled") {
+        removeWorktree(rs.repoDir, rs.cwd, rs.branchName);
+        removeReviewSession(rs.taskId);
+        continue;
+      }
+
+      if (task.status === "in_progress" && !pm.hasTask(rs.taskId)) {
+        logger.info(`Task ${rs.taskId} was rejected, resuming agent in existing worktree`);
+
+        const privateKey = (await crypto.subtle.importKey("jwk", rs.privateKeyJwk, { name: "Ed25519" } as any, true, ["sign"])) as CryptoKey;
+
+        try {
+          await client.reopenSession(rs.agentId, rs.sessionId);
+        } catch {
+          logger.warn(`Failed to reopen session ${rs.sessionId}, releasing task ${rs.taskId}`);
+          removeWorktree(rs.repoDir, rs.cwd, rs.branchName);
+          removeReviewSession(rs.taskId);
+          await client.releaseTask(rs.taskId).catch(() => {});
+          continue;
+        }
+
+        const agentClient = new AgentClient(apiUrl, rs.agentId, rs.sessionId, privateKey);
+
+        const agentEnv = {
+          AK_AGENT_ID: rs.agentId,
+          AK_SESSION_ID: rs.sessionId,
+          AK_AGENT_KEY: JSON.stringify(rs.privateKeyJwk),
+          AK_API_URL: apiUrl,
+        };
+
+        const logs = (await client.getTaskLogs(rs.taskId)) as any[];
+        const rejectLog = [...logs].reverse().find((l: any) => l.action === "rejected");
+        const rejectReason = rejectLog?.detail || "No reason provided";
+
+        try {
+          await pm.spawnAgent(
+            rs.taskId,
+            rs.sessionId,
+            rs.cwd,
+            rs.repoDir,
+            rs.branchName,
+            "",
+            agentClient,
+            agentEnv,
+            privateKey,
+            rs.privateKeyJwk,
+            undefined,
+            true,
+            () => removeWorktree(rs.repoDir, rs.cwd, rs.branchName),
+          );
+
+          await agentClient.sendMessage(rs.taskId, {
+            sender_type: "user",
+            sender_id: "system",
+            content: `Task rejected. Reason: ${rejectReason}\n\nPlease fix the issues and submit for review again.`,
+          });
+        } catch {
+          logger.warn(`Failed to resume rejected task ${rs.taskId}, releasing`);
+          removeWorktree(rs.repoDir, rs.cwd, rs.branchName);
+          await client.releaseTask(rs.taskId).catch(() => {});
+        }
+
+        removeReviewSession(rs.taskId);
+      }
+    }
+  }
+
   function schedulePoll(delayMs: number) {
     if (!running) return;
     if (pollTimer) clearTimeout(pollTimer);
@@ -223,6 +301,9 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           await pm.killTask(taskId);
         }
       }
+
+      // Check review sessions for rejected/completed tasks
+      await checkReviewSessions();
 
       if (pm.activeCount >= opts.maxConcurrent) {
         schedulePoll(baseInterval);

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -14,3 +14,4 @@ export const REPOS_DIR = join(DATA_DIR, "repos");
 export const WORKTREES_DIR = join(DATA_DIR, "worktrees");
 export const TRACKED_TASKS_FILE = join(DATA_DIR, "tracked-tasks.json");
 export const SESSION_PIDS_FILE = join(DATA_DIR, "session-pids.json");
+export const REVIEW_SESSIONS_FILE = join(DATA_DIR, "review-sessions.json");

--- a/packages/cli/src/processManager.ts
+++ b/packages/cli/src/processManager.ts
@@ -1,6 +1,7 @@
 import { type ChildProcess, spawn } from "node:child_process";
 import type { AgentClient, ApiClient } from "./client.js";
 import { createLogger } from "./logger.js";
+import { saveReviewSession } from "./reviewSessions.js";
 import { cleanupPromptFile } from "./systemPrompt.js";
 
 const logger = createLogger("process");
@@ -207,8 +208,22 @@ export class ProcessManager {
       await this.closeSession(agentClient);
 
       if (code === 0) {
-        logger.info(`Agent finished task ${taskId}`);
-        agent.onCleanup?.();
+        const task = (await this.client.getTask(taskId)) as any;
+        if (task?.status === "in_review") {
+          saveReviewSession({
+            taskId,
+            sessionId,
+            cwd: agent.cwd,
+            repoDir: agent.repoDir,
+            branchName: agent.branchName,
+            agentId: agentClient.getAgentId(),
+            privateKeyJwk: agent.privateKeyJwk,
+          });
+          logger.info(`Agent submitted task ${taskId} for review, preserving worktree`);
+        } else {
+          logger.info(`Agent finished task ${taskId}`);
+          agent.onCleanup?.();
+        }
       } else if (agent.rateLimited) {
         logger.warn(`Agent for task ${taskId} exited due to rate limit, suspending`);
         this.suspended.push({

--- a/packages/cli/src/reviewSessions.ts
+++ b/packages/cli/src/reviewSessions.ts
@@ -1,0 +1,41 @@
+import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { REVIEW_SESSIONS_FILE } from "./paths.js";
+
+export interface PersistedReviewSession {
+  taskId: string;
+  sessionId: string;
+  cwd: string;
+  repoDir: string;
+  branchName: string;
+  agentId: string;
+  privateKeyJwk: JsonWebKey;
+}
+
+export function loadReviewSessions(): PersistedReviewSession[] {
+  try {
+    return JSON.parse(readFileSync(REVIEW_SESSIONS_FILE, "utf-8"));
+  } catch {
+    return [];
+  }
+}
+
+export function saveReviewSession(session: PersistedReviewSession): void {
+  const sessions = loadReviewSessions();
+  sessions.push(session);
+  writeFileSync(REVIEW_SESSIONS_FILE, JSON.stringify(sessions, null, 2));
+}
+
+export function removeReviewSession(taskId: string): void {
+  const sessions = loadReviewSessions();
+  const filtered = sessions.filter((s) => s.taskId !== taskId);
+  if (filtered.length === sessions.length) return;
+  writeFileSync(REVIEW_SESSIONS_FILE, JSON.stringify(filtered, null, 2));
+}
+
+export function clearReviewSessions(): void {
+  try {
+    unlinkSync(REVIEW_SESSIONS_FILE);
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Summary
- When an agent exits successfully with task in `in_review` status, the worktree and session metadata are persisted to disk (`review-sessions.json`) instead of being destroyed
- The daemon poll loop checks review sessions each cycle: rejected tasks resume the agent in-place with the rejection reason; completed/cancelled tasks clean up the worktree
- New `reviewSessions.ts` persistence module follows the same pattern as `session-pids.json`

## Changes
- `packages/cli/src/reviewSessions.ts` — **NEW** persistence layer for review session state
- `packages/cli/src/paths.ts` — added `REVIEW_SESSIONS_FILE` constant
- `packages/cli/src/processManager.ts` — on `code === 0`, check task status; if `in_review`, persist session instead of cleaning up
- `packages/cli/src/daemon.ts` — `checkReviewSessions()` in poll loop: resumes rejected tasks, cleans up completed/cancelled ones

## Test plan
- [ ] Agent submits task for review → worktree preserved, `review-sessions.json` written
- [ ] Human rejects task → daemon detects `in_progress` status, resumes agent in same worktree with rejection message
- [ ] Human completes task → daemon cleans up worktree and removes review session
- [ ] Daemon restart → review sessions survive (loaded from disk)
- [ ] Session reopen failure → worktree cleaned up, task released gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)