### PR TITLE
feat: AgentProvider interface, registry, and Claude adapter

### DIFF
--- a/packages/cli/src/providers/claude.ts
+++ b/packages/cli/src/providers/claude.ts
@@ -1,0 +1,181 @@
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../logger.js";
+import type { AgentEvent, AgentProvider, SpawnOpts, UsageInfo } from "./types.js";
+
+const logger = createLogger("claude");
+
+const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
+const USAGE_API = "https://api.anthropic.com/api/oauth/usage";
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const RATE_LIMIT_CODES = new Set(["rate_limit_error", "overloaded_error"]);
+
+let cachedUsage: UsageInfo | null = null;
+let cachedAt = 0;
+
+function parseToken(raw: string): string | null {
+  const creds = JSON.parse(raw);
+  return creds.claudeAiOauth?.accessToken || null;
+}
+
+function readOAuthToken(): string | null {
+  try {
+    if (platform() === "darwin") {
+      const raw = execSync('security find-generic-password -s "Claude Code-credentials" -w', { stdio: ["pipe", "pipe", "pipe"] })
+        .toString()
+        .trim();
+      return parseToken(raw);
+    }
+    return parseToken(readFileSync(CREDENTIALS_PATH, "utf-8"));
+  } catch {
+    return null;
+  }
+}
+
+function detectError(event: any): { code?: string; detail: string } | null {
+  if (event.type !== "error" && !event.error) return null;
+
+  let code: string | undefined;
+  if (event.error && typeof event.error === "object") {
+    code = event.error.type;
+  }
+
+  let detail: string | undefined;
+  if (event.type === "assistant" && Array.isArray(event.message?.content)) {
+    const textBlock = event.message.content.find((e: any) => e.type === "text" && e.text);
+    if (textBlock?.text) detail = textBlock.text;
+  }
+  if (!detail) {
+    detail =
+      event.error?.message ||
+      (typeof event.error === "string" && event.error !== "unknown" ? event.error : undefined) ||
+      event.message ||
+      JSON.stringify(event);
+  }
+
+  return { code, detail: String(detail) };
+}
+
+export const claudeProvider: AgentProvider = {
+  name: "claude",
+  label: "Claude Code",
+  command: "claude",
+
+  buildArgs(opts: SpawnOpts): string[] {
+    const args = [
+      "--print",
+      "--verbose",
+      "--input-format",
+      "stream-json",
+      "--output-format",
+      "stream-json",
+      "--dangerously-skip-permissions",
+      "--session-id",
+      opts.sessionId,
+    ];
+    if (opts.systemPromptFile) {
+      args.push("--system-prompt-file", opts.systemPromptFile);
+    }
+    return args;
+  },
+
+  buildResumeArgs(sessionId: string): string[] {
+    return [
+      "--resume",
+      sessionId,
+      "--print",
+      "--verbose",
+      "--input-format",
+      "stream-json",
+      "--output-format",
+      "stream-json",
+      "--dangerously-skip-permissions",
+    ];
+  },
+
+  parseEvent(raw: string): AgentEvent | null {
+    let event: any;
+    try {
+      event = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+
+    if (event.type === "rate_limit_event") {
+      const info = event.rate_limit_info;
+      if (info && info.status !== "allowed") {
+        return { type: "rate_limit", resetAt: new Date(info.resetsAt * 1000).toISOString() };
+      }
+      return null;
+    }
+
+    const err = detectError(event);
+    if (err) {
+      if (err.code && RATE_LIMIT_CODES.has(err.code)) {
+        return { type: "rate_limit", resetAt: new Date(Date.now() + 60 * 60 * 1000).toISOString() };
+      }
+      return { type: "error", code: err.code, detail: err.detail };
+    }
+
+    if (event.type === "assistant" && Array.isArray(event.message?.content)) {
+      const texts = event.message.content.filter((b: any) => b.type === "text" && b.text).map((b: any) => b.text);
+      if (texts.length > 0) {
+        return { type: "message", text: texts.join("\n") };
+      }
+    }
+
+    if (event.type === "result") {
+      return {
+        type: "result",
+        cost: event.total_cost_usd,
+        usage: event.usage,
+      };
+    }
+
+    return null;
+  },
+
+  buildInput(taskContext: string): string {
+    return JSON.stringify({ type: "user", message: { role: "user", content: taskContext } });
+  },
+
+  async getUsage(): Promise<UsageInfo | null> {
+    if (cachedUsage && Date.now() - cachedAt < CACHE_TTL_MS) {
+      return cachedUsage;
+    }
+
+    const token = readOAuthToken();
+    if (!token) return null;
+
+    try {
+      const res = await fetch(USAGE_API, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "anthropic-beta": "oauth-2025-04-20",
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (!res.ok) {
+        logger.warn(`Usage API returned ${res.status}`);
+        return cachedUsage;
+      }
+
+      const data = (await res.json()) as Record<string, { utilization: number; resets_at: string }>;
+      cachedUsage = {
+        ...(data.five_hour && { five_hour: data.five_hour }),
+        ...(data.seven_day && { seven_day: data.seven_day }),
+        ...(data.seven_day_sonnet && { seven_day_sonnet: data.seven_day_sonnet }),
+        ...(data.seven_day_opus && { seven_day_opus: data.seven_day_opus }),
+        updated_at: new Date().toISOString(),
+      };
+      cachedAt = Date.now();
+      return cachedUsage;
+    } catch (err: any) {
+      logger.warn(`Failed to fetch usage: ${err.message}`);
+      return cachedUsage;
+    }
+  },
+};

--- a/packages/cli/src/providers/index.ts
+++ b/packages/cli/src/providers/index.ts
@@ -1,0 +1,3 @@
+export { claudeProvider } from "./claude.js";
+export { getAvailableProviders, getProvider, registerProvider, resetRegistry } from "./registry.js";
+export type { AgentEvent, AgentProvider, SpawnOpts, UsageInfo } from "./types.js";

--- a/packages/cli/src/providers/registry.ts
+++ b/packages/cli/src/providers/registry.ts
@@ -1,0 +1,31 @@
+import { spawnSync } from "node:child_process";
+import { claudeProvider } from "./claude.js";
+import type { AgentProvider } from "./types.js";
+
+const providers = new Map<string, AgentProvider>();
+
+export function registerProvider(provider: AgentProvider): void {
+  providers.set(provider.name, provider);
+}
+
+export function getProvider(name: string): AgentProvider {
+  const provider = providers.get(name);
+  if (!provider) {
+    throw new Error(`Unknown provider: "${name}". Available: ${[...providers.keys()].join(", ")}`);
+  }
+  return provider;
+}
+
+export function getAvailableProviders(): AgentProvider[] {
+  return [...providers.values()].filter((p) => {
+    const result = spawnSync("which", [p.command], { stdio: "ignore" });
+    return result.status === 0;
+  });
+}
+
+export function resetRegistry(): void {
+  providers.clear();
+  registerProvider(claudeProvider);
+}
+
+registerProvider(claudeProvider);

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -1,0 +1,35 @@
+export interface UsageWindow {
+  utilization: number;
+  resets_at: string;
+}
+
+export interface UsageInfo {
+  five_hour?: UsageWindow;
+  seven_day?: UsageWindow;
+  seven_day_sonnet?: UsageWindow;
+  seven_day_opus?: UsageWindow;
+  updated_at: string;
+}
+
+export interface SpawnOpts {
+  sessionId: string;
+  systemPromptFile?: string;
+}
+
+export type AgentEvent =
+  | { type: "message"; text: string }
+  | { type: "result"; cost?: number; usage?: Record<string, any> }
+  | { type: "rate_limit"; resetAt: string }
+  | { type: "error"; code?: string; detail: string };
+
+export interface AgentProvider {
+  readonly name: string;
+  readonly label: string;
+  readonly command: string;
+
+  buildArgs(opts: SpawnOpts): string[];
+  buildResumeArgs(sessionId: string): string[];
+  parseEvent(raw: string): AgentEvent | null;
+  buildInput(taskContext: string): string;
+  getUsage?(): Promise<UsageInfo | null>;
+}

--- a/packages/cli/tests/claude.test.ts
+++ b/packages/cli/tests/claude.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from "vitest";
+import { claudeProvider } from "../src/providers/claude.js";
+
+describe("claudeProvider", () => {
+  describe("identity", () => {
+    it("has name 'claude'", () => {
+      expect(claudeProvider.name).toBe("claude");
+    });
+
+    it("has label 'Claude Code'", () => {
+      expect(claudeProvider.label).toBe("Claude Code");
+    });
+
+    it("has command 'claude'", () => {
+      expect(claudeProvider.command).toBe("claude");
+    });
+  });
+
+  describe("buildArgs", () => {
+    it("returns required flags", () => {
+      const args = claudeProvider.buildArgs({ sessionId: "sess-1" });
+      expect(args).toContain("--print");
+      expect(args).toContain("--verbose");
+      expect(args).toContain("--input-format");
+      expect(args).toContain("stream-json");
+      expect(args).toContain("--output-format");
+      expect(args).toContain("--dangerously-skip-permissions");
+    });
+
+    it("includes session-id flag and value", () => {
+      const args = claudeProvider.buildArgs({ sessionId: "my-session" });
+      const idx = args.indexOf("--session-id");
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(args[idx + 1]).toBe("my-session");
+    });
+
+    it("does not include system-prompt-file when not provided", () => {
+      const args = claudeProvider.buildArgs({ sessionId: "sess-1" });
+      expect(args).not.toContain("--system-prompt-file");
+    });
+
+    it("includes system-prompt-file when provided", () => {
+      const args = claudeProvider.buildArgs({ sessionId: "sess-1", systemPromptFile: "/tmp/prompt.txt" });
+      const idx = args.indexOf("--system-prompt-file");
+      expect(idx).toBeGreaterThanOrEqual(0);
+      expect(args[idx + 1]).toBe("/tmp/prompt.txt");
+    });
+  });
+
+  describe("buildResumeArgs", () => {
+    it("starts with --resume and session id", () => {
+      const args = claudeProvider.buildResumeArgs("resume-id");
+      expect(args[0]).toBe("--resume");
+      expect(args[1]).toBe("resume-id");
+    });
+
+    it("includes required streaming flags", () => {
+      const args = claudeProvider.buildResumeArgs("resume-id");
+      expect(args).toContain("--print");
+      expect(args).toContain("--verbose");
+      expect(args).toContain("--input-format");
+      expect(args).toContain("stream-json");
+      expect(args).toContain("--output-format");
+      expect(args).toContain("--dangerously-skip-permissions");
+    });
+
+    it("does not include --session-id flag", () => {
+      const args = claudeProvider.buildResumeArgs("resume-id");
+      expect(args).not.toContain("--session-id");
+    });
+  });
+
+  describe("parseEvent", () => {
+    it("returns null for invalid JSON", () => {
+      expect(claudeProvider.parseEvent("not-json")).toBeNull();
+    });
+
+    it("returns null for empty string", () => {
+      expect(claudeProvider.parseEvent("")).toBeNull();
+    });
+
+    it("returns null for unrecognized event type", () => {
+      expect(claudeProvider.parseEvent(JSON.stringify({ type: "unknown" }))).toBeNull();
+    });
+
+    it("returns rate_limit for rate_limit_event with blocked status", () => {
+      const raw = JSON.stringify({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "blocked", resetsAt: 1700000000 },
+      });
+      const event = claudeProvider.parseEvent(raw);
+      expect(event?.type).toBe("rate_limit");
+      if (event?.type === "rate_limit") {
+        expect(event.resetAt).toBe(new Date(1700000000 * 1000).toISOString());
+      }
+    });
+
+    it("returns null for rate_limit_event with allowed status", () => {
+      const raw = JSON.stringify({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "allowed", resetsAt: 1700000000 },
+      });
+      expect(claudeProvider.parseEvent(raw)).toBeNull();
+    });
+
+    it("returns null for rate_limit_event with no rate_limit_info", () => {
+      const raw = JSON.stringify({ type: "rate_limit_event" });
+      expect(claudeProvider.parseEvent(raw)).toBeNull();
+    });
+
+    it("returns rate_limit when error code is rate_limit_error", () => {
+      const raw = JSON.stringify({
+        type: "error",
+        error: { type: "rate_limit_error", message: "Rate limited" },
+      });
+      const event = claudeProvider.parseEvent(raw);
+      expect(event?.type).toBe("rate_limit");
+    });
+
+    it("returns rate_limit when error code is overloaded_error", () => {
+      const raw = JSON.stringify({
+        type: "error",
+        error: { type: "overloaded_error", message: "Overloaded" },
+      });
+      const event = claudeProvider.parseEvent(raw);
+      expect(event?.type).toBe("rate_limit");
+    });
+
+    it("returns error event for generic error type", () => {
+      const raw = JSON.stringify({
+        type: "error",
+        error: { type: "server_error", message: "Something went wrong" },
+      });
+      const event = claudeProvider.parseEvent(raw);
+      expect(event?.type).toBe("error");
+      if (event?.type === "error") {
+        expect(event.code).toBe("server_error");
+        expect(event.detail).toBe("Something went wrong");
+      }
+    });
+
+    it("returns error event with detail from error.message when no code", () => {
+      const raw = JSON.stringify({
+        type: "error",
+        error: { message: "plain error" },
+      });
+      const event = claudeProvider.parseEvent(raw);
+      expect(event?.type).toBe("error");
+      if (event?.type === "error") {
+        expect(event.detail).toBe("plain error");
+      }
+    });
+
+    it("returns message event for assistant event with text content", () => {
+      const raw = JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "Hello world" }] },
+      });
+      const event = claudeProvider.parseEvent(raw);
+      expect(event?.type).toBe("message");
+      if (event?.type === "message") {
+        expect(event.text).toBe("Hello world");
+      }
+    });
+
+    it("joins multiple text blocks with newline", () => {
+      const raw = JSON.stringify({
+        type: "assistant",
+        message: {
+          content: [
+            { type: "text", text: "Line one" },
+            { type: "text", text: "Line two" },
+          ],
+        },
+      });
+      const event = claudeProvider.parseEvent(raw);
+      expect(event?.type).toBe("message");
+      if (event?.type === "message") {
+        expect(event.text).toBe("Line one\nLine two");
+      }
+    });
+
+    it("returns null for assistant event with no text blocks", () => {
+      const raw = JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "tu_1" }] },
+      });
+      expect(claudeProvider.parseEvent(raw)).toBeNull();
+    });
+
+    it("returns null for assistant event with empty content array", () => {
+      const raw = JSON.stringify({
+        type: "assistant",
+        message: { content: [] },
+      });
+      expect(claudeProvider.parseEvent(raw)).toBeNull();
+    });
+
+    it("returns result event with cost and usage", () => {
+      const raw = JSON.stringify({
+        type: "result",
+        total_cost_usd: 0.005,
+        usage: { input_tokens: 100, output_tokens: 50 },
+      });
+      const event = claudeProvider.parseEvent(raw);
+      expect(event?.type).toBe("result");
+      if (event?.type === "result") {
+        expect(event.cost).toBe(0.005);
+        expect(event.usage).toEqual({ input_tokens: 100, output_tokens: 50 });
+      }
+    });
+
+    it("returns result event with undefined cost when not present", () => {
+      const raw = JSON.stringify({ type: "result" });
+      const event = claudeProvider.parseEvent(raw);
+      expect(event?.type).toBe("result");
+      if (event?.type === "result") {
+        expect(event.cost).toBeUndefined();
+        expect(event.usage).toBeUndefined();
+      }
+    });
+
+    it("extracts error detail from assistant message text block when event has error field", () => {
+      const raw = JSON.stringify({
+        type: "assistant",
+        error: { type: "some_error", message: "fallback" },
+        message: {
+          content: [{ type: "text", text: "Error from content" }],
+        },
+      });
+      const event = claudeProvider.parseEvent(raw);
+      expect(event?.type).toBe("error");
+      if (event?.type === "error") {
+        expect(event.detail).toBe("Error from content");
+      }
+    });
+  });
+
+  describe("buildInput", () => {
+    it("returns valid JSON string", () => {
+      const input = claudeProvider.buildInput("do the thing");
+      expect(() => JSON.parse(input)).not.toThrow();
+    });
+
+    it("wraps task context in user message structure", () => {
+      const input = claudeProvider.buildInput("my task context");
+      const parsed = JSON.parse(input);
+      expect(parsed.type).toBe("user");
+      expect(parsed.message.role).toBe("user");
+      expect(parsed.message.content).toBe("my task context");
+    });
+
+    it("preserves task context verbatim", () => {
+      const ctx = "context with special chars: <>&\"'";
+      const parsed = JSON.parse(claudeProvider.buildInput(ctx));
+      expect(parsed.message.content).toBe(ctx);
+    });
+  });
+});

