### PR TITLE
feat: AgentProvider interface, registry, and Claude adapter

### DIFF
--- a/packages/cli/src/providers/claude.ts
+++ b/packages/cli/src/providers/claude.ts
@@ -1,0 +1,193 @@
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../logger.js";
+import type { AgentEvent, AgentProvider, SpawnOpts, UsageInfo } from "./types.js";
+
+const logger = createLogger("claude");
+
+const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
+const USAGE_API = "https://api.anthropic.com/api/oauth/usage";
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const RATE_LIMIT_CODES = new Set(["rate_limit_error", "overloaded_error"]);
+
+let cachedUsage: UsageInfo | null = null;
+let cachedAt = 0;
+let cachedToken: string | null = null;
+
+function parseToken(raw: string): string | null {
+  const creds = JSON.parse(raw);
+  return creds.claudeAiOauth?.accessToken || null;
+}
+
+function readOAuthToken(): string | null {
+  if (cachedToken) return cachedToken;
+  try {
+    if (platform() === "darwin") {
+      const raw = execSync('security find-generic-password -s "Claude Code-credentials" -w', { stdio: ["pipe", "pipe", "pipe"] })
+        .toString()
+        .trim();
+      cachedToken = parseToken(raw);
+    } else {
+      cachedToken = parseToken(readFileSync(CREDENTIALS_PATH, "utf-8"));
+    }
+    return cachedToken;
+  } catch {
+    return null;
+  }
+}
+
+function detectError(event: any): { code?: string; detail: string } | null {
+  if (event.type !== "error" && !event.error) return null;
+
+  let code: string | undefined;
+  if (event.error && typeof event.error === "object") {
+    code = event.error.type;
+  }
+
+  let detail: string | undefined;
+  if (event.type === "assistant" && Array.isArray(event.message?.content)) {
+    const textBlock = event.message.content.find((e: any) => e.type === "text" && e.text);
+    if (textBlock?.text) detail = textBlock.text;
+  }
+  if (!detail) {
+    detail = event.error?.message || (event.error !== "unknown" ? event.error : undefined) || event.message || JSON.stringify(event);
+  }
+
+  return { code, detail: String(detail) };
+}
+
+export const claudeProvider: AgentProvider = {
+  name: "claude",
+  label: "Claude Code",
+  command: "claude",
+
+  buildArgs(opts: SpawnOpts): string[] {
+    const args = [
+      "--print",
+      "--verbose",
+      "--input-format",
+      "stream-json",
+      "--output-format",
+      "stream-json",
+      "--dangerously-skip-permissions",
+      "--session-id",
+      opts.sessionId,
+    ];
+    if (opts.systemPromptFile) {
+      args.push("--system-prompt-file", opts.systemPromptFile);
+    }
+    return args;
+  },
+
+  buildResumeArgs(sessionId: string): string[] {
+    return [
+      "--resume",
+      sessionId,
+      "--print",
+      "--verbose",
+      "--input-format",
+      "stream-json",
+      "--output-format",
+      "stream-json",
+      "--dangerously-skip-permissions",
+    ];
+  },
+
+  parseEvent(raw: string): AgentEvent | null {
+    let event: any;
+    try {
+      event = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+
+    // rate_limit_event
+    if (event.type === "rate_limit_event") {
+      const info = event.rate_limit_info;
+      if (info && info.status !== "allowed") {
+        const resetAt = new Date(info.resetsAt * 1000).toISOString();
+        return { type: "rate_limit", resetAt };
+      }
+      return null;
+    }
+
+    // Error detection (covers all CLI error shapes)
+    const err = detectError(event);
+    if (err) {
+      if (err.code && RATE_LIMIT_CODES.has(err.code)) {
+        const resetAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+        return { type: "rate_limit", resetAt };
+      }
+      return { type: "error", code: err.code, detail: err.detail };
+    }
+
+    // Assistant message
+    if (event.type === "assistant" && Array.isArray(event.message?.content)) {
+      const texts: string[] = [];
+      for (const block of event.message.content) {
+        if (block.type === "text" && block.text) texts.push(block.text);
+      }
+      if (texts.length > 0) {
+        return { type: "message", text: texts.join("\n") };
+      }
+    }
+
+    // Result
+    if (event.type === "result") {
+      return {
+        type: "result",
+        cost: event.total_cost_usd || 0,
+        usage: event.usage,
+      };
+    }
+
+    return null;
+  },
+
+  buildInput(taskContext: string): string {
+    return JSON.stringify({
+      type: "user",
+      message: { role: "user", content: taskContext },
+    });
+  },
+
+  async getUsage(): Promise<UsageInfo | null> {
+    if (cachedUsage && Date.now() - cachedAt < CACHE_TTL_MS) {
+      return cachedUsage;
+    }
+
+    const token = readOAuthToken();
+    if (!token) return cachedUsage;
+
+    try {
+      const res = await fetch(USAGE_API, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "anthropic-beta": "oauth-2025-04-20",
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (!res.ok) {
+        logger.warn(`Usage API returned ${res.status}`);
+        return cachedUsage;
+      }
+
+      const data = (await res.json()) as Record<string, { utilization: number; resets_at: string }>;
+      cachedUsage = {
+        ...(data.five_hour && { five_hour: data.five_hour }),
+        ...(data.seven_day && { seven_day: data.seven_day }),
+        ...(data.seven_day_sonnet && { seven_day_sonnet: data.seven_day_sonnet }),
+        ...(data.seven_day_opus && { seven_day_opus: data.seven_day_opus }),
+        updated_at: new Date().toISOString(),
+      };
+      cachedAt = Date.now();
+      return cachedUsage;
+    } catch (err: any) {
+      logger.warn(`Failed to fetch usage: ${err.message}`);
+      return cachedUsage;
+    }
+  },
+};

--- a/packages/cli/src/providers/index.ts
+++ b/packages/cli/src/providers/index.ts
@@ -1,0 +1,3 @@
+export { claudeProvider } from "./claude.js";
+export { getAvailableProviders, getProvider, registerProvider } from "./registry.js";
+export type { AgentEvent, AgentProvider, SpawnOpts, UsageInfo } from "./types.js";

--- a/packages/cli/src/providers/registry.ts
+++ b/packages/cli/src/providers/registry.ts
@@ -1,0 +1,31 @@
+import { execSync } from "node:child_process";
+import { claudeProvider } from "./claude.js";
+import type { AgentProvider } from "./types.js";
+
+const providers = new Map<string, AgentProvider>();
+
+export function registerProvider(provider: AgentProvider): void {
+  providers.set(provider.name, provider);
+}
+
+export function getProvider(name: string): AgentProvider {
+  const provider = providers.get(name);
+  if (!provider) {
+    throw new Error(`Unknown provider: ${name}. Available: ${[...providers.keys()].join(", ")}`);
+  }
+  return provider;
+}
+
+export function getAvailableProviders(): AgentProvider[] {
+  return [...providers.values()].filter((p) => {
+    try {
+      execSync(`which ${p.command}`, { stdio: "ignore" });
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}
+
+// Auto-register built-in providers
+registerProvider(claudeProvider);

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -1,0 +1,35 @@
+export interface UsageWindow {
+  utilization: number;
+  resets_at: string;
+}
+
+export interface UsageInfo {
+  five_hour?: UsageWindow;
+  seven_day?: UsageWindow;
+  seven_day_sonnet?: UsageWindow;
+  seven_day_opus?: UsageWindow;
+  updated_at: string;
+}
+
+export interface SpawnOpts {
+  sessionId: string;
+  systemPromptFile?: string;
+}
+
+export type AgentEvent =
+  | { type: "message"; text: string }
+  | { type: "result"; cost?: number; usage?: Record<string, any> }
+  | { type: "rate_limit"; resetAt: string }
+  | { type: "error"; code?: string; detail: string };
+
+export interface AgentProvider {
+  readonly name: string;
+  readonly label: string;
+  readonly command: string;
+
+  buildArgs(opts: SpawnOpts): string[];
+  buildResumeArgs(sessionId: string): string[];
+  parseEvent(raw: string): AgentEvent | null;
+  buildInput(taskContext: string): string;
+  getUsage?(): Promise<UsageInfo | null>;
+}

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -1,0 +1,446 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+import { claudeProvider } from "../src/providers/claude.js";
+import { getAvailableProviders, getProvider, registerProvider } from "../src/providers/registry.js";
+import type { AgentProvider } from "../src/providers/types.js";
+
+// ---------------------------------------------------------------------------
+// claudeProvider.buildArgs
+// ---------------------------------------------------------------------------
+
+describe("claudeProvider.buildArgs", () => {
+  it("includes --print flag", () => {
+    const args = claudeProvider.buildArgs({ sessionId: "s1" });
+    expect(args).toContain("--print");
+  });
+
+  it("includes --verbose flag", () => {
+    const args = claudeProvider.buildArgs({ sessionId: "s1" });
+    expect(args).toContain("--verbose");
+  });
+
+  it("includes --input-format stream-json", () => {
+    const args = claudeProvider.buildArgs({ sessionId: "s1" });
+    const idx = args.indexOf("--input-format");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("stream-json");
+  });
+
+  it("includes --output-format stream-json", () => {
+    const args = claudeProvider.buildArgs({ sessionId: "s1" });
+    const idx = args.indexOf("--output-format");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("stream-json");
+  });
+
+  it("includes --dangerously-skip-permissions flag", () => {
+    const args = claudeProvider.buildArgs({ sessionId: "s1" });
+    expect(args).toContain("--dangerously-skip-permissions");
+  });
+
+  it("includes --session-id with the provided session ID", () => {
+    const args = claudeProvider.buildArgs({ sessionId: "abc-123" });
+    const idx = args.indexOf("--session-id");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("abc-123");
+  });
+
+  it("does not include --system-prompt-file when systemPromptFile is absent", () => {
+    const args = claudeProvider.buildArgs({ sessionId: "s1" });
+    expect(args).not.toContain("--system-prompt-file");
+  });
+
+  it("appends --system-prompt-file when systemPromptFile is provided", () => {
+    const args = claudeProvider.buildArgs({ sessionId: "s1", systemPromptFile: "/tmp/prompt.txt" });
+    const idx = args.indexOf("--system-prompt-file");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("/tmp/prompt.txt");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claudeProvider.buildResumeArgs
+// ---------------------------------------------------------------------------
+
+describe("claudeProvider.buildResumeArgs", () => {
+  it("starts with --resume flag", () => {
+    const args = claudeProvider.buildResumeArgs("sess-99");
+    expect(args[0]).toBe("--resume");
+  });
+
+  it("includes the session ID immediately after --resume", () => {
+    const args = claudeProvider.buildResumeArgs("sess-99");
+    expect(args[1]).toBe("sess-99");
+  });
+
+  it("includes --print flag", () => {
+    const args = claudeProvider.buildResumeArgs("sess-99");
+    expect(args).toContain("--print");
+  });
+
+  it("includes --verbose flag", () => {
+    const args = claudeProvider.buildResumeArgs("sess-99");
+    expect(args).toContain("--verbose");
+  });
+
+  it("includes --dangerously-skip-permissions flag", () => {
+    const args = claudeProvider.buildResumeArgs("sess-99");
+    expect(args).toContain("--dangerously-skip-permissions");
+  });
+
+  it("includes --input-format stream-json", () => {
+    const args = claudeProvider.buildResumeArgs("sess-99");
+    const idx = args.indexOf("--input-format");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("stream-json");
+  });
+
+  it("includes --output-format stream-json", () => {
+    const args = claudeProvider.buildResumeArgs("sess-99");
+    const idx = args.indexOf("--output-format");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("stream-json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claudeProvider.parseEvent
+// ---------------------------------------------------------------------------
+
+describe("claudeProvider.parseEvent — invalid input", () => {
+  it("returns null for non-JSON string", () => {
+    expect(claudeProvider.parseEvent("not json")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(claudeProvider.parseEvent("")).toBeNull();
+  });
+
+  it("returns null for unrecognised event type", () => {
+    expect(claudeProvider.parseEvent(JSON.stringify({ type: "unknown_event" }))).toBeNull();
+  });
+});
+
+describe("claudeProvider.parseEvent — rate_limit_event", () => {
+  it("returns rate_limit when rate_limit_info.status is not allowed", () => {
+    const raw = JSON.stringify({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "blocked", resetsAt: 1700000000 },
+    });
+    const event = claudeProvider.parseEvent(raw);
+    expect(event?.type).toBe("rate_limit");
+  });
+
+  it("resetAt is a valid ISO string derived from resetsAt epoch", () => {
+    const resetsAt = 1700000000;
+    const raw = JSON.stringify({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "blocked", resetsAt },
+    });
+    const event = claudeProvider.parseEvent(raw);
+    expect(event?.type).toBe("rate_limit");
+    if (event?.type === "rate_limit") {
+      expect(new Date(event.resetAt).getTime()).toBe(resetsAt * 1000);
+    }
+  });
+
+  it("returns null when rate_limit_info.status is allowed", () => {
+    const raw = JSON.stringify({
+      type: "rate_limit_event",
+      rate_limit_info: { status: "allowed", resetsAt: 1700000000 },
+    });
+    expect(claudeProvider.parseEvent(raw)).toBeNull();
+  });
+
+  it("returns null when rate_limit_info is absent", () => {
+    const raw = JSON.stringify({ type: "rate_limit_event" });
+    expect(claudeProvider.parseEvent(raw)).toBeNull();
+  });
+});
+
+describe("claudeProvider.parseEvent — assistant message", () => {
+  it("returns a message event with the text content", () => {
+    const raw = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "Hello world" }] },
+    });
+    const event = claudeProvider.parseEvent(raw);
+    expect(event?.type).toBe("message");
+    if (event?.type === "message") {
+      expect(event.text).toBe("Hello world");
+    }
+  });
+
+  it("joins multiple text blocks with newline", () => {
+    const raw = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "text", text: "Line one" },
+          { type: "text", text: "Line two" },
+        ],
+      },
+    });
+    const event = claudeProvider.parseEvent(raw);
+    expect(event?.type).toBe("message");
+    if (event?.type === "message") {
+      expect(event.text).toBe("Line one\nLine two");
+    }
+  });
+
+  it("returns null when content has no text blocks", () => {
+    const raw = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "tool_use", id: "tu1" }] },
+    });
+    expect(claudeProvider.parseEvent(raw)).toBeNull();
+  });
+
+  it("returns null when message content is missing", () => {
+    const raw = JSON.stringify({ type: "assistant", message: {} });
+    expect(claudeProvider.parseEvent(raw)).toBeNull();
+  });
+});
+
+describe("claudeProvider.parseEvent — result", () => {
+  it("returns a result event", () => {
+    const raw = JSON.stringify({ type: "result", total_cost_usd: 0.05 });
+    const event = claudeProvider.parseEvent(raw);
+    expect(event?.type).toBe("result");
+  });
+
+  it("includes cost from total_cost_usd", () => {
+    const raw = JSON.stringify({ type: "result", total_cost_usd: 0.12 });
+    const event = claudeProvider.parseEvent(raw);
+    if (event?.type === "result") {
+      expect(event.cost).toBe(0.12);
+    }
+  });
+
+  it("defaults cost to 0 when total_cost_usd is absent", () => {
+    const raw = JSON.stringify({ type: "result" });
+    const event = claudeProvider.parseEvent(raw);
+    if (event?.type === "result") {
+      expect(event.cost).toBe(0);
+    }
+  });
+
+  it("includes usage when present", () => {
+    const usage = { input_tokens: 100, output_tokens: 50 };
+    const raw = JSON.stringify({ type: "result", total_cost_usd: 0, usage });
+    const event = claudeProvider.parseEvent(raw);
+    if (event?.type === "result") {
+      expect(event.usage).toEqual(usage);
+    }
+  });
+});
+
+describe("claudeProvider.parseEvent — error variants", () => {
+  it("returns error event when event.type is error", () => {
+    const raw = JSON.stringify({ type: "error", message: "Something went wrong" });
+    const event = claudeProvider.parseEvent(raw);
+    expect(event?.type).toBe("error");
+  });
+
+  it("includes detail from event.message when error object is absent", () => {
+    const raw = JSON.stringify({ type: "error", message: "Boom" });
+    const event = claudeProvider.parseEvent(raw);
+    if (event?.type === "error") {
+      expect(event.detail).toContain("Boom");
+    }
+  });
+
+  it("includes error code from event.error.type", () => {
+    const raw = JSON.stringify({
+      type: "error",
+      error: { type: "invalid_request_error", message: "Bad input" },
+    });
+    const event = claudeProvider.parseEvent(raw);
+    if (event?.type === "error") {
+      expect(event.code).toBe("invalid_request_error");
+    }
+  });
+
+  it("returns rate_limit when error code is rate_limit_error", () => {
+    const raw = JSON.stringify({
+      type: "error",
+      error: { type: "rate_limit_error", message: "Rate limited" },
+    });
+    const event = claudeProvider.parseEvent(raw);
+    expect(event?.type).toBe("rate_limit");
+  });
+
+  it("returns rate_limit when error code is overloaded_error", () => {
+    const raw = JSON.stringify({
+      type: "error",
+      error: { type: "overloaded_error", message: "Overloaded" },
+    });
+    const event = claudeProvider.parseEvent(raw);
+    expect(event?.type).toBe("rate_limit");
+  });
+
+  it("rate_limit resetAt for rate_limit_error is roughly 1 hour from now", () => {
+    const before = Date.now();
+    const raw = JSON.stringify({
+      type: "error",
+      error: { type: "rate_limit_error", message: "Rate limited" },
+    });
+    const event = claudeProvider.parseEvent(raw);
+    const after = Date.now();
+    if (event?.type === "rate_limit") {
+      const resetMs = new Date(event.resetAt).getTime();
+      expect(resetMs).toBeGreaterThanOrEqual(before + 60 * 60 * 1000 - 100);
+      expect(resetMs).toBeLessThanOrEqual(after + 60 * 60 * 1000 + 100);
+    }
+  });
+
+  it("returns error event when event.error is present even without event.type=error", () => {
+    const raw = JSON.stringify({ type: "assistant", error: { type: "some_error", message: "Oops" } });
+    const event = claudeProvider.parseEvent(raw);
+    expect(event?.type).toBe("error");
+  });
+
+  it("uses assistant message text block as detail when event has both error and assistant content", () => {
+    const raw = JSON.stringify({
+      type: "assistant",
+      error: { type: "some_error", message: "fallback" },
+      message: {
+        content: [{ type: "text", text: "Error explanation from content" }],
+      },
+    });
+    const event = claudeProvider.parseEvent(raw);
+    expect(event?.type).toBe("error");
+    if (event?.type === "error") {
+      expect(event.detail).toBe("Error explanation from content");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claudeProvider.buildInput
+// ---------------------------------------------------------------------------
+
+describe("claudeProvider.buildInput", () => {
+  it("returns valid JSON string", () => {
+    const result = claudeProvider.buildInput("do the task");
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+
+  it("wraps context in user message envelope", () => {
+    const parsed = JSON.parse(claudeProvider.buildInput("do the task"));
+    expect(parsed.type).toBe("user");
+    expect(parsed.message.role).toBe("user");
+  });
+
+  it("includes the task context as message content", () => {
+    const parsed = JSON.parse(claudeProvider.buildInput("implement feature X"));
+    expect(parsed.message.content).toBe("implement feature X");
+  });
+
+  it("handles empty string context", () => {
+    const parsed = JSON.parse(claudeProvider.buildInput(""));
+    expect(parsed.message.content).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// claudeProvider identity fields
+// ---------------------------------------------------------------------------
+
+describe("claudeProvider identity", () => {
+  it("name is claude", () => {
+    expect(claudeProvider.name).toBe("claude");
+  });
+
+  it("label is Claude Code", () => {
+    expect(claudeProvider.label).toBe("Claude Code");
+  });
+
+  it("command is claude", () => {
+    expect(claudeProvider.command).toBe("claude");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registry: registerProvider / getProvider / getAvailableProviders
+// ---------------------------------------------------------------------------
+
+describe("registry.getProvider", () => {
+  it("returns claudeProvider which is registered by default", () => {
+    const provider = getProvider("claude");
+    expect(provider.name).toBe("claude");
+  });
+
+  it("throws when provider name is not registered", () => {
+    expect(() => getProvider("nonexistent-provider-xyz")).toThrow("Unknown provider: nonexistent-provider-xyz");
+  });
+
+  it("error message lists available providers", () => {
+    expect(() => getProvider("ghost")).toThrow(/Available:/);
+  });
+});
+
+describe("registry.registerProvider", () => {
+  it("makes a newly registered provider retrievable by name", () => {
+    const fake: AgentProvider = {
+      name: "fake-provider-test",
+      label: "Fake",
+      command: "fake",
+      buildArgs: () => [],
+      buildResumeArgs: () => [],
+      parseEvent: () => null,
+      buildInput: (ctx) => ctx,
+    };
+    registerProvider(fake);
+    expect(getProvider("fake-provider-test").name).toBe("fake-provider-test");
+  });
+
+  it("overwrites an existing provider with the same name", () => {
+    const v1: AgentProvider = {
+      name: "overwrite-test",
+      label: "V1",
+      command: "cmd",
+      buildArgs: () => ["v1"],
+      buildResumeArgs: () => [],
+      parseEvent: () => null,
+      buildInput: (ctx) => ctx,
+    };
+    const v2: AgentProvider = {
+      name: "overwrite-test",
+      label: "V2",
+      command: "cmd",
+      buildArgs: () => ["v2"],
+      buildResumeArgs: () => [],
+      parseEvent: () => null,
+      buildInput: (ctx) => ctx,
+    };
+    registerProvider(v1);
+    registerProvider(v2);
+    expect(getProvider("overwrite-test").label).toBe("V2");
+  });
+});
+
+describe("registry.getAvailableProviders", () => {
+  it("returns an array", () => {
+    const result = getAvailableProviders();
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  it("returns only providers whose command exists on PATH", () => {
+    // Each returned provider must pass a `which <command>` check.
+    // We can verify this by registering a provider with a command that surely
+    // does not exist and confirming it is not included.
+    const ghost: AgentProvider = {
+      name: "ghost-cmd-provider",
+      label: "Ghost",
+      command: "__definitely_not_a_real_command_xyz__",
+      buildArgs: () => [],
+      buildResumeArgs: () => [],
+      parseEvent: () => null,
+      buildInput: (ctx) => ctx,
+    };
+    registerProvider(ghost);
+    const available = getAvailableProviders();
+    expect(available.find((p) => p.name === "ghost-cmd-provider")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Define `AgentProvider` interface and `AgentEvent` types in `packages/cli/src/providers/types.ts`
- Implement Claude Code adapter in `packages/cli/src/providers/claude.ts` — extracts arg building, event parsing, input formatting, and usage fetching from `processManager.ts` and `usage.ts`
- Create provider registry in `packages/cli/src/providers/registry.ts` with `registerProvider`, `getProvider`, and `getAvailableProviders` (replaces `detectRuntimes()`)
- Add barrel exports in `packages/cli/src/providers/index.ts`
- 52 unit tests covering all provider methods and registry operations

## Test plan
- [x] All 52 unit tests pass (`npx vitest run`)
- [x] Build passes (`pnpm build`)
- [x] Type check passes (`tsc --noEmit`)
- [x] Biome lint passes (pre-commit hook)
- [ ] Verify `parseEvent` handles all Claude CLI event shapes correctly
- [ ] Verify `getAvailableProviders` correctly detects installed CLI tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)