### PR TITLE
Add TODO comment in paths.ts for reject-resume test v6

### DIFF
--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -1,3 +1,4 @@
+// TODO: reject-resume test v6
 import { homedir } from "node:os";
 import { join } from "node:path";
 


### PR DESCRIPTION
## Summary
- Adds `// TODO: reject-resume test v6` as line 1 of `packages/cli/src/paths.ts`

## Test plan
- [x] Verify the comment is on line 1 of `packages/cli/src/paths.ts`
- [x] Pre-commit hooks (biome + typecheck) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)