### PR TITLE
docs: add providers reference for Gemini CLI validation

### DIFF
--- a/packages/cli/src/providers/PROVIDERS.md
+++ b/packages/cli/src/providers/PROVIDERS.md
@@ -1,0 +1,4 @@
+# Providers
+
+- Claude Code (claude.ts)
+- Gemini CLI (gemini.ts)


### PR DESCRIPTION
## Summary
- Adds `packages/cli/src/providers/PROVIDERS.md` listing the two CLI providers (Claude Code and Gemini CLI)
- Validates the Gemini provider integration is in place

## Test plan
- [x] File content matches spec
- [x] Pre-commit hooks pass (typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)