### PR TITLE
feat(cli): implement ak get for all resources

### DIFF
--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -169,6 +169,9 @@ export abstract class ApiClient {
     const qs = params.toString();
     return this.request<any[]>("GET", `/api/repositories${qs ? `?${qs}` : ""}`);
   }
+  getRepository(repoId: string) {
+    return this.request("GET", `/api/repositories/${repoId}`);
+  }
   deleteRepository(repoId: string) {
     return this.request("DELETE", `/api/repositories/${repoId}`);
   }

--- a/packages/cli/src/commands/get.ts
+++ b/packages/cli/src/commands/get.ts
@@ -5,9 +5,11 @@ import {
   formatAgentList,
   formatBoard,
   formatBoardList,
+  formatRepository,
   formatRepositoryList,
   formatTask,
   formatTaskList,
+  formatTaskLogs,
   getFormat,
   output,
 } from "../output.js";
@@ -18,6 +20,12 @@ export function registerGetCommand(program: Command) {
     .command("get <resource> [id]")
     .description("Get a resource or list resources")
     .option("--format <format>", "Output format (json, text)")
+    .option("--board <id>", "Filter tasks by board ID")
+    .option("--status <status>", "Filter tasks by status")
+    .option("--label <label>", "Filter tasks by label")
+    .option("--repo <id>", "Filter tasks by repository ID")
+    .option("--task <id>", "Task ID (required for notes)")
+    .option("--since <timestamp>", "Only show notes after this timestamp")
     .action(async (resource: string, id: string | undefined, opts) => {
       const name = normalizeResource(resource);
       const client = await createClient();
@@ -38,7 +46,12 @@ export function registerGetCommand(program: Command) {
             const task = await client.getTask(id);
             output(task, fmt, formatTask);
           } else {
-            const tasks = await client.listTasks({});
+            const params: Record<string, string> = {};
+            if (opts.board) params.board_id = opts.board;
+            if (opts.status) params.status = opts.status;
+            if (opts.label) params.label = opts.label;
+            if (opts.repo) params.repository_id = opts.repo;
+            const tasks = await client.listTasks(params);
             output(tasks, fmt, formatTaskList);
           }
           break;
@@ -53,17 +66,24 @@ export function registerGetCommand(program: Command) {
           break;
         case "repo":
           if (id) {
-            console.error("ak get repo <id> is not implemented yet.");
-            process.exit(1);
+            const repo = await client.getRepository(id);
+            output(repo, fmt, formatRepository);
           } else {
             const repos = await client.listRepositories();
             output(repos, fmt, formatRepositoryList);
           }
           break;
-        case "note":
-          console.error("ak get note is not implemented yet.");
-          process.exit(1);
+        case "note": {
+          const taskId = id ? undefined : opts.task;
+          const noteTaskId = id ?? opts.task;
+          if (!noteTaskId) {
+            console.error("Usage: ak get note --task <task-id> or ak get note <task-id>");
+            process.exit(1);
+          }
+          const logs = await client.getTaskLogs(noteTaskId, opts.since);
+          output(logs, fmt, formatTaskLogs);
           break;
+        }
       }
     });
 }

--- a/packages/cli/src/commands/get.ts
+++ b/packages/cli/src/commands/get.ts
@@ -74,7 +74,6 @@ export function registerGetCommand(program: Command) {
           }
           break;
         case "note": {
-          const taskId = id ? undefined : opts.task;
           const noteTaskId = id ?? opts.task;
           if (!noteTaskId) {
             console.error("Usage: ak get note --task <task-id> or ak get note <task-id>");

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -53,6 +53,15 @@ export function formatBoardList(boards: any[]): string {
   return lines.join("\n");
 }
 
+export function formatRepository(repo: any): string {
+  const lines: string[] = [];
+  lines.push(`${repo.name}`);
+  lines.push(`  ID:   ${repo.id}`);
+  lines.push(`  URL:  ${repo.url}`);
+  if (repo.created_at) lines.push(`  Created: ${repo.created_at}`);
+  return lines.join("\n");
+}
+
 export function formatRepositoryList(repos: any[]): string {
   if (repos.length === 0) return "No repositories found.";
 


### PR DESCRIPTION
## Summary
- Add task filter flags (`--board`, `--status`, `--label`, `--repo`) to `ak get task`
- Implement `ak get repo <id>` with new `getRepository` client method and `formatRepository` formatter
- Implement `ak get note` with `--task` (required) and `--since` flags, reusing existing `getTaskLogs` and `formatTaskLogs`

## Test plan
- [x] `ak get board` — lists boards
- [x] `ak get note --task <id>` — shows task logs
- [x] `ak get note` without `--task` — shows usage error
- [x] Build passes, lint clean, type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)