### PR TITLE
feat: select provider per agent runtime/model

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -3,8 +3,7 @@ import type { Command } from "commander";
 import { deleteConfigValue, getConfigValue, setConfigValue } from "../config.js";
 import { startDaemon } from "../daemon.js";
 import { clearLinks } from "../links.js";
-import { getAvailableProviders, getProvider } from "../providers/registry.js";
-import type { AgentProvider } from "../providers/types.js";
+import { getAvailableProviders } from "../providers/registry.js";
 
 function confirm(question: string): Promise<boolean> {
   const rl = createInterface({ input: process.stdin, output: process.stdout });
@@ -51,28 +50,25 @@ export function registerStartCommand(program: Command) {
         process.exit(1);
       }
 
-      // Resolve provider: --provider flag > --agent-cli (deprecated) > auto-detect
-      let providerName = opts.provider;
-      if (!providerName && opts.agentCli) {
+      // Resolve default provider: --provider flag > --agent-cli (deprecated) > auto-detect
+      let defaultProvider = opts.provider;
+      if (!defaultProvider && opts.agentCli) {
         console.warn("Warning: --agent-cli is deprecated, use --provider instead");
-        providerName = opts.agentCli;
+        defaultProvider = opts.agentCli;
       }
 
-      let provider: AgentProvider;
-      if (providerName) {
-        provider = getProvider(providerName);
-      } else {
+      if (!defaultProvider) {
         const available = getAvailableProviders();
         if (available.length === 0) {
           console.error("No agent providers found. Install claude, codex, or gemini CLI.");
           process.exit(1);
         }
-        provider = available[0];
+        defaultProvider = available[0].name;
       }
 
       await startDaemon({
         maxConcurrent: parseInt(opts.maxConcurrent, 10),
-        provider,
+        defaultProvider,
         pollInterval: parseInt(opts.pollInterval, 10),
         taskTimeout: parseInt(opts.taskTimeout, 10),
       });

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -10,7 +10,7 @@ import { createLogger } from "./logger.js";
 import { REPOS_DIR, SESSION_PIDS_FILE, WORKTREES_DIR } from "./paths.js";
 import { PrMonitor } from "./prMonitor.js";
 import { ProcessManager } from "./processManager.js";
-import { getAvailableProviders } from "./providers/registry.js";
+import { getAvailableProviders, getProvider } from "./providers/registry.js";
 import type { AgentProvider } from "./providers/types.js";
 import { loadReviewSessions, removeReviewSession } from "./reviewSessions.js";
 import { type AgentInfo, generateSystemPrompt, writePromptFile } from "./systemPrompt.js";
@@ -26,9 +26,14 @@ const logger = createLogger("daemon");
 
 export interface DaemonOptions {
   maxConcurrent: number;
-  provider: AgentProvider;
+  defaultProvider?: string;
   pollInterval?: number;
   taskTimeout?: number; // ms, default 2h
+}
+
+function normalizeRuntime(runtime: string): string {
+  if (runtime === "claude-code") return "claude";
+  return runtime;
 }
 
 export async function startDaemon(opts: DaemonOptions): Promise<void> {
@@ -69,7 +74,6 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   let resumeTargetMs = 0;
 
   const pm = new ProcessManager(
-    opts.provider,
     client,
     {
       onSlotFreed: () => schedulePoll(baseInterval),
@@ -106,7 +110,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
 
-  logger.info(`Daemon started (PID ${process.pid}, max_concurrent=${opts.maxConcurrent}, provider=${opts.provider.name})`);
+  logger.info(`Daemon started (PID ${process.pid}, max_concurrent=${opts.maxConcurrent}, default_provider=${opts.defaultProvider ?? "claude"})`);
 
   // Register machine (first run) or reuse existing
   const machineInfo = getMachineInfo();
@@ -126,8 +130,16 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   await cleanupStaleSessions(client, machineId);
   logger.info(`Machine online: ${machineInfo.name} (${machineInfo.os}, runtimes: ${machineInfo.runtimes.join(", ") || "none"})`);
 
+  const defaultProviderName = opts.defaultProvider ?? "claude";
+  let defaultProviderInstance: AgentProvider | null = null;
+  try {
+    defaultProviderInstance = getProvider(normalizeRuntime(defaultProviderName));
+  } catch {
+    // No default provider available — usage polling disabled
+  }
+
   const heartbeatInterval = setInterval(async () => {
-    const usageInfo = opts.provider.getUsage ? await opts.provider.getUsage() : null;
+    const usageInfo = defaultProviderInstance?.getUsage ? await defaultProviderInstance.getUsage() : null;
     client
       .heartbeat(machineId!, {
         version: machineInfo.version,
@@ -182,10 +194,13 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         AK_API_URL: getConfigValue("api-url")!,
       };
 
-      logger.info(`Resuming task ${s.taskId} (session=${s.sessionId.slice(0, 8)})`);
+      const resumeProvider = getProvider(s.providerName);
+
+      logger.info(`Resuming task ${s.taskId} (session=${s.sessionId.slice(0, 8)}, provider=${s.providerName})`);
       try {
         const resumeCleanup = () => removeWorktree(s.repoDir, s.cwd, s.branchName);
         await pm.spawnAgent(
+          resumeProvider,
           s.taskId,
           s.sessionId,
           s.cwd,
@@ -199,6 +214,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
           undefined,
           true,
           resumeCleanup,
+          s.model,
         );
       } catch {
         logger.warn(`Failed to resume task ${s.taskId}, releasing`);
@@ -225,6 +241,18 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
 
       if (task.status === "in_progress" && !pm.hasTask(rs.taskId)) {
         logger.info(`Task ${rs.taskId} was rejected, resuming agent in existing worktree`);
+
+        const agentDetails = (await client.getAgent(rs.agentId)) as AgentInfo | null;
+        if (!agentDetails) {
+          logger.warn(`Agent ${rs.agentId} not found, cleaning up review session for task ${rs.taskId}`);
+          removeWorktree(rs.repoDir, rs.cwd, rs.branchName);
+          removeReviewSession(rs.taskId);
+          await client.releaseTask(rs.taskId).catch(() => {});
+          continue;
+        }
+
+        const reviewProviderName = normalizeRuntime(agentDetails.runtime ?? defaultProviderName);
+        const reviewProvider = getProvider(reviewProviderName);
 
         const privateKey = (await crypto.subtle.importKey("jwk", rs.privateKeyJwk, { name: "Ed25519" } as any, true, ["sign"])) as CryptoKey;
 
@@ -254,6 +282,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         try {
           const rejectMessage = `Task rejected. Reason: ${rejectReason}\n\nPlease fix the issues and submit for review again.`;
           await pm.spawnAgent(
+            reviewProvider,
             rs.taskId,
             rs.sessionId,
             rs.cwd,
@@ -267,6 +296,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
             undefined,
             true,
             () => removeWorktree(rs.repoDir, rs.cwd, rs.branchName),
+            agentDetails.model ?? undefined,
           );
         } catch {
           logger.warn(`Failed to resume rejected task ${rs.taskId}, releasing`);
@@ -416,6 +446,9 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         AK_AGENT_KEY: JSON.stringify(privKeyJwk),
         AK_API_URL: getConfigValue("api-url")!,
       };
+      const providerName = normalizeRuntime(agentDetails.runtime ?? defaultProviderName);
+      const taskProvider = getProvider(providerName);
+
       const systemPromptFile = writePromptFile(sessionId, generateSystemPrompt(agentDetails));
 
       const repos = await client.listRepositories();
@@ -434,6 +467,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
 
       const cleanup = () => removeWorktree(repoDir, worktreeDir, branchName);
       await pm.spawnAgent(
+        taskProvider,
         task.id,
         sessionId,
         worktreeDir,
@@ -447,6 +481,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         systemPromptFile,
         false,
         cleanup,
+        agentDetails.model ?? undefined,
       );
       prMonitor.track(task.id);
 

--- a/packages/cli/src/processManager.ts
+++ b/packages/cli/src/processManager.ts
@@ -24,6 +24,8 @@ export interface SuspendedSession {
   agentId: string;
   privateKey: CryptoKey;
   privateKeyJwk: JsonWebKey;
+  providerName: string;
+  model?: string;
 }
 
 export interface AgentProcess {
@@ -33,6 +35,7 @@ export interface AgentProcess {
   repoDir: string;
   branchName: string;
   process: ChildProcess;
+  provider: AgentProvider;
   agentClient: AgentClient;
   privateKey: CryptoKey;
   privateKeyJwk: JsonWebKey;
@@ -52,7 +55,6 @@ export interface ProcessManagerCallbacks {
 export class ProcessManager {
   private agents = new Map<string, AgentProcess>();
   private suspended: SuspendedSession[] = [];
-  private provider: AgentProvider;
   private client: ApiClient;
   private onSlotFreed: () => void;
   private onRateLimited: (resetAt: string) => void;
@@ -60,8 +62,7 @@ export class ProcessManager {
   private onProcessExited?: (sessionId: string) => void;
   private taskTimeoutMs: number;
 
-  constructor(provider: AgentProvider, client: ApiClient, callbacks: ProcessManagerCallbacks, taskTimeoutMs = 2 * 60 * 60 * 1000) {
-    this.provider = provider;
+  constructor(client: ApiClient, callbacks: ProcessManagerCallbacks, taskTimeoutMs = 2 * 60 * 60 * 1000) {
     this.client = client;
     this.onSlotFreed = callbacks.onSlotFreed;
     this.onRateLimited = callbacks.onRateLimited;
@@ -79,6 +80,7 @@ export class ProcessManager {
   }
 
   async spawnAgent(
+    provider: AgentProvider,
     taskId: string,
     sessionId: string,
     cwd: string,
@@ -92,24 +94,25 @@ export class ProcessManager {
     systemPromptFile?: string,
     resume?: boolean,
     onCleanup?: () => void,
+    model?: string,
   ): Promise<void> {
-    const args = resume ? this.provider.buildResumeArgs(sessionId) : this.provider.buildArgs({ sessionId, systemPromptFile });
+    const args = resume ? provider.buildResumeArgs(sessionId, model) : provider.buildArgs({ sessionId, systemPromptFile, model });
 
     let proc: ChildProcess;
     try {
-      proc = spawn(this.provider.command, args, {
+      proc = spawn(provider.command, args, {
         cwd,
         stdio: ["pipe", "pipe", "pipe"],
         env: { ...process.env, ...agentEnv },
       });
     } catch (err: any) {
-      logger.error(`Failed to spawn ${this.provider.command}: ${err.message}`);
+      logger.error(`Failed to spawn ${provider.command}: ${err.message}`);
       await this.releaseTask(taskId);
       return;
     }
 
     if (!proc.pid) {
-      logger.error(`${this.provider.command} not found or failed to start`);
+      logger.error(`${provider.command} not found or failed to start`);
       await this.releaseTask(taskId);
       return;
     }
@@ -121,6 +124,7 @@ export class ProcessManager {
       repoDir,
       branchName,
       process: proc,
+      provider,
       agentClient,
       privateKey,
       privateKeyJwk,
@@ -138,7 +142,7 @@ export class ProcessManager {
 
     proc.on("spawn", () => {
       if (taskContext) {
-        proc.stdin?.write(`${this.provider.buildInput(taskContext)}\n`);
+        proc.stdin?.write(`${provider.buildInput(taskContext)}\n`);
       }
       proc.stdin?.end();
     });
@@ -150,7 +154,7 @@ export class ProcessManager {
       stdoutBuffer = lines.pop() || "";
       for (const line of lines) {
         if (!line.trim()) continue;
-        const event = this.provider.parseEvent(line);
+        const event = provider.parseEvent(line);
         if (event) this.handleEvent(taskId, sessionId, event, agentClient);
       }
     });
@@ -170,7 +174,7 @@ export class ProcessManager {
       if (!this.agents.has(taskId)) return;
 
       if (stdoutBuffer.trim()) {
-        const event = this.provider.parseEvent(stdoutBuffer);
+        const event = provider.parseEvent(stdoutBuffer);
         if (event) this.handleEvent(taskId, sessionId, event, agentClient);
       }
 
@@ -210,6 +214,8 @@ export class ProcessManager {
           agentId: agentClient.getAgentId(),
           privateKey: agent.privateKey,
           privateKeyJwk: agent.privateKeyJwk,
+          providerName: agent.provider.name,
+          model,
         });
       } else {
         logger.warn(`Agent crashed on task ${taskId} (exit ${code})`);
@@ -235,7 +241,7 @@ export class ProcessManager {
       this.onSlotFreed();
     });
 
-    logger.info(`Spawned ${this.provider.command} (session=${sessionId}) for task ${taskId} in ${cwd}`);
+    logger.info(`Spawned ${provider.command} (session=${sessionId}) for task ${taskId} in ${cwd}`);
   }
 
   async killTask(taskId: string): Promise<void> {

--- a/packages/cli/src/providers/claude.ts
+++ b/packages/cli/src/providers/claude.ts
@@ -78,11 +78,14 @@ export const claudeProvider: AgentProvider = {
     if (opts.systemPromptFile) {
       args.push("--system-prompt-file", opts.systemPromptFile);
     }
+    if (opts.model) {
+      args.push("--model", opts.model);
+    }
     return args;
   },
 
-  buildResumeArgs(sessionId: string): string[] {
-    return [
+  buildResumeArgs(sessionId: string, model?: string): string[] {
+    const args = [
       "--resume",
       sessionId,
       "--print",
@@ -93,6 +96,10 @@ export const claudeProvider: AgentProvider = {
       "stream-json",
       "--dangerously-skip-permissions",
     ];
+    if (model) {
+      args.push("--model", model);
+    }
+    return args;
   },
 
   parseEvent(raw: string): AgentEvent | null {

--- a/packages/cli/src/providers/gemini.ts
+++ b/packages/cli/src/providers/gemini.ts
@@ -21,12 +21,19 @@ export const geminiProvider: AgentProvider = {
   buildArgs(opts: SpawnOpts): string[] {
     const systemPrompt = readSystemPrompt(opts.systemPromptFile);
     const args = ["--prompt", systemPrompt, "--output-format", "stream-json", "--yolo"];
+    if (opts.model) {
+      args.push("--model", opts.model);
+    }
     return args;
   },
 
-  buildResumeArgs(_sessionId: string): string[] {
+  buildResumeArgs(_sessionId: string, model?: string): string[] {
     logger.warn("Gemini CLI does not support resume by session ID — resuming latest session");
-    return ["--resume", "latest", "--prompt", "", "--output-format", "stream-json", "--yolo"];
+    const args = ["--resume", "latest", "--prompt", "", "--output-format", "stream-json", "--yolo"];
+    if (model) {
+      args.push("--model", model);
+    }
+    return args;
   },
 
   parseEvent(raw: string): AgentEvent | null {

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -14,6 +14,7 @@ export interface UsageInfo {
 export interface SpawnOpts {
   sessionId: string;
   systemPromptFile?: string;
+  model?: string;
 }
 
 export type AgentEvent =
@@ -28,7 +29,7 @@ export interface AgentProvider {
   readonly command: string;
 
   buildArgs(opts: SpawnOpts): string[];
-  buildResumeArgs(sessionId: string): string[];
+  buildResumeArgs(sessionId: string, model?: string): string[];
   parseEvent(raw: string): AgentEvent | null;
   buildInput(taskContext: string): string;
   getUsage?(): Promise<UsageInfo | null>;

--- a/packages/cli/src/systemPrompt.ts
+++ b/packages/cli/src/systemPrompt.ts
@@ -8,6 +8,8 @@ export interface AgentInfo {
   soul: string | null;
   handoff_to: string[] | null;
   skills: string[] | null;
+  runtime: string | null;
+  model: string | null;
 }
 
 export function generateSystemPrompt(agent: AgentInfo): string {


### PR DESCRIPTION
## Summary
- Daemon now resolves provider dynamically per task from the agent's `runtime` field instead of using a single global `--provider` flag
- Added `model` to `SpawnOpts` — Claude and Gemini providers pass `--model` flag when set
- `ProcessManager` no longer holds a global provider; each `spawnAgent()` call receives its own provider instance
- `--provider` CLI flag becomes an optional fallback default for agents without a runtime set
- Added `normalizeRuntime()` helper to map agent runtime names (e.g. "claude-code" → "claude") to provider registry names
- Added `runtime` and `model` fields to `AgentInfo` interface

## Test plan
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] All 500 existing tests pass (`npx vitest run`)
- [x] Build succeeds (`pnpm build`)
- [ ] Manual: start daemon without `--provider` flag — should auto-detect
- [ ] Manual: assign task to agent with `runtime: "gemini"` — should spawn gemini CLI
- [ ] Manual: assign task to agent with `model: "opus"` — should pass `--model opus` to claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)