### PR TITLE
Add descriptive comment to Claude provider

### DIFF
--- a/packages/cli/src/providers/claude.ts
+++ b/packages/cli/src/providers/claude.ts
@@ -1,3 +1,4 @@
+// Claude Code provider — handles Claude CLI spawning and event parsing
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";


### PR DESCRIPTION
## Summary
- Adds a one-line descriptive comment at the top of `packages/cli/src/providers/claude.ts` to clarify the module's purpose

## Test plan
- [x] Pre-commit hooks pass (biome + typecheck)
- [x] Comment-only change, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)