### PR TITLE
Add descriptive comment to Gemini CLI provider

### DIFF
--- a/packages/cli/src/providers/gemini.ts
+++ b/packages/cli/src/providers/gemini.ts
@@ -1,3 +1,4 @@
+// Gemini CLI provider — handles Gemini CLI spawning and event parsing
 import { readFileSync } from "node:fs";
 import { createLogger } from "../logger.js";
 import type { AgentEvent, AgentProvider, SpawnOpts } from "./types.js";


### PR DESCRIPTION
## Summary
- Adds a one-line descriptive comment at the top of `packages/cli/src/providers/gemini.ts`
- Validates Gemini provider end-to-end as part of v1.4.0 validation

## Test plan
- [x] Pre-commit hooks pass (biome + typecheck)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)