### PR TITLE
test: add TODO comment in paths.ts for reject-resume verification

### DIFF
--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -1,3 +1,4 @@
+// TODO: reject-resume verification test
 import { homedir } from "node:os";
 import { join } from "node:path";
 


### PR DESCRIPTION
## Summary
- Adds a `// TODO: reject-resume verification test` comment at line 1 of `packages/cli/src/paths.ts`

## Test plan
- [x] Verify comment is present as line 1 of `packages/cli/src/paths.ts`
- [x] Build and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)