### PR TITLE
Add pricing last-updated comment to Gemini provider

### DIFF
--- a/packages/cli/src/providers/gemini.ts
+++ b/packages/cli/src/providers/gemini.ts
@@ -13,6 +13,7 @@ const GEMINI_PRICING: Record<string, { input: number; output: number }> = {
   "gemini-3.1-pro-preview": { input: 2.0, output: 12.0 },
   "gemini-3.1-flash-lite-preview": { input: 0.25, output: 1.5 },
 };
+// Pricing last updated: 2026-03-25
 
 function readSystemPrompt(filePath?: string): string {
   if (!filePath) return "";


### PR DESCRIPTION
## Summary
- Added `// Pricing last updated: 2026-03-25` comment after the `GEMINI_PRICING` table in `packages/cli/src/providers/gemini.ts`

## Test plan
- [x] Verify comment is placed correctly after the pricing table
- [x] Build passes
- [x] Type check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)