### PR TITLE
feat(cli): add top-level get/create/update/delete commands

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,0 +1,14 @@
+import type { Command } from "commander";
+import { normalizeResource } from "./resources.js";
+
+export function registerCreateCommand(program: Command) {
+  program
+    .command("create <resource>")
+    .description("Create a resource")
+    .allowUnknownOption()
+    .action(async (resource: string) => {
+      const name = normalizeResource(resource);
+      console.error(`ak create ${name} is not implemented yet. Use "ak ${name} create" instead.`);
+      process.exit(1);
+    });
+}

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -1,0 +1,13 @@
+import type { Command } from "commander";
+import { normalizeResource } from "./resources.js";
+
+export function registerDeleteCommand(program: Command) {
+  program
+    .command("delete <resource> <id>")
+    .description("Delete a resource")
+    .action(async (resource: string, id: string) => {
+      const name = normalizeResource(resource);
+      console.error(`ak delete ${name} ${id} is not implemented yet. Use "ak ${name} delete ${id}" instead.`);
+      process.exit(1);
+    });
+}

--- a/packages/cli/src/commands/get.ts
+++ b/packages/cli/src/commands/get.ts
@@ -11,7 +11,7 @@ import {
   getFormat,
   output,
 } from "../output.js";
-import { normalizeResource, SUPPORTED_RESOURCES } from "./resources.js";
+import { normalizeResource } from "./resources.js";
 
 export function registerGetCommand(program: Command) {
   program

--- a/packages/cli/src/commands/get.ts
+++ b/packages/cli/src/commands/get.ts
@@ -1,0 +1,69 @@
+import type { Command } from "commander";
+import { createClient } from "../client.js";
+import {
+  formatAgent,
+  formatAgentList,
+  formatBoard,
+  formatBoardList,
+  formatRepositoryList,
+  formatTask,
+  formatTaskList,
+  getFormat,
+  output,
+} from "../output.js";
+import { normalizeResource, SUPPORTED_RESOURCES } from "./resources.js";
+
+export function registerGetCommand(program: Command) {
+  program
+    .command("get <resource> [id]")
+    .description("Get a resource or list resources")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (resource: string, id: string | undefined, opts) => {
+      const name = normalizeResource(resource);
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+
+      switch (name) {
+        case "board":
+          if (id) {
+            const board = await client.getBoard(id);
+            output(board, fmt, formatBoard);
+          } else {
+            const boards = await client.listBoards();
+            output(boards, fmt, formatBoardList);
+          }
+          break;
+        case "task":
+          if (id) {
+            const task = await client.getTask(id);
+            output(task, fmt, formatTask);
+          } else {
+            const tasks = await client.listTasks({});
+            output(tasks, fmt, formatTaskList);
+          }
+          break;
+        case "agent":
+          if (id) {
+            const agent = await client.getAgent(id);
+            output(agent, fmt, formatAgent);
+          } else {
+            const agents = await client.listAgents();
+            output(agents, fmt, formatAgentList);
+          }
+          break;
+        case "repo":
+          if (id) {
+            console.error("ak get repo <id> is not implemented yet.");
+            process.exit(1);
+          } else {
+            const repos = await client.listRepositories();
+            output(repos, fmt, formatRepositoryList);
+          }
+          break;
+        case "note":
+          console.error("ak get note is not implemented yet.");
+          process.exit(1);
+          break;
+      }
+    });
+}

--- a/packages/cli/src/commands/resources.ts
+++ b/packages/cli/src/commands/resources.ts
@@ -1,0 +1,23 @@
+export const SUPPORTED_RESOURCES = ["board", "task", "agent", "repo", "note"] as const;
+export type ResourceName = (typeof SUPPORTED_RESOURCES)[number];
+
+const PLURAL_MAP: Record<string, ResourceName> = {
+  boards: "board",
+  tasks: "task",
+  agents: "agent",
+  repos: "repo",
+  repositories: "repo",
+  notes: "note",
+};
+
+export function normalizeResource(input: string): ResourceName {
+  const lower = input.toLowerCase();
+  if ((SUPPORTED_RESOURCES as readonly string[]).includes(lower)) {
+    return lower as ResourceName;
+  }
+  const mapped = PLURAL_MAP[lower];
+  if (mapped) return mapped;
+
+  console.error(`Unknown resource: ${input}. Supported: ${SUPPORTED_RESOURCES.join(", ")}`);
+  process.exit(1);
+}

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,0 +1,14 @@
+import type { Command } from "commander";
+import { normalizeResource } from "./resources.js";
+
+export function registerUpdateCommand(program: Command) {
+  program
+    .command("update <resource> <id>")
+    .description("Update a resource")
+    .allowUnknownOption()
+    .action(async (resource: string, id: string) => {
+      const name = normalizeResource(resource);
+      console.error(`ak update ${name} ${id} is not implemented yet. Use "ak ${name} update ${id}" instead.`);
+      process.exit(1);
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,8 +3,12 @@ import { join } from "node:path";
 import { fetchTemplate } from "@agent-kanban/shared";
 import { Command } from "commander";
 import { type ApiClient, createClient } from "./client.js";
+import { registerCreateCommand } from "./commands/create.js";
+import { registerDeleteCommand } from "./commands/delete.js";
+import { registerGetCommand } from "./commands/get.js";
 import { registerLinkCommand, registerUnlinkCommand } from "./commands/link.js";
 import { registerStartCommand } from "./commands/start.js";
+import { registerUpdateCommand } from "./commands/update.js";
 import { getConfigValue, setConfigValue } from "./config.js";
 import {
   formatAgent,
@@ -521,6 +525,13 @@ repoCmd
     const fmt = getFormat(opts.format);
     output({ deleted: id }, fmt, () => `Deleted repository ${id}`);
   });
+
+// ─── Top-level CRUD ───
+
+registerGetCommand(program);
+registerCreateCommand(program);
+registerUpdateCommand(program);
+registerDeleteCommand(program);
 
 // ─── Link & Start ───
 


### PR DESCRIPTION
## Summary
- Add four top-level CRUD commands (`ak get`, `ak create`, `ak update`, `ak delete`) that accept a resource name and dispatch to handlers
- Shared `resources.ts` normalizes singular/plural forms (e.g. `tasks` → `task`) for board, task, agent, repo, note
- `ak get` wires up existing client methods for listing/viewing boards, tasks, agents, repos
- `ak create/update/delete` show placeholder messages pointing to existing subcommands

## Test plan
- [x] Build passes (`pnpm build`)
- [x] Type check passes (`tsc --noEmit`)
- [x] All 502 tests pass (`npx vitest run`)
- [x] Lint passes (biome pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)