### PR TITLE
test: add TODO comment in paths.ts for reject-resume verification v2

### DIFF
--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -1,3 +1,4 @@
+// TODO: reject-resume verification test v2
 import { homedir } from "node:os";
 import { join } from "node:path";
 


### PR DESCRIPTION
## Summary
- Added `// TODO: reject-resume verification test v2` as line 1 of `packages/cli/src/paths.ts`

## Test plan
- [x] Verify comment is present at line 1 of paths.ts
- [x] Pre-commit hooks pass (biome + typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)