### PR TITLE
Show empty state for machine runtimes

### DIFF
--- a/apps/web/src/routes/MachineDetailPage.tsx
+++ b/apps/web/src/routes/MachineDetailPage.tsx
@@ -141,18 +141,20 @@ export function MachineDetailPage() {
               <span className="font-mono text-xs text-content-primary">{formatRelative(machine.created_at)}</span>
             </div>
           </div>
-          {runtimes.length > 0 && (
-            <div>
-              <span className="text-[11px] text-content-tertiary uppercase tracking-wide block mb-1.5">Runtimes</span>
-              <div className="flex gap-1.5">
+          <div>
+            <span className="text-[11px] text-content-tertiary uppercase tracking-wide block mb-1.5">Runtimes</span>
+            {runtimes.length > 0 ? (
+              <div className="flex gap-1.5 flex-wrap">
                 {runtimes.map((r: string) => (
                   <span key={r} className="text-[11px] font-mono text-accent bg-accent-soft px-2 py-0.5 rounded">
                     {r}
                   </span>
                 ))}
               </div>
-            </div>
-          )}
+            ) : (
+              <span className="text-[11px] font-mono text-content-tertiary">No runtimes detected</span>
+            )}
+          </div>
         </div>
 
         {/* Stats */}

--- a/apps/web/src/routes/MachinesPage.tsx
+++ b/apps/web/src/routes/MachinesPage.tsx
@@ -139,15 +139,17 @@ export function MachinesPage() {
                       {machine.last_heartbeat_at ? formatRelative(machine.last_heartbeat_at) : "—"}
                     </span>
                   </div>
-                  {machine.runtimes && (
-                    <div className="flex gap-1 ml-auto">
-                      {machine.runtimes.map((r: string) => (
+                  <div className="flex gap-1 ml-auto">
+                    {machine.runtimes?.length > 0 ? (
+                      machine.runtimes.map((r: string) => (
                         <span key={r} className="text-[10px] font-mono text-accent bg-accent-soft px-1.5 py-0.5 rounded">
                           {r}
                         </span>
-                      ))}
-                    </div>
-                  )}
+                      ))
+                    ) : (
+                      <span className="text-[10px] font-mono text-content-tertiary">No runtimes</span>
+                    )}
+                  </div>
                 </div>
               </Link>
             ))}


### PR DESCRIPTION
## Summary
- Display "No runtimes detected" on machine detail page when runtimes array is empty (previously hidden entirely)
- Display "No runtimes" on machines list page when runtimes array is empty
- Added `flex-wrap` to runtimes container on detail page for better overflow handling

## Verification
The frontend already correctly renders the `runtimes` field from the API as badge/tags. The only gap was missing empty-state messaging per the spec. All 463 tests pass, build and type-check clean.

## Test plan
- [ ] Verify machine detail page shows "No runtimes detected" when runtimes is empty
- [ ] Verify machine detail page shows runtime badges when runtimes has values
- [ ] Verify machines list shows "No runtimes" when runtimes is empty
- [ ] Verify machines list shows runtime badges when runtimes has values

🤖 Generated with [Claude Code](https://claude.com/claude-code)