### PR TITLE
feat(cli): implement ak delete for all resources

### DIFF
--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -1,13 +1,42 @@
 import type { Command } from "commander";
+import { createClient } from "../client.js";
+import { getFormat, output } from "../output.js";
 import { normalizeResource } from "./resources.js";
 
 export function registerDeleteCommand(program: Command) {
   program
     .command("delete <resource> <id>")
-    .description("Delete a resource")
-    .action(async (resource: string, id: string) => {
+    .description("Delete a resource (board, task, agent, repo)")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (resource: string, id: string, opts) => {
       const name = normalizeResource(resource);
-      console.error(`ak delete ${name} ${id} is not implemented yet. Use "ak ${name} delete ${id}" instead.`);
-      process.exit(1);
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+
+      switch (name) {
+        case "board": {
+          const board = await client.deleteBoard(id);
+          output(board, fmt, () => `Deleted board ${id}`);
+          break;
+        }
+        case "task": {
+          const task = await client.deleteTask(id);
+          output(task, fmt, () => `Deleted task ${id}`);
+          break;
+        }
+        case "agent": {
+          const agent = await client.deleteAgent(id);
+          output(agent, fmt, () => `Deleted agent ${id}`);
+          break;
+        }
+        case "repo": {
+          const repo = await client.deleteRepository(id);
+          output(repo, fmt, () => `Deleted repository ${id}`);
+          break;
+        }
+        default:
+          console.error(`Delete is not supported for resource: ${name}`);
+          process.exit(1);
+      }
     });
 }


### PR DESCRIPTION
## Summary
- Implements `ak delete <resource> <id>` for board, task, agent, and repo
- Replaces the placeholder stub with working handlers that reuse existing `ApiClient` delete methods and output formatters
- Supports `--format json|text` flag consistent with other commands

## Test plan
- [ ] `ak delete board <id>` deletes a board
- [ ] `ak delete task <id>` deletes a task (only todo+unassigned or cancelled)
- [ ] `ak delete agent <id>` deletes an agent
- [ ] `ak delete repo <id>` deletes a repository
- [ ] `ak delete board <id> --format json` returns JSON response
- [ ] Unknown resource type shows error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)