### PR TITLE
Add TODO comment to paths.ts for reject-resume test v8

### DIFF
--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -1,3 +1,4 @@
+// TODO: reject-resume test v8
 import { homedir } from "node:os";
 import { join } from "node:path";
 


### PR DESCRIPTION
## Summary
- Adds `// TODO: reject-resume test v8` as line 1 of `packages/cli/src/paths.ts`

## Test plan
- [x] Verify comment is present as line 1 of the file
- [x] Type checks pass (lefthook pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)