### PR TITLE
feat(gemini): calculate session cost from token pricing

### DIFF
--- a/packages/cli/src/providers/gemini.ts
+++ b/packages/cli/src/providers/gemini.ts
@@ -4,6 +4,16 @@ import type { AgentEvent, AgentProvider, SpawnOpts } from "./types.js";
 
 const logger = createLogger("gemini");
 
+/** Per 1M tokens, paid tier pricing */
+const GEMINI_PRICING: Record<string, { input: number; output: number }> = {
+  "gemini-2.5-flash": { input: 0.3, output: 2.5 },
+  "gemini-2.5-flash-lite": { input: 0.1, output: 0.4 },
+  "gemini-2.5-pro": { input: 1.25, output: 10.0 },
+  "gemini-3-flash-preview": { input: 0.5, output: 3.0 },
+  "gemini-3.1-pro-preview": { input: 2.0, output: 12.0 },
+  "gemini-3.1-flash-lite-preview": { input: 0.25, output: 1.5 },
+};
+
 function readSystemPrompt(filePath?: string): string {
   if (!filePath) return "";
   try {
@@ -49,10 +59,17 @@ export const geminiProvider: AgentProvider = {
     }
 
     if (event.type === "result") {
-      return {
-        type: "result",
-        usage: event.stats,
-      };
+      let cost = 0;
+      if (event.stats?.models) {
+        for (const [model, usage] of Object.entries(event.stats.models)) {
+          const pricing = GEMINI_PRICING[model];
+          if (pricing) {
+            const u = usage as { input_tokens: number; output_tokens: number };
+            cost += (u.input_tokens * pricing.input + u.output_tokens * pricing.output) / 1_000_000;
+          }
+        }
+      }
+      return { type: "result", cost, usage: event.stats };
     }
 
     if (event.type === "error" || event.status === "error") {

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -620,11 +620,49 @@ describe("geminiProvider.parseEvent — result", () => {
     }
   });
 
-  it("does not include a cost field (Gemini does not report cost)", () => {
+  it("returns zero cost when no model breakdown is present", () => {
     const raw = JSON.stringify({ type: "result", status: "success", stats: {} });
     const event = geminiProvider.parseEvent(raw);
     if (event?.type === "result") {
-      expect(event.cost).toBeUndefined();
+      expect(event.cost).toBe(0);
+    }
+  });
+
+  it("calculates cost from per-model token breakdown", () => {
+    const raw = JSON.stringify({
+      type: "result",
+      stats: {
+        models: {
+          "gemini-2.5-flash-lite": { input_tokens: 1_000_000, output_tokens: 1_000_000 },
+          "gemini-2.5-pro": { input_tokens: 500_000, output_tokens: 200_000 },
+        },
+      },
+    });
+    const event = geminiProvider.parseEvent(raw);
+    // flash-lite: 1M * 0.10/1M + 1M * 0.40/1M = 0.50
+    // pro: 500K * 1.25/1M + 200K * 10.00/1M = 0.625 + 2.00 = 2.625
+    // total: 3.125
+    expect(event?.type).toBe("result");
+    if (event?.type === "result") {
+      expect(event.cost).toBeCloseTo(3.125, 6);
+    }
+  });
+
+  it("skips unknown models in cost calculation", () => {
+    const raw = JSON.stringify({
+      type: "result",
+      stats: {
+        models: {
+          "gemini-unknown-model": { input_tokens: 1000, output_tokens: 1000 },
+          "gemini-2.5-flash": { input_tokens: 1_000_000, output_tokens: 0 },
+        },
+      },
+    });
+    const event = geminiProvider.parseEvent(raw);
+    // only flash counted: 1M * 0.30/1M = 0.30
+    expect(event?.type).toBe("result");
+    if (event?.type === "result") {
+      expect(event.cost).toBeCloseTo(0.3, 6);
     }
   });
 });


### PR DESCRIPTION
## Summary
- Add client-side pricing table for 6 Gemini models (per 1M token rates)
- Calculate cost from `stats.models` token breakdown in result events
- Unknown models are skipped gracefully (contribute $0 to cost)

## Test plan
- [x] Existing tests updated — zero cost when no model breakdown present
- [x] New test: multi-model cost calculation with known pricing
- [x] New test: unknown models are skipped in cost calculation
- [x] All 502 tests pass, build and type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)