### PR TITLE
Fix infinite API calls on task detail page

### DIFF
--- a/apps/web/src/components/ActivityLog.tsx
+++ b/apps/web/src/components/ActivityLog.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useRef, useState } from "react";
-import { useSSE } from "../hooks/useSSE";
 import { formatRelative } from "./TaskDetailFields";
 import { Button } from "./ui/button";
 
 interface ActivityLogProps {
-  taskId: string;
   initialLogs: any[];
-  assigned: boolean;
+  sseLogs: any[];
+  reconnecting: boolean;
 }
 
 const actionStyles: Record<string, string> = {
@@ -33,8 +32,7 @@ const actionLabels: Record<string, string> = {
   review_requested: "Moved to review",
 };
 
-export function ActivityLog({ taskId, initialLogs, assigned }: ActivityLogProps) {
-  const { logs: sseLogs, reconnecting } = useSSE({ taskId, enabled: assigned });
+export function ActivityLog({ initialLogs, sseLogs, reconnecting }: ActivityLogProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
   const [newCount, setNewCount] = useState(0);

--- a/apps/web/src/components/TaskDetail.tsx
+++ b/apps/web/src/components/TaskDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useSSE } from "../hooks/useSSE";
 import { api } from "../lib/api";
 import { useSession } from "../lib/auth-client";
@@ -43,9 +43,9 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
   const [repositories, setRepositories] = useState<{ id: string; name: string }[]>([]);
   const [depTitles, setDepTitles] = useState<Record<string, string>>({});
   const [initialMessages, setInitialMessages] = useState<any[]>([]);
-  const { messages: sseMessages } = useSSE({ taskId, enabled: true });
+  const { logs: sseLogs, messages: sseMessages, reconnecting } = useSSE({ taskId, enabled: true });
 
-  const reload = () => api.tasks.get(taskId).then(setTask);
+  const reload = useCallback(() => api.tasks.get(taskId).then(setTask), [taskId]);
 
   useEffect(() => {
     reload().finally(() => setLoading(false));
@@ -217,7 +217,7 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
 
       <div>
         <FieldLabel>Activity</FieldLabel>
-        <ActivityLog taskId={taskId} initialLogs={task.logs || []} assigned={!!task.assigned_to} />
+        <ActivityLog initialLogs={task.logs || []} sseLogs={sseLogs} reconnecting={reconnecting} />
       </div>
 
       <Separator />


### PR DESCRIPTION
## Summary
- Wrap `reload` in `useCallback` with `[taskId]` dependency to stabilize its reference, fixing the infinite render→useEffect→setState→render loop
- Consolidate duplicate SSE connections: remove `useSSE` from `ActivityLog` and pass SSE logs/reconnecting state down as props from `TaskDetail`
- Net result: one SSE connection per task detail view instead of two, and no more infinite API calls

## Test plan
- [ ] Open a task detail page and verify network tab shows a single SSE connection and no repeated GET requests
- [ ] Verify activity logs still stream in real-time
- [ ] Verify chat messages still arrive via SSE
- [ ] Verify reconnecting indicator still shows when SSE fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)