--- a/packages/cli/tests/registry.test.ts
+++ b/packages/cli/tests/registry.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { getAvailableProviders, getProvider, registerProvider, resetRegistry } from "../src/providers/registry.js";
+import type { AgentProvider } from "../src/providers/types.js";
+
+// Minimal stub provider for test registration
+function makeProvider(name: string, command = "echo"): AgentProvider {
+  return {
+    name,
+    label: `Label for ${name}`,
+    command,
+    buildArgs: () => [],
+    buildResumeArgs: () => [],
+    parseEvent: () => null,
+    buildInput: (ctx) => ctx,
+  };
+}
+
+describe("registry", () => {
+  afterEach(() => {
+    resetRegistry();
+  });
+
+  describe("getProvider", () => {
+    it("returns claudeProvider which is auto-registered on import", () => {
+      const provider = getProvider("claude");
+      expect(provider.name).toBe("claude");
+    });
+
+    it("throws for unknown provider name", () => {
+      expect(() => getProvider("nonexistent-xyz")).toThrow(/Unknown provider/);
+    });
+
+    it("error message includes the unknown name", () => {
+      expect(() => getProvider("ghost")).toThrow(/"ghost"/);
+    });
+
+    it("error message lists available providers", () => {
+      expect(() => getProvider("ghost")).toThrow(/Available:/);
+    });
+  });
+
+  describe("registerProvider", () => {
+    const testProviderName = "test-provider-unique-1";
+
+    it("registers a new provider and makes it retrievable", () => {
+      const provider = makeProvider(testProviderName);
+      registerProvider(provider);
+      expect(getProvider(testProviderName)).toBe(provider);
+    });
+
+    it("overwrites an existing provider with the same name", () => {
+      const first = makeProvider("overwrite-test");
+      const second = makeProvider("overwrite-test");
+      registerProvider(first);
+      registerProvider(second);
+      expect(getProvider("overwrite-test")).toBe(second);
+    });
+  });
+
+  describe("getAvailableProviders", () => {
+    it("returns an array", () => {
+      const result = getAvailableProviders();
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it("only includes providers whose command exists on PATH", () => {
+      // Register a provider with a command that definitely does not exist
+      registerProvider(makeProvider("unavailable-provider", "this-command-surely-does-not-exist-xyz123"));
+      const available = getAvailableProviders();
+      const names = available.map((p) => p.name);
+      expect(names).not.toContain("unavailable-provider");
+    });
+
+    it("includes providers whose command is available on PATH", () => {
+      // 'echo' is universally available
+      const echoProvider = makeProvider("echo-provider", "echo");
+      registerProvider(echoProvider);
+      const available = getAvailableProviders();
+      const names = available.map((p) => p.name);
+      expect(names).toContain("echo-provider");
+    });
+
+    it("returns only AgentProvider objects", () => {
+      const available = getAvailableProviders();
+      for (const p of available) {
+        expect(typeof p.name).toBe("string");
+        expect(typeof p.command).toBe("string");
+        expect(typeof p.buildArgs).toBe("function");
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Define `AgentProvider` interface and `AgentEvent` types in `packages/cli/src/providers/types.ts`
- Implement provider registry with `registerProvider`, `getProvider`, `getAvailableProviders` in `packages/cli/src/providers/registry.ts`
- Extract Claude Code adapter from `processManager.ts` and `usage.ts` into `packages/cli/src/providers/claude.ts`
- 40 unit tests covering all public API surface (buildArgs, buildResumeArgs, parseEvent, buildInput, registry operations)

## Key decisions
- Claude adapter is a singleton object (not a class), matching existing codebase style
- `getAvailableProviders()` uses `spawnSync` instead of `execSync` to prevent shell injection
- OAuth token is re-read on each `getUsage()` call instead of cached forever (tokens expire)
- `resetRegistry()` exported for test isolation
- Error detail fallback chain fixed to check `typeof event.error === "string"` before using as detail

## Test plan
- [x] All 40 unit tests pass (`npx vitest run`)
- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Biome lint/format passes
- [x] Full build passes (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)