### PR TITLE
Add provider registry comment

### DIFF
--- a/packages/cli/src/providers/index.ts
+++ b/packages/cli/src/providers/index.ts
@@ -1,3 +1,4 @@
+// Provider registry - exports all providers and registry functions
 export { claudeProvider } from "./claude.js";
 export { geminiProvider } from "./gemini.js";
 export { getAvailableProviders, getProvider, registerProvider } from "./registry.js";


### PR DESCRIPTION
## Summary
- Adds a descriptive comment to `packages/cli/src/providers/index.ts` clarifying the file's purpose as the provider registry barrel export.

## Test plan
- [x] Verify comment is present at top of file
- [x] No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)