### PR TITLE
feat: add GET /api/repositories/:id endpoint

### DIFF
--- a/apps/web/functions/api/repositoryRepo.ts
+++ b/apps/web/functions/api/repositoryRepo.ts
@@ -65,6 +65,11 @@ export async function listRepositories(db: D1, ownerId: string, filters?: { url?
   return result.results.map(withFullName);
 }
 
+export async function getRepository(db: D1, id: string, ownerId: string): Promise<Repository | null> {
+  const row = await db.prepare("SELECT * FROM repositories WHERE id = ? AND owner_id = ?").bind(id, ownerId).first<Repository>();
+  return row ? withFullName(row) : null;
+}
+
 export async function deleteRepository(db: D1, id: string): Promise<boolean> {
   const result = await db.prepare("DELETE FROM repositories WHERE id = ?").bind(id).run();
   return result.meta.changes > 0;

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -9,7 +9,7 @@ import { createBoard, deleteBoard, getBoard, getBoardByName, listBoards, updateB
 import { createLogger } from "./logger";
 import { createMachine, deleteMachine, getMachine, listMachines, updateMachine } from "./machineRepo";
 import { createMessage, listMessages } from "./messageRepo";
-import { createRepository, deleteRepository, listRepositories } from "./repositoryRepo";
+import { createRepository, deleteRepository, getRepository, listRepositories } from "./repositoryRepo";
 import { createSSEResponse } from "./sse";
 import {
   addTaskLog,
@@ -447,6 +447,12 @@ api.get("/api/repositories", async (c) => {
   const { url } = c.req.query();
   const repositories = await listRepositories(c.env.DB, c.get("ownerId"), { url });
   return c.json(repositories);
+});
+
+api.get("/api/repositories/:id", async (c) => {
+  const repo = await getRepository(c.env.DB, c.req.param("id"), c.get("ownerId"));
+  if (!repo) throw new HTTPException(404, { message: "Repository not found" });
+  return c.json(repo);
 });
 
 api.delete("/api/repositories/:id", async (c) => {


### PR DESCRIPTION
## Summary
- Adds `getRepository(db, id, ownerId)` to `repositoryRepo.ts` — owner-scoped lookup by ID
- Adds `GET /api/repositories/:id` route in `routes.ts` following existing patterns (e.g. `GET /api/agents/:id`)
- Returns 404 if repository not found or not owned by the authenticated user

## Test plan
- [ ] Verify `GET /api/repositories/:id` returns the repository with `full_name` computed
- [ ] Verify 404 when ID doesn't exist
- [ ] Verify 404 when repository belongs to a different owner
- [ ] All existing tests pass (502/502 ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)