### PR TITLE
feat: select provider per agent runtime/model in daemon

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -3,8 +3,7 @@ import type { Command } from "commander";
 import { deleteConfigValue, getConfigValue, setConfigValue } from "../config.js";
 import { startDaemon } from "../daemon.js";
 import { clearLinks } from "../links.js";
-import { getAvailableProviders, getProvider } from "../providers/registry.js";
-import type { AgentProvider } from "../providers/types.js";
+import { getAvailableProviders } from "../providers/registry.js";
 
 function confirm(question: string): Promise<boolean> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
@@ -51,28 +50,25 @@ export function registerStartCommand(program: Command) {
         process.exit(1);
       }
 
-      // Resolve provider: --provider flag > --agent-cli (deprecated) > auto-detect
-      let providerName = opts.provider;
-      if (!providerName && opts.agentCli) {
+      // Resolve default provider: --provider flag > --agent-cli (deprecated) > auto-detect
+      let defaultProvider = opts.provider;
+      if (!defaultProvider && opts.agentCli) {
         console.warn("Warning: --agent-cli is deprecated, use --provider instead");
-        providerName = opts.agentCli;
+        defaultProvider = opts.agentCli;
       }
 
-      let provider: AgentProvider;
-      if (providerName) {
-        provider = getProvider(providerName);
-      } else {
+      if (!defaultProvider) {
         const available = getAvailableProviders();
         if (available.length === 0) {
           console.error("No agent providers found. Install claude, codex, or gemini CLI.");
           process.exit(1);
         }
-        provider = available[0];
+        defaultProvider = available[0].name;
       }
 
       await startDaemon({
         maxConcurrent: parseInt(opts.maxConcurrent, 10),
-        provider,
+        defaultProvider,
         pollInterval: parseInt(opts.pollInterval, 10),
         taskTimeout: parseInt(opts.taskTimeout, 10),
       });

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -10,8 +10,8 @@ import { createLogger } from "./logger.js";
 import { REPOS_DIR, SESSION_PIDS_FILE, WORKTREES_DIR } from "./paths.js";
 import { PrMonitor } from "./prMonitor.js";
 import { ProcessManager } from "./processManager.js";
-import { getAvailableProviders } from "./providers/registry.js";
-import type { AgentProvider } from "./providers/types.js";
+import { getAvailableProviders, getProvider } from "./providers/registry.js";
+
 import { loadReviewSessions, removeReviewSession } from "./reviewSessions.js";
 import { type AgentInfo, generateSystemPrompt, writePromptFile } from "./systemPrompt.js";
 
@@ -26,9 +26,14 @@ const logger = createLogger("daemon");
 
 export interface DaemonOptions {
   maxConcurrent: number;
-  provider: AgentProvider;
+  defaultProvider?: string;
   pollInterval?: number;
   taskTimeout?: number; // ms, default 2h
+}
+
+function normalizeRuntime(runtime: string): string {
+  if (runtime === "claude-code") return "claude";
+  return runtime;
 }
 
 export async function startDaemon(opts: DaemonOptions): Promise<void> {
@@ -69,7 +74,6 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   let resumeTargetMs = 0;
 
   const pm = new ProcessManager(
-    opts.provider,
     client,
     {
       onSlotFreed: () => schedulePoll(baseInterval),
@@ -106,7 +110,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
 
-  logger.info(`Daemon started (PID ${process.pid}, max_concurrent=${opts.maxConcurrent}, provider=${opts.provider.name})`);
+  logger.info(`Daemon started (PID ${process.pid}, max_concurrent=${opts.maxConcurrent}, default_provider=${opts.defaultProvider ?? "auto"})`);
 
   // Register machine (first run) or reuse existing
   const machineInfo = getMachineInfo();
@@ -126,8 +130,10 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   await cleanupStaleSessions(client, machineId);
   logger.info(`Machine online: ${machineInfo.name} (${machineInfo.os}, runtimes: ${machineInfo.runtimes.join(", ") || "none"})`);
 
+  const defaultProvider = opts.defaultProvider ? getProvider(normalizeRuntime(opts.defaultProvider)) : null;
+
   const heartbeatInterval = setInterval(async () => {
-    const usageInfo = opts.provider.getUsage ? await opts.provider.getUsage() : null;
+    const usageInfo = defaultProvider?.getUsage ? await defaultProvider.getUsage() : null;
     client
       .heartbeat(machineId!, {
         version: machineInfo.version,
@@ -186,6 +192,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       try {
         const resumeCleanup = () => removeWorktree(s.repoDir, s.cwd, s.branchName);
         await pm.spawnAgent(
+          s.provider,
           s.taskId,
           s.sessionId,
           s.cwd,
@@ -199,6 +206,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           undefined,
           true,
           resumeCleanup,
+          s.model,
         );
       } catch {
         logger.warn(`Failed to resume task ${s.taskId}, releasing`);
@@ -247,6 +255,10 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           AK_API_URL: apiUrl,
         };
 
+        const agentDetails = (await client.getAgent(rs.agentId)) as AgentInfo | null;
+        const providerName = normalizeRuntime(agentDetails?.runtime ?? opts.defaultProvider ?? "claude");
+        const reviewProvider = getProvider(providerName);
+
         const logs = (await client.getTaskLogs(rs.taskId)) as any[];
         const rejectLog = [...logs].reverse().find((l: any) => l.action === "rejected");
         const rejectReason = rejectLog?.detail || "No reason provided";
@@ -254,6 +266,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         try {
           const rejectMessage = `Task rejected. Reason: ${rejectReason}\n\nPlease fix the issues and submit for review again.`;
           await pm.spawnAgent(
+            reviewProvider,
             rs.taskId,
             rs.sessionId,
             rs.cwd,
@@ -267,6 +280,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
             undefined,
             true,
             () => removeWorktree(rs.repoDir, rs.cwd, rs.branchName),
+            agentDetails?.model ?? undefined,
           );
         } catch {
           logger.warn(`Failed to resume rejected task ${rs.taskId}, releasing`);
@@ -398,6 +412,10 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         return;
       }
 
+      // Resolve provider from agent runtime
+      const providerName = normalizeRuntime(agentDetails.runtime ?? opts.defaultProvider ?? "claude");
+      const taskProvider = getProvider(providerName);
+
       const agentSkills = agentDetails.skills ?? [];
       if (!ensureSkills(worktreeDir, agentSkills)) {
         logger.error(`Skill install failed for task ${task.id}, releasing task`);
@@ -434,6 +452,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
 
       const cleanup = () => removeWorktree(repoDir, worktreeDir, branchName);
       await pm.spawnAgent(
+        taskProvider,
         task.id,
         sessionId,
         worktreeDir,
@@ -447,6 +466,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         systemPromptFile,
         false,
         cleanup,
+        agentDetails.model ?? undefined,
       );
       prMonitor.track(task.id);
 

--- a/packages/cli/src/processManager.ts
+++ b/packages/cli/src/processManager.ts
@@ -24,6 +24,8 @@ export interface SuspendedSession {
   agentId: string;
   privateKey: CryptoKey;
   privateKeyJwk: JsonWebKey;
+  provider: AgentProvider;
+  model?: string;
 }
 
 export interface AgentProcess {
@@ -33,6 +35,7 @@ export interface AgentProcess {
   repoDir: string;
   branchName: string;
   process: ChildProcess;
+  provider: AgentProvider;
   agentClient: AgentClient;
   privateKey: CryptoKey;
   privateKeyJwk: JsonWebKey;
@@ -52,7 +55,6 @@ export interface ProcessManagerCallbacks {
 export class ProcessManager {
   private agents = new Map<string, AgentProcess>();
   private suspended: SuspendedSession[] = [];
-  private provider: AgentProvider;
   private client: ApiClient;
   private onSlotFreed: () => void;
   private onRateLimited: (resetAt: string) => void;
@@ -60,8 +62,7 @@ export class ProcessManager {
   private onProcessExited?: (sessionId: string) => void;
   private taskTimeoutMs: number;
 
-  constructor(provider: AgentProvider, client: ApiClient, callbacks: ProcessManagerCallbacks, taskTimeoutMs = 2 * 60 * 60 * 1000) {
-    this.provider = provider;
+  constructor(client: ApiClient, callbacks: ProcessManagerCallbacks, taskTimeoutMs = 2 * 60 * 60 * 1000) {
     this.client = client;
     this.onSlotFreed = callbacks.onSlotFreed;
     this.onRateLimited = callbacks.onRateLimited;
@@ -79,6 +80,7 @@ export class ProcessManager {
   }
 
   async spawnAgent(
+    provider: AgentProvider,
     taskId: string,
     sessionId: string,
     cwd: string,
@@ -92,24 +94,25 @@ export class ProcessManager {
     systemPromptFile?: string,
     resume?: boolean,
     onCleanup?: () => void,
+    model?: string,
   ): Promise<void> {
-    const args = resume ? this.provider.buildResumeArgs(sessionId) : this.provider.buildArgs({ sessionId, systemPromptFile });
+    const args = resume ? provider.buildResumeArgs(sessionId, model) : provider.buildArgs({ sessionId, systemPromptFile, model });
 
     let proc: ChildProcess;
     try {
-      proc = spawn(this.provider.command, args, {
+      proc = spawn(provider.command, args, {
         cwd,
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env, ...agentEnv },
       });
     } catch (err: any) {
-      logger.error(`Failed to spawn ${this.provider.command}: ${err.message}`);
+      logger.error(`Failed to spawn ${provider.command}: ${err.message}`);
       await this.releaseTask(taskId);
       return;
     }
 
     if (!proc.pid) {
-      logger.error(`${this.provider.command} not found or failed to start`);
+      logger.error(`${provider.command} not found or failed to start`);
       await this.releaseTask(taskId);
       return;
     }
@@ -121,6 +124,7 @@ export class ProcessManager {
       repoDir,
       branchName,
       process: proc,
+      provider,
       agentClient,
       privateKey,
       privateKeyJwk,
@@ -138,7 +142,7 @@ export class ProcessManager {
 
     proc.on("spawn", () => {
       if (taskContext) {
-        proc.stdin?.write(`${this.provider.buildInput(taskContext)}\n`);
+        proc.stdin?.write(`${provider.buildInput(taskContext)}\n`);
       }
       proc.stdin?.end();
     });
@@ -150,7 +154,7 @@ export class ProcessManager {
       stdoutBuffer = lines.pop() || "";
       for (const line of lines) {
         if (!line.trim()) continue;
-        const event = this.provider.parseEvent(line);
+        const event = provider.parseEvent(line);
         if (event) this.handleEvent(taskId, sessionId, event, agentClient);
       }
     });
@@ -170,7 +174,7 @@ export class ProcessManager {
       if (!this.agents.has(taskId)) return;
 
       if (stdoutBuffer.trim()) {
-        const event = this.provider.parseEvent(stdoutBuffer);
+        const event = agent.provider.parseEvent(stdoutBuffer);
         if (event) this.handleEvent(taskId, sessionId, event, agentClient);
       }
 
@@ -210,6 +214,7 @@ export class ProcessManager {
           agentId: agentClient.getAgentId(),
           privateKey: agent.privateKey,
           privateKeyJwk: agent.privateKeyJwk,
+          provider: agent.provider,
         });
       } else {
         logger.warn(`Agent crashed on task ${taskId} (exit ${code})`);
@@ -235,7 +240,7 @@ export class ProcessManager {
       this.onSlotFreed();
     });
 
-    logger.info(`Spawned ${this.provider.command} (session=${sessionId}) for task ${taskId} in ${cwd}`);
+    logger.info(`Spawned ${provider.command} (session=${sessionId}) for task ${taskId} in ${cwd}`);
   }
 
   async killTask(taskId: string): Promise<void> {

--- a/packages/cli/src/providers/claude.ts
+++ b/packages/cli/src/providers/claude.ts
@@ -78,11 +78,14 @@ export const claudeProvider: AgentProvider = {
     if (opts.systemPromptFile) {
       args.push("--system-prompt-file", opts.systemPromptFile);
     }
+    if (opts.model) {
+      args.push("--model", opts.model);
+    }
     return args;
   },
 
-  buildResumeArgs(sessionId: string): string[] {
-    return [
+  buildResumeArgs(sessionId: string, model?: string): string[] {
+    const args = [
       "--resume",
       sessionId,
       "--print",
@@ -93,6 +96,10 @@ export const claudeProvider: AgentProvider = {
       "stream-json",
       "--dangerously-skip-permissions",
     ];
+    if (model) {
+      args.push("--model", model);
+    }
+    return args;
   },
 
   parseEvent(raw: string): AgentEvent | null {

--- a/packages/cli/src/providers/gemini.ts
+++ b/packages/cli/src/providers/gemini.ts
@@ -21,12 +21,19 @@ export const geminiProvider: AgentProvider = {
   buildArgs(opts: SpawnOpts): string[] {
     const systemPrompt = readSystemPrompt(opts.systemPromptFile);
     const args = ["--prompt", systemPrompt, "--output-format", "stream-json", "--yolo"];
+    if (opts.model) {
+      args.push("--model", opts.model);
+    }
     return args;
   },
 
-  buildResumeArgs(_sessionId: string): string[] {
+  buildResumeArgs(_sessionId: string, model?: string): string[] {
     logger.warn("Gemini CLI does not support resume by session ID — resuming latest session");
-    return ["--resume", "latest", "--prompt", "", "--output-format", "stream-json", "--yolo"];
+    const args = ["--resume", "latest", "--prompt", "", "--output-format", "stream-json", "--yolo"];
+    if (model) {
+      args.push("--model", model);
+    }
+    return args;
   },
 
   parseEvent(raw: string): AgentEvent | null {

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -14,6 +14,7 @@ export interface UsageInfo {
 export interface SpawnOpts {
   sessionId: string;
   systemPromptFile?: string;
+  model?: string;
 }
 
 export type AgentEvent =
@@ -28,7 +29,7 @@ export interface AgentProvider {
   readonly command: string;
 
   buildArgs(opts: SpawnOpts): string[];
-  buildResumeArgs(sessionId: string): string[];
+  buildResumeArgs(sessionId: string, model?: string): string[];
   parseEvent(raw: string): AgentEvent | null;
   buildInput(taskContext: string): string;
   getUsage?(): Promise<UsageInfo | null>;

--- a/packages/cli/src/systemPrompt.ts
+++ b/packages/cli/src/systemPrompt.ts
@@ -8,6 +8,8 @@ export interface AgentInfo {
   soul: string | null;
   handoff_to: string[] | null;
   skills: string[] | null;
+  runtime: string | null;
+  model: string | null;
 }
 
 export function generateSystemPrompt(agent: AgentInfo): string {


### PR DESCRIPTION
## Summary
- Daemon now resolves the agent provider dynamically from each agent's `runtime` field instead of using a single global `--provider` flag
- `ProcessManager` accepts provider per-spawn instead of per-constructor, so each agent process uses the correct provider
- `--model` flag is passed through to Claude/Gemini CLIs when the agent has a model set
- `--provider` flag on `ak start` becomes an optional fallback default for agents without a runtime set

## Changes
- **types.ts**: Added `model` to `SpawnOpts`, added `model` param to `buildResumeArgs`
- **claude.ts / gemini.ts**: Pass `--model` flag in `buildArgs` and `buildResumeArgs` when model is set
- **processManager.ts**: Removed `provider` from constructor, added as first param to `spawnAgent()`, stored on `AgentProcess` and `SuspendedSession`
- **daemon.ts**: Resolve provider from `agent.runtime` via `normalizeRuntime()` helper (`"claude-code"` → `"claude"`), pass per-task provider and model to `spawnAgent()`
- **start.ts**: Changed `--provider` to optional, passes `defaultProvider` string instead of resolved `AgentProvider`
- **systemPrompt.ts**: Added `runtime` and `model` fields to `AgentInfo` interface

## Test plan
- [x] Type check passes (`tsc --noEmit`)
- [x] All 500 existing tests pass
- [x] Pre-commit hooks (biome + typecheck) pass
- [ ] Manual: start daemon without `--provider` — should auto-detect
- [ ] Manual: agent with `runtime: "claude-code"` resolves to claude provider
- [ ] Manual: agent with `runtime: "gemini"` resolves to gemini provider
- [ ] Manual: agent with `model: "opus"` passes `--model opus` to CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)