### PR TITLE
Rename task_logs to task_notes across API, database, and codebase

### DIFF
--- a/apps/web/functions/api/agentRepo.ts
+++ b/apps/web/functions/api/agentRepo.ts
@@ -72,7 +72,7 @@ export async function listAgents(db: D1, ownerId: string): Promise<AgentWithActi
     SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.handoff_to, a.runtime, a.model, a.skills,
       a.public_key, a.fingerprint, a.builtin, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
-      (SELECT MAX(tl.created_at) FROM task_logs tl WHERE tl.agent_id = a.id) as last_active_at,
+      (SELECT MAX(tl.created_at) FROM task_notes tl WHERE tl.agent_id = a.id) as last_active_at,
       (SELECT COUNT(*) FROM tasks t WHERE t.assigned_to = a.id) as task_count,
       COALESCE((SELECT SUM(s.input_tokens) FROM agent_sessions s WHERE s.agent_id = a.id), 0) as input_tokens,
       COALESCE((SELECT SUM(s.output_tokens) FROM agent_sessions s WHERE s.agent_id = a.id), 0) as output_tokens,
@@ -94,7 +94,7 @@ export async function getAgent(db: D1, agentId: string, ownerId: string): Promis
     SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.handoff_to, a.runtime, a.model, a.skills,
       a.public_key, a.fingerprint, a.builtin, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
-      (SELECT MAX(tl.created_at) FROM task_logs tl WHERE tl.agent_id = a.id) as last_active_at,
+      (SELECT MAX(tl.created_at) FROM task_notes tl WHERE tl.agent_id = a.id) as last_active_at,
       (SELECT COUNT(*) FROM tasks t WHERE t.assigned_to = a.id) as task_count,
       COALESCE((SELECT SUM(s.input_tokens) FROM agent_sessions s WHERE s.agent_id = a.id), 0) as input_tokens,
       COALESCE((SELECT SUM(s.output_tokens) FROM agent_sessions s WHERE s.agent_id = a.id), 0) as output_tokens,
@@ -147,7 +147,7 @@ export async function deleteAgent(db: D1, agentId: string): Promise<boolean> {
 export async function getAgentLogs(db: D1, agentId: string): Promise<any[]> {
   const result = await db
     .prepare(
-      "SELECT tl.*, t.title as task_title FROM task_logs tl JOIN tasks t ON tl.task_id = t.id WHERE tl.agent_id = ? ORDER BY tl.created_at DESC LIMIT 100",
+      "SELECT tl.*, t.title as task_title FROM task_notes tl JOIN tasks t ON tl.task_id = t.id WHERE tl.agent_id = ? ORDER BY tl.created_at DESC LIMIT 100",
     )
     .bind(agentId)
     .all();

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -12,7 +12,7 @@ import { createMessage, listMessages } from "./messageRepo";
 import { createRepository, deleteRepository, getRepository, listRepositories } from "./repositoryRepo";
 import { createSSEResponse } from "./sse";
 import {
-  addTaskLog,
+  addTaskNote,
   assignTask,
   cancelTask,
   claimTask,
@@ -20,7 +20,7 @@ import {
   createTask,
   deleteTask,
   getTask,
-  getTaskLogs,
+  getTaskNotes,
   listTasks,
   rejectTask,
   releaseTask,
@@ -331,9 +331,9 @@ api.post("/api/tasks/:id/reject", async (c) => {
   return c.json(task);
 });
 
-// ─── Task Logs ───
+// ─── Task Notes ───
 
-api.post("/api/tasks/:id/logs", async (c) => {
+api.post("/api/tasks/:id/notes", async (c) => {
   const body = await c.req.json<{ detail: string; agent_id?: string }>();
   if (!body.detail) throw new HTTPException(400, { message: "detail is required" });
 
@@ -341,17 +341,17 @@ api.post("/api/tasks/:id/logs", async (c) => {
   if (!task) throw new HTTPException(404, { message: "Task not found" });
 
   const agentId = c.get("agentId") || body.agent_id;
-  const log = await addTaskLog(c.env.DB, c.req.param("id"), agentId || null, "commented", body.detail);
-  return c.json(log, 201);
+  const note = await addTaskNote(c.env.DB, c.req.param("id"), agentId || null, "commented", body.detail);
+  return c.json(note, 201);
 });
 
-api.get("/api/tasks/:id/logs", async (c) => {
+api.get("/api/tasks/:id/notes", async (c) => {
   const task = await c.env.DB.prepare("SELECT id FROM tasks WHERE id = ?").bind(c.req.param("id")).first();
   if (!task) throw new HTTPException(404, { message: "Task not found" });
 
   const since = c.req.query("since");
-  const logs = await getTaskLogs(c.env.DB, c.req.param("id"), since || undefined);
-  return c.json(logs);
+  const notes = await getTaskNotes(c.env.DB, c.req.param("id"), since || undefined);
+  return c.json(notes);
 });
 
 // ─── Messages ───

--- a/apps/web/functions/api/sse.ts
+++ b/apps/web/functions/api/sse.ts
@@ -1,23 +1,23 @@
 import { listMessages } from "./messageRepo";
-import { getTaskLogs } from "./taskRepo";
+import { getTaskNotes } from "./taskRepo";
 import type { Env } from "./types";
 
 interface SSEEvent {
   id: string;
-  type: "log" | "message";
+  type: "note" | "message";
   data: string;
   created_at: string;
 }
 
-function mergeByTime(logs: SSEEvent[], messages: SSEEvent[]): SSEEvent[] {
+function mergeByTime(notes: SSEEvent[], messages: SSEEvent[]): SSEEvent[] {
   const merged: SSEEvent[] = [];
   let i = 0,
     j = 0;
-  while (i < logs.length && j < messages.length) {
-    if (logs[i].created_at <= messages[j].created_at) merged.push(logs[i++]);
+  while (i < notes.length && j < messages.length) {
+    if (notes[i].created_at <= messages[j].created_at) merged.push(notes[i++]);
     else merged.push(messages[j++]);
   }
-  while (i < logs.length) merged.push(logs[i++]);
+  while (i < notes.length) merged.push(notes[i++]);
   while (j < messages.length) merged.push(messages[j++]);
   return merged;
 }
@@ -29,7 +29,7 @@ export async function createSSEResponse(env: Env, taskId: string, lastEventId: s
   let since: string | undefined;
   if (lastEventId) {
     const ref = await db
-      .prepare("SELECT created_at FROM task_logs WHERE id = ? UNION SELECT created_at FROM messages WHERE id = ?")
+      .prepare("SELECT created_at FROM task_notes WHERE id = ? UNION SELECT created_at FROM messages WHERE id = ?")
       .bind(lastEventId, lastEventId)
       .first<{ created_at: string }>();
     if (!ref) {
@@ -58,11 +58,11 @@ export async function createSSEResponse(env: Env, taskId: string, lastEventId: s
   };
 
   const run = async () => {
-    const [initialLogs, initialMessages] = await Promise.all([getTaskLogs(db, taskId, since), listMessages(db, taskId, since)]);
+    const [initialNotes, initialMessages] = await Promise.all([getTaskNotes(db, taskId, since), listMessages(db, taskId, since)]);
 
-    const logEvents: SSEEvent[] = (since ? initialLogs : initialLogs.slice(-50)).map((l) => ({
+    const noteEvents: SSEEvent[] = (since ? initialNotes : initialNotes.slice(-50)).map((l) => ({
       id: l.id,
-      type: "log" as const,
+      type: "note" as const,
       data: JSON.stringify(l),
       created_at: l.created_at,
     }));
@@ -73,7 +73,7 @@ export async function createSSEResponse(env: Env, taskId: string, lastEventId: s
       created_at: m.created_at,
     }));
 
-    const batch = mergeByTime(logEvents, msgEvents);
+    const batch = mergeByTime(noteEvents, msgEvents);
     for (const event of batch) {
       await write(event);
     }
@@ -85,11 +85,11 @@ export async function createSSEResponse(env: Env, taskId: string, lastEventId: s
     while (Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 2000));
 
-      const [newLogs, newMessages] = await Promise.all([getTaskLogs(db, taskId, lastSeen), listMessages(db, taskId, lastSeen)]);
+      const [newNotes, newMessages] = await Promise.all([getTaskNotes(db, taskId, lastSeen), listMessages(db, taskId, lastSeen)]);
 
-      const newLogEvents = newLogs.map((l) => ({
+      const newNoteEvents = newNotes.map((l) => ({
         id: l.id,
-        type: "log" as const,
+        type: "note" as const,
         data: JSON.stringify(l),
         created_at: l.created_at,
       }));
@@ -99,7 +99,7 @@ export async function createSSEResponse(env: Env, taskId: string, lastEventId: s
         data: JSON.stringify(m),
         created_at: m.created_at,
       }));
-      const merged = mergeByTime(newLogEvents, newMsgEvents);
+      const merged = mergeByTime(newNoteEvents, newMsgEvents);
 
       for (const event of merged) {
         await write(event);

--- a/apps/web/functions/api/taskRepo.ts
+++ b/apps/web/functions/api/taskRepo.ts
@@ -1,4 +1,4 @@
-import type { CreateTaskInput, IdentityType, Task, TaskLog, TaskStatus, TaskTransition, TaskWithLogs } from "@agent-kanban/shared";
+import type { CreateTaskInput, IdentityType, Task, TaskNote, TaskStatus, TaskTransition, TaskWithNotes } from "@agent-kanban/shared";
 import { validateTransition } from "@agent-kanban/shared";
 import { HTTPException } from "hono/http-exception";
 import { getDefaultBoard } from "./boardRepo";
@@ -65,12 +65,14 @@ export async function createTask(db: D1, ownerId: string, input: CreateTaskInput
         now,
       ),
     db
-      .prepare("INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'created', NULL, ?)")
+      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'created', NULL, ?)")
       .bind(logId, taskId, input.agentId || null, null, now),
     ...(input.assigned_to
       ? [
           db
-            .prepare("INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)")
+            .prepare(
+              "INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)",
+            )
             .bind(newLongId(), taskId, input.assigned_to, null, now),
         ]
       : []),
@@ -165,7 +167,7 @@ export async function listTasks(
   return tasks;
 }
 
-export async function getTask(db: D1, taskId: string): Promise<TaskWithLogs | null> {
+export async function getTask(db: D1, taskId: string): Promise<TaskWithNotes | null> {
   const task = await db
     .prepare(`
     SELECT t.*, a.name as agent_name, a.public_key as agent_public_key, a.fingerprint as agent_fingerprint,
@@ -181,16 +183,16 @@ export async function getTask(db: D1, taskId: string): Promise<TaskWithLogs | nu
   if (!task) return null;
   parseTask(task);
 
-  const [logs, deps, blockedSet] = await Promise.all([
-    db.prepare("SELECT * FROM task_logs WHERE task_id = ? ORDER BY created_at ASC").bind(taskId).all<TaskLog>(),
+  const [notes, deps, blockedSet] = await Promise.all([
+    db.prepare("SELECT * FROM task_notes WHERE task_id = ? ORDER BY created_at ASC").bind(taskId).all<TaskNote>(),
     getDependencies(db, taskId),
     computeBlocked(db, [taskId]),
   ]);
 
-  const duration = computeDuration(logs.results);
+  const duration = computeDuration(notes.results);
   task.blocked = blockedSet.has(taskId);
 
-  return { ...task, logs: logs.results, duration_minutes: duration, depends_on: deps, subtask_count: task.subtask_count };
+  return { ...task, notes: notes.results, duration_minutes: duration, depends_on: deps, subtask_count: task.subtask_count };
 }
 
 export async function updateTask(
@@ -262,7 +264,7 @@ export async function claimTask(db: D1, taskId: string, agentId: string, identit
   await db.batch([
     db.prepare("UPDATE tasks SET status = 'in_progress', updated_at = ? WHERE id = ?").bind(now, taskId),
     db
-      .prepare("INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'claimed', NULL, ?)")
+      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'claimed', NULL, ?)")
       .bind(logId, taskId, agentId, null, now),
   ]);
 
@@ -281,7 +283,7 @@ export async function assignTask(db: D1, taskId: string, agentId: string): Promi
   await db.batch([
     db.prepare("UPDATE tasks SET assigned_to = ?, updated_at = ? WHERE id = ? AND assigned_to IS NULL").bind(agentId, now, taskId),
     db
-      .prepare("INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)")
+      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)")
       .bind(logId, taskId, agentId, null, now),
   ]);
 
@@ -306,7 +308,7 @@ export async function completeTask(
   await db.batch([
     db.prepare("UPDATE tasks SET status = 'done', result = ?, pr_url = ?, updated_at = ? WHERE id = ?").bind(result, prUrl, now, taskId),
     db
-      .prepare("INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'completed', ?, ?)")
+      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'completed', ?, ?)")
       .bind(logId, taskId, agentId, null, result, now),
   ]);
 
@@ -324,7 +326,7 @@ export async function cancelTask(db: D1, taskId: string, agentId: string | null,
   await db.batch([
     db.prepare("UPDATE tasks SET status = 'cancelled', assigned_to = NULL, updated_at = ? WHERE id = ?").bind(now, taskId),
     db
-      .prepare("INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'cancelled', NULL, ?)")
+      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'cancelled', NULL, ?)")
       .bind(logId, taskId, agentId, null, now),
   ]);
 
@@ -343,7 +345,7 @@ export async function reviewTask(db: D1, taskId: string, agentId: string | null,
     db.prepare("UPDATE tasks SET status = 'in_review', pr_url = COALESCE(?, pr_url), updated_at = ? WHERE id = ?").bind(prUrl, now, taskId),
     db
       .prepare(
-        "INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'review_requested', NULL, ?)",
+        "INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'review_requested', NULL, ?)",
       )
       .bind(logId, taskId, agentId, null, now),
   ]);
@@ -368,7 +370,7 @@ export async function releaseTask(
   await db.batch([
     db.prepare("UPDATE tasks SET status = 'todo', updated_at = ? WHERE id = ?").bind(now, taskId),
     db
-      .prepare("INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, NULL, ?)")
+      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, NULL, ?)")
       .bind(logId, taskId, agentId, null, action, now),
   ]);
 
@@ -386,27 +388,27 @@ export async function rejectTask(db: D1, taskId: string, agentId: string | null,
   await db.batch([
     db.prepare("UPDATE tasks SET status = 'in_progress', updated_at = ? WHERE id = ?").bind(now, taskId),
     db
-      .prepare("INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'rejected', ?, ?)")
+      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'rejected', ?, ?)")
       .bind(logId, taskId, agentId, null, reason || null, now),
   ]);
 
   return parseTask({ ...task, status: "in_progress" as const, updated_at: now });
 }
 
-export async function addTaskLog(db: D1, taskId: string, agentId: string | null, action: string, detail: string | null): Promise<TaskLog> {
-  const logId = newLongId();
+export async function addTaskNote(db: D1, taskId: string, agentId: string | null, action: string, detail: string | null): Promise<TaskNote> {
+  const noteId = newLongId();
   const now = new Date().toISOString();
 
   await db
-    .prepare("INSERT INTO task_logs (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)")
-    .bind(logId, taskId, agentId, null, action, detail, now)
+    .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)")
+    .bind(noteId, taskId, agentId, null, action, detail, now)
     .run();
 
-  return { id: logId, task_id: taskId, agent_id: agentId, session_id: null, action: action as any, detail, created_at: now };
+  return { id: noteId, task_id: taskId, agent_id: agentId, session_id: null, action: action as any, detail, created_at: now };
 }
 
-export async function getTaskLogs(db: D1, taskId: string, since?: string): Promise<TaskLog[]> {
-  let query = "SELECT * FROM task_logs WHERE task_id = ?";
+export async function getTaskNotes(db: D1, taskId: string, since?: string): Promise<TaskNote[]> {
+  let query = "SELECT * FROM task_notes WHERE task_id = ?";
   const binds: unknown[] = [taskId];
 
   if (since) {
@@ -419,13 +421,13 @@ export async function getTaskLogs(db: D1, taskId: string, since?: string): Promi
   const result = await db
     .prepare(query)
     .bind(...binds)
-    .all<TaskLog>();
+    .all<TaskNote>();
   return result.results;
 }
 
-function computeDuration(logs: TaskLog[]): number | null {
-  const claimed = logs.find((l) => l.action === "claimed");
-  const completed = logs.find((l) => l.action === "completed");
+function computeDuration(notes: TaskNote[]): number | null {
+  const claimed = notes.find((l) => l.action === "claimed");
+  const completed = notes.find((l) => l.action === "completed");
   if (!completed) return null;
 
   const end = new Date(completed.created_at);
@@ -434,7 +436,7 @@ function computeDuration(logs: TaskLog[]): number | null {
     return Math.round((end.getTime() - new Date(claimed.created_at).getTime()) / 60000);
   }
 
-  const created = logs.find((l) => l.action === "created");
+  const created = notes.find((l) => l.action === "created");
   if (!created) return null;
   return Math.round((end.getTime() - new Date(created.created_at).getTime()) / 60000);
 }

--- a/apps/web/functions/api/taskStale.ts
+++ b/apps/web/functions/api/taskStale.ts
@@ -10,7 +10,7 @@ export async function detectAndReleaseStale(db: D1, boardId: string): Promise<vo
     SELECT t.id, t.assigned_to FROM tasks t
     WHERE t.board_id = ? AND t.status IN ('in_progress', 'in_review') AND t.assigned_to IS NOT NULL
     AND (
-      SELECT MAX(tl.created_at) FROM task_logs tl WHERE tl.task_id = t.id
+      SELECT MAX(tl.created_at) FROM task_notes tl WHERE tl.task_id = t.id
     ) < ?
   `)
     .bind(boardId, cutoff)

--- a/apps/web/migrations/0002_rename_task_logs_to_task_notes.sql
+++ b/apps/web/migrations/0002_rename_task_logs_to_task_notes.sql
@@ -1,0 +1,6 @@
+-- Rename task_logs table to task_notes
+ALTER TABLE task_logs RENAME TO task_notes;
+
+-- Recreate index with new name
+DROP INDEX IF EXISTS idx_task_logs_task;
+CREATE INDEX idx_task_notes_task ON task_notes (task_id, created_at);

--- a/apps/web/src/components/ActivityLog.tsx
+++ b/apps/web/src/components/ActivityLog.tsx
@@ -3,8 +3,8 @@ import { formatRelative } from "./TaskDetailFields";
 import { Button } from "./ui/button";
 
 interface ActivityLogProps {
-  initialLogs: any[];
-  sseLogs: any[];
+  initialNotes: any[];
+  sseNotes: any[];
   reconnecting: boolean;
 }
 
@@ -32,34 +32,34 @@ const actionLabels: Record<string, string> = {
   review_requested: "Moved to review",
 };
 
-export function ActivityLog({ initialLogs, sseLogs, reconnecting }: ActivityLogProps) {
+export function ActivityLog({ initialNotes, sseNotes, reconnecting }: ActivityLogProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [autoScroll, setAutoScroll] = useState(true);
   const [newCount, setNewCount] = useState(0);
 
-  // Merge initial logs with SSE logs (dedup by ID)
-  const allLogs = (() => {
+  // Merge initial notes with SSE notes (dedup by ID)
+  const allNotes = (() => {
     const seen = new Set<string>();
     const merged: any[] = [];
-    for (const log of [...initialLogs, ...sseLogs]) {
-      if (!seen.has(log.id)) {
-        seen.add(log.id);
-        merged.push(log);
+    for (const note of [...initialNotes, ...sseNotes]) {
+      if (!seen.has(note.id)) {
+        seen.add(note.id);
+        merged.push(note);
       }
     }
     return merged.sort((a, b) => a.created_at.localeCompare(b.created_at));
   })();
 
-  const displayed = allLogs.slice().reverse();
+  const displayed = allNotes.slice().reverse();
 
-  // Auto-scroll when new logs arrive
+  // Auto-scroll when new notes arrive
   useEffect(() => {
     if (autoScroll && containerRef.current) {
       containerRef.current.scrollTop = 0;
-    } else if (!autoScroll && sseLogs.length > 0) {
+    } else if (!autoScroll && sseNotes.length > 0) {
       setNewCount((c) => c + 1);
     }
-  }, [autoScroll, sseLogs.length]);
+  }, [autoScroll, sseNotes.length]);
 
   function handleScroll() {
     if (!containerRef.current) return;
@@ -75,7 +75,7 @@ export function ActivityLog({ initialLogs, sseLogs, reconnecting }: ActivityLogP
   }
 
   if (displayed.length === 0) {
-    return <p className="text-sm text-content-tertiary">No activity yet. Assign an agent to see logs.</p>;
+    return <p className="text-sm text-content-tertiary">No activity yet. Assign an agent to see notes.</p>;
   }
 
   return (

--- a/apps/web/src/components/TaskDetail.tsx
+++ b/apps/web/src/components/TaskDetail.tsx
@@ -39,7 +39,7 @@ const PRIORITIES = ["urgent", "high", "medium", "low"] as const;
 export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDetailProps) {
   const { data: session } = useSession();
   const queryClient = useQueryClient();
-  const { logs: sseLogs, messages: sseMessages, reconnecting } = useSSE({ taskId, enabled: true });
+  const { notes: sseNotes, messages: sseMessages, reconnecting } = useSSE({ taskId, enabled: true });
 
   const { data: task, isLoading: loading } = useQuery({
     queryKey: ["task", taskId],
@@ -218,7 +218,7 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
 
       <div>
         <FieldLabel>Activity</FieldLabel>
-        <ActivityLog initialLogs={task.logs || []} sseLogs={sseLogs} reconnecting={reconnecting} />
+        <ActivityLog initialNotes={task.notes || []} sseNotes={sseNotes} reconnecting={reconnecting} />
       </div>
 
       <Separator />

--- a/apps/web/src/hooks/useSSE.ts
+++ b/apps/web/src/hooks/useSSE.ts
@@ -7,7 +7,7 @@ interface UseSSEOptions {
 }
 
 export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
-  const [logs, setLogs] = useState<any[]>([]);
+  const [notes, setNotes] = useState<any[]>([]);
   const [messages, setMessages] = useState<any[]>([]);
   const [connected, setConnected] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
@@ -41,8 +41,8 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
         }
       };
 
-      es.addEventListener("log", (e: MessageEvent) => {
-        setLogs((prev) => [...prev, JSON.parse(e.data)]);
+      es.addEventListener("note", (e: MessageEvent) => {
+        setNotes((prev) => [...prev, JSON.parse(e.data)]);
       });
 
       es.addEventListener("message", (e: MessageEvent) => {
@@ -71,11 +71,11 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
       const poll = async () => {
         try {
           const headers = { Authorization: `Bearer ${tk}` };
-          const [logsRes, msgsRes] = await Promise.all([
-            fetch(`/api/tasks/${taskId}/logs`, { headers }),
+          const [notesRes, msgsRes] = await Promise.all([
+            fetch(`/api/tasks/${taskId}/notes`, { headers }),
             fetch(`/api/tasks/${taskId}/messages`, { headers }),
           ]);
-          if (logsRes.ok) setLogs(await logsRes.json());
+          if (notesRes.ok) setNotes(await notesRes.json());
           if (msgsRes.ok) setMessages(await msgsRes.json());
         } catch {
           /* ignore polling errors */
@@ -95,5 +95,5 @@ export function useSSE({ taskId, enabled = true }: UseSSEOptions) {
     };
   }, [taskId, enabled]);
 
-  return { logs, messages, connected, reconnecting };
+  return { notes, messages, connected, reconnecting };
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -44,10 +44,10 @@ export const api = {
     review: (id: string) => request<any>("POST", `/tasks/${id}/review`),
     reject: (id: string) => request<any>("POST", `/tasks/${id}/reject`),
     assign: (id: string, agentId: string) => request<any>("POST", `/tasks/${id}/assign`, { agent_id: agentId }),
-    addLog: (id: string, detail: string) => request<any>("POST", `/tasks/${id}/logs`, { detail }),
-    getLogs: (id: string, since?: string) => {
+    addNote: (id: string, detail: string) => request<any>("POST", `/tasks/${id}/notes`, { detail }),
+    getNotes: (id: string, since?: string) => {
       const qs = since ? `?since=${encodeURIComponent(since)}` : "";
-      return request<any[]>("GET", `/tasks/${id}/logs${qs}`);
+      return request<any[]>("GET", `/tasks/${id}/notes${qs}`);
     },
   },
   messages: {

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -79,8 +79,8 @@ export abstract class ApiClient {
   assignTask(id: string, agentId: string) {
     return this.request("POST", `/api/tasks/${id}/assign`, { agent_id: agentId });
   }
-  addLog(taskId: string, detail: string) {
-    return this.request("POST", `/api/tasks/${taskId}/logs`, { detail });
+  addNote(taskId: string, detail: string) {
+    return this.request("POST", `/api/tasks/${taskId}/notes`, { detail });
   }
   deleteTask(id: string) {
     return this.request("DELETE", `/api/tasks/${id}`);
@@ -88,9 +88,9 @@ export abstract class ApiClient {
   rejectTask(id: string, body: Record<string, unknown> = {}) {
     return this.request("POST", `/api/tasks/${id}/reject`, body);
   }
-  getTaskLogs(taskId: string, since?: string) {
+  getTaskNotes(taskId: string, since?: string) {
     const qs = since ? `?since=${encodeURIComponent(since)}` : "";
-    return this.request("GET", `/api/tasks/${taskId}/logs${qs}`);
+    return this.request("GET", `/api/tasks/${taskId}/notes${qs}`);
   }
   getAgent(agentId: string) {
     return this.request("GET", `/api/agents/${agentId}`);

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -121,7 +121,7 @@ async function createNote(taskId: string, message: string) {
     process.exit(1);
   }
   const client = await createClient();
-  await client.addLog(taskId, message);
+  await client.addNote(taskId, message);
   console.log("Log entry added.");
 }
 

--- a/packages/cli/src/commands/get.ts
+++ b/packages/cli/src/commands/get.ts
@@ -9,7 +9,7 @@ import {
   formatRepositoryList,
   formatTask,
   formatTaskList,
-  formatTaskLogs,
+  formatTaskNotes,
   getFormat,
   output,
 } from "../output.js";
@@ -79,8 +79,8 @@ export function registerGetCommand(program: Command) {
             console.error("Usage: ak get note --task <task-id> or ak get note <task-id>");
             process.exit(1);
           }
-          const logs = await client.getTaskLogs(noteTaskId, opts.since);
-          output(logs, fmt, formatTaskLogs);
+          const notes = await client.getTaskNotes(noteTaskId, opts.since);
+          output(notes, fmt, formatTaskNotes);
           break;
         }
       }

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -259,8 +259,8 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
         const providerName = normalizeRuntime(agentDetails?.runtime ?? opts.defaultProvider ?? "claude");
         const reviewProvider = getProvider(providerName);
 
-        const logs = (await client.getTaskLogs(rs.taskId)) as any[];
-        const rejectLog = [...logs].reverse().find((l: any) => l.action === "rejected");
+        const notes = (await client.getTaskNotes(rs.taskId)) as any[];
+        const rejectLog = [...notes].reverse().find((l: any) => l.action === "rejected");
         const rejectReason = rejectLog?.detail || "No reason provided";
 
         try {

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -89,9 +89,9 @@ export function formatTask(task: any): string {
   return lines.join("\n");
 }
 
-export function formatTaskLogs(logs: any[]): string {
-  if (logs.length === 0) return "No logs.";
-  return logs
+export function formatTaskNotes(notes: any[]): string {
+  if (notes.length === 0) return "No notes.";
+  return notes
     .map((l) => {
       const time = new Date(l.created_at).toLocaleString();
       const actor = l.actor_id ? ` [${l.actor_id}]` : "";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -47,11 +47,11 @@ export interface TaskWithMeta extends Task {
   depends_on: string[];
 }
 
-export interface TaskWithLogs extends TaskWithMeta {
-  logs: TaskLog[];
+export interface TaskWithNotes extends TaskWithMeta {
+  notes: TaskNote[];
 }
 
-export interface TaskLog {
+export interface TaskNote {
   id: string;
   task_id: string;
   agent_id: string | null;

--- a/tests/agent-auth.test.ts
+++ b/tests/agent-auth.test.ts
@@ -18,7 +18,7 @@ let db: D1Database;
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     const statements = sql

--- a/tests/agent-json-fields.test.ts
+++ b/tests/agent-json-fields.test.ts
@@ -11,7 +11,7 @@ let db: D1Database;
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/agent-redesign.test.ts
+++ b/tests/agent-redesign.test.ts
@@ -30,7 +30,7 @@ const env = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql
@@ -415,7 +415,7 @@ describe("user assigns task to agent", () => {
   });
 
   it("task logs record assignment with persistent agent ID", async () => {
-    const logs = await env.DB.prepare("SELECT * FROM task_logs WHERE task_id = ? AND action = 'assigned'").bind(taskId).all();
+    const logs = await env.DB.prepare("SELECT * FROM task_notes WHERE task_id = ? AND action = 'assigned'").bind(taskId).all();
     expect(logs.results.length).toBe(1);
     expect((logs.results[0] as any).agent_id).toBe(agentId);
   });

--- a/tests/builtin-agents.test.ts
+++ b/tests/builtin-agents.test.ts
@@ -20,7 +20,7 @@ const env = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/cli-agent-jwt.test.ts
+++ b/tests/cli-agent-jwt.test.ts
@@ -24,7 +24,7 @@ const testEnv = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/client-methods.test.ts
+++ b/tests/client-methods.test.ts
@@ -28,14 +28,14 @@ describe("ApiClient new methods — public contract", () => {
     expect((ApiClient.prototype as any).rejectTask.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("getTaskLogs is a function on ApiClient", async () => {
+  it("getTaskNotes is a function on ApiClient", async () => {
     const { ApiClient } = await import("../packages/cli/src/client");
-    expect(typeof (ApiClient.prototype as any).getTaskLogs).toBe("function");
+    expect(typeof (ApiClient.prototype as any).getTaskNotes).toBe("function");
   });
 
-  it("getTaskLogs accepts taskId as first parameter", async () => {
+  it("getTaskNotes accepts taskId as first parameter", async () => {
     const { ApiClient } = await import("../packages/cli/src/client");
-    expect((ApiClient.prototype as any).getTaskLogs.length).toBeGreaterThanOrEqual(1);
+    expect((ApiClient.prototype as any).getTaskNotes.length).toBeGreaterThanOrEqual(1);
   });
 
   it("deleteAgent is a function on ApiClient", async () => {

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -15,7 +15,7 @@ export function createTestEnv() {
 }
 
 export async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/machine-agent-flow.test.ts
+++ b/tests/machine-agent-flow.test.ts
@@ -25,7 +25,7 @@ const env = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql
@@ -188,9 +188,9 @@ describe("machine → agent session flow", () => {
     expect(task.status).toBe("in_progress");
   });
 
-  it("agent adds a task log", async () => {
+  it("agent adds a task note", async () => {
     const jwt = await signSessionJWT();
-    const res = await apiRequest("POST", `/api/tasks/${taskId}/logs`, { detail: "Working on it" }, jwt);
+    const res = await apiRequest("POST", `/api/tasks/${taskId}/notes`, { detail: "Working on it" }, jwt);
     expect(res.status).toBe(201);
   });
 
@@ -250,7 +250,7 @@ describe("machine → agent session flow", () => {
     expect(task.status).toBe("in_review");
     expect(task.assigned_to).toBe(agentId);
 
-    const logs = await env.DB.prepare("SELECT action FROM task_logs WHERE task_id = ? ORDER BY created_at").bind(taskId).all();
+    const logs = await env.DB.prepare("SELECT action FROM task_notes WHERE task_id = ? ORDER BY created_at").bind(taskId).all();
     const actions = logs.results.map((r: any) => r.action);
     expect(actions).toContain("created");
     expect(actions).toContain("assigned");

--- a/tests/machine-usage.test.ts
+++ b/tests/machine-usage.test.ts
@@ -12,7 +12,7 @@ let db: D1Database;
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -8,7 +8,7 @@ import {
   formatRepositoryList,
   formatTask,
   formatTaskList,
-  formatTaskLogs,
+  formatTaskNotes,
   getFormat,
   output,
 } from "../packages/cli/src/output";
@@ -156,14 +156,14 @@ describe("formatTask", () => {
   });
 });
 
-describe("formatTaskLogs", () => {
-  it("returns 'No logs.' for empty array", () => {
-    expect(formatTaskLogs([])).toBe("No logs.");
+describe("formatTaskNotes", () => {
+  it("returns 'No notes.' for empty array", () => {
+    expect(formatTaskNotes([])).toBe("No notes.");
   });
 
   it("includes the action for each log entry", () => {
     const logs = [{ id: "l1", task_id: "t1", actor_id: null, action: "created", detail: null, created_at: "2024-01-01T00:00:00.000Z" }];
-    const result = formatTaskLogs(logs);
+    const result = formatTaskNotes(logs);
     expect(result).toContain("created");
   });
 
@@ -171,19 +171,19 @@ describe("formatTaskLogs", () => {
     const logs = [
       { id: "l1", task_id: "t1", actor_id: null, action: "commented", detail: "This is the detail", created_at: "2024-01-01T00:00:00.000Z" },
     ];
-    const result = formatTaskLogs(logs);
+    const result = formatTaskNotes(logs);
     expect(result).toContain("This is the detail");
   });
 
   it("includes actor_id when present", () => {
     const logs = [{ id: "l1", task_id: "t1", actor_id: "agent-5", action: "claimed", detail: null, created_at: "2024-01-01T00:00:00.000Z" }];
-    const result = formatTaskLogs(logs);
+    const result = formatTaskNotes(logs);
     expect(result).toContain("agent-5");
   });
 
   it("omits actor bracket when actor_id is absent", () => {
     const logs = [{ id: "l1", task_id: "t1", actor_id: null, action: "created", detail: null, created_at: "2024-01-01T00:00:00.000Z" }];
-    const result = formatTaskLogs(logs);
+    const result = formatTaskNotes(logs);
     expect(result).not.toContain("[null]");
     expect(result).not.toContain("[undefined]");
   });
@@ -193,14 +193,14 @@ describe("formatTaskLogs", () => {
       { id: "l1", task_id: "t1", actor_id: null, action: "created", detail: null, created_at: "2024-01-01T00:00:00.000Z" },
       { id: "l2", task_id: "t1", actor_id: "ag1", action: "claimed", detail: null, created_at: "2024-01-02T00:00:00.000Z" },
     ];
-    const result = formatTaskLogs(logs);
+    const result = formatTaskNotes(logs);
     const lines = result.split("\n");
     expect(lines.length).toBe(2);
   });
 
   it("formats the created_at timestamp", () => {
     const logs = [{ id: "l1", task_id: "t1", actor_id: null, action: "created", detail: null, created_at: "2024-06-15T10:30:00.000Z" }];
-    const result = formatTaskLogs(logs);
+    const result = formatTaskNotes(logs);
     // The timestamp should be a recognisable date string (locale-formatted)
     expect(result.trim().length).toBeGreaterThan(0);
   });

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -400,42 +400,42 @@ describe("routes", () => {
     expect(body.status).toBe("in_progress");
   });
 
-  // ─── Task Logs ───
+  // ─── Task Notes ───
 
-  it("POST /api/tasks/:id/logs creates a log", async () => {
+  it("POST /api/tasks/:id/notes creates a note", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, userId, { title: "Log Task", board_id: boardId });
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/logs`, { detail: "A log entry" }, apiKey);
+    const task = await createTask(env.DB, userId, { title: "Note Task", board_id: boardId });
+    const res = await apiRequest("POST", `/api/tasks/${task.id}/notes`, { detail: "A note entry" }, apiKey);
     expect(res.status).toBe(201);
     const body = (await res.json()) as any;
-    expect(body.detail).toBe("A log entry");
+    expect(body.detail).toBe("A note entry");
   });
 
-  it("POST /api/tasks/:id/logs requires detail", async () => {
+  it("POST /api/tasks/:id/notes requires detail", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, userId, { title: "Log Task 2", board_id: boardId });
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/logs`, {}, apiKey);
+    const task = await createTask(env.DB, userId, { title: "Note Task 2", board_id: boardId });
+    const res = await apiRequest("POST", `/api/tasks/${task.id}/notes`, {}, apiKey);
     expect(res.status).toBe(400);
   });
 
-  it("POST /api/tasks/:id/logs returns 404 for unknown task", async () => {
-    const res = await apiRequest("POST", "/api/tasks/nonexistent/logs", { detail: "X" }, apiKey);
+  it("POST /api/tasks/:id/notes returns 404 for unknown task", async () => {
+    const res = await apiRequest("POST", "/api/tasks/nonexistent/notes", { detail: "X" }, apiKey);
     expect(res.status).toBe(404);
   });
 
-  it("GET /api/tasks/:id/logs returns logs", async () => {
-    const { createTask, addTaskLog } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, userId, { title: "Get Logs Task", board_id: boardId });
-    await addTaskLog(env.DB, task.id, null, "commented", "Test log");
-    const res = await apiRequest("GET", `/api/tasks/${task.id}/logs`, undefined, apiKey);
+  it("GET /api/tasks/:id/notes returns notes", async () => {
+    const { createTask, addTaskNote } = await import("../apps/web/functions/api/taskRepo");
+    const task = await createTask(env.DB, userId, { title: "Get Notes Task", board_id: boardId });
+    await addTaskNote(env.DB, task.id, null, "commented", "Test note");
+    const res = await apiRequest("GET", `/api/tasks/${task.id}/notes`, undefined, apiKey);
     expect(res.status).toBe(200);
     const body = (await res.json()) as any;
     expect(Array.isArray(body)).toBe(true);
     expect(body.length).toBeGreaterThanOrEqual(1);
   });
 
-  it("GET /api/tasks/:id/logs returns 404 for unknown task", async () => {
-    const res = await apiRequest("GET", "/api/tasks/nonexistent/logs", undefined, apiKey);
+  it("GET /api/tasks/:id/notes returns 404 for unknown task", async () => {
+    const res = await apiRequest("GET", "/api/tasks/nonexistent/notes", undefined, apiKey);
     expect(res.status).toBe(404);
   });
 

--- a/tests/sse.test.ts
+++ b/tests/sse.test.ts
@@ -59,15 +59,15 @@ describe("createSSEResponse", () => {
   });
 
   it("streams initial logs as SSE events", async () => {
-    const { addTaskLog } = await import("../apps/web/functions/api/taskRepo");
-    await addTaskLog(env.DB, taskId, null, "commented", "Log entry 1");
-    await addTaskLog(env.DB, taskId, null, "commented", "Log entry 2");
+    const { addTaskNote } = await import("../apps/web/functions/api/taskRepo");
+    await addTaskNote(env.DB, taskId, null, "commented", "Log entry 1");
+    await addTaskNote(env.DB, taskId, null, "commented", "Log entry 2");
 
     const { createSSEResponse } = await import("../apps/web/functions/api/sse");
     const response = await createSSEResponse(env as any, taskId, null);
     const text = await readSSEUntil(response.body!, (t) => t.includes("Log entry 2"));
 
-    expect(text).toContain("event: log");
+    expect(text).toContain("event: note");
     expect(text).toContain("Log entry 1");
     expect(text).toContain("Log entry 2");
     expect(text).toContain("id: ");
@@ -87,14 +87,14 @@ describe("createSSEResponse", () => {
   });
 
   it("resumes from lastEventId", async () => {
-    const { addTaskLog, getTaskLogs } = await import("../apps/web/functions/api/taskRepo");
-    await addTaskLog(env.DB, taskId, null, "commented", "Before resume");
-    const logsBeforeResume = await getTaskLogs(env.DB, taskId);
+    const { addTaskNote, getTaskNotes } = await import("../apps/web/functions/api/taskRepo");
+    await addTaskNote(env.DB, taskId, null, "commented", "Before resume");
+    const logsBeforeResume = await getTaskNotes(env.DB, taskId);
     const lastLogId = logsBeforeResume[logsBeforeResume.length - 1].id;
 
     // Small delay to ensure distinct timestamp in D1 (millisecond resolution)
     await new Promise((r) => setTimeout(r, 50));
-    await addTaskLog(env.DB, taskId, null, "commented", "After resume");
+    await addTaskNote(env.DB, taskId, null, "commented", "After resume");
 
     const { createSSEResponse } = await import("../apps/web/functions/api/sse");
     const response = await createSSEResponse(env as any, taskId, lastLogId);
@@ -115,14 +115,14 @@ describe("createSSEResponse", () => {
     expect(response).toBeInstanceOf(Response);
     expect(response.headers.get("Content-Type")).toBe("text/event-stream");
 
-    const text = await readSSEUntil(response.body!, (t) => t.includes("event: log"));
+    const text = await readSSEUntil(response.body!, (t) => t.includes("event: note"));
 
-    expect(text).toContain("event: log");
+    expect(text).toContain("event: note");
     expect(text).toContain('"action":"created"');
   });
 
   it("merges logs and messages by time order", async () => {
-    const { createTask, addTaskLog } = await import("../apps/web/functions/api/taskRepo");
+    const { createTask, addTaskNote } = await import("../apps/web/functions/api/taskRepo");
     const { createMessage } = await import("../apps/web/functions/api/messageRepo");
     const mergeTask = await createTask(env.DB, "sse-user", {
       title: "Merge SSE Task",
@@ -132,14 +132,14 @@ describe("createSSEResponse", () => {
     await createMessage(env.DB, mergeTask.id, "user", "sse-user", "Message first");
     // Small delay to ensure distinct timestamp in D1 (millisecond resolution)
     await new Promise((r) => setTimeout(r, 50));
-    await addTaskLog(env.DB, mergeTask.id, null, "commented", "Log second");
+    await addTaskNote(env.DB, mergeTask.id, null, "commented", "Log second");
 
     const { createSSEResponse } = await import("../apps/web/functions/api/sse");
     const response = await createSSEResponse(env as any, mergeTask.id, null);
     const text = await readSSEUntil(response.body!, (t) => t.includes("Message first") && t.includes("Log second"));
 
     expect(text).toContain("event: message");
-    expect(text).toContain("event: log");
+    expect(text).toContain("event: note");
     expect(text).toContain("Message first");
     expect(text).toContain("Log second");
 
@@ -149,14 +149,14 @@ describe("createSSEResponse", () => {
   });
 
   it("poll loop picks up new events after initial batch", async () => {
-    const { createTask, addTaskLog } = await import("../apps/web/functions/api/taskRepo");
+    const { createTask, addTaskNote } = await import("../apps/web/functions/api/taskRepo");
     const pollTask = await createTask(env.DB, "sse-user", {
       title: "Poll SSE Task",
       board_id: boardId,
     });
 
     setTimeout(async () => {
-      await addTaskLog(env.DB, pollTask.id, null, "commented", "Polled event from loop");
+      await addTaskNote(env.DB, pollTask.id, null, "commented", "Polled event from loop");
     }, 500);
 
     const { createSSEResponse } = await import("../apps/web/functions/api/sse");
@@ -188,21 +188,21 @@ describe("createSSEResponse", () => {
   });
 
   it("limits initial events to 50 per type", async () => {
-    const { createTask, addTaskLog } = await import("../apps/web/functions/api/taskRepo");
+    const { createTask, addTaskNote } = await import("../apps/web/functions/api/taskRepo");
     const bigTask = await createTask(env.DB, "sse-user", {
       title: "Big SSE Task",
       board_id: boardId,
     });
 
     for (let i = 0; i < 55; i++) {
-      await addTaskLog(env.DB, bigTask.id, null, "commented", `Bulk log ${i}`);
+      await addTaskNote(env.DB, bigTask.id, null, "commented", `Bulk log ${i}`);
     }
 
     const { createSSEResponse } = await import("../apps/web/functions/api/sse");
     const response = await createSSEResponse(env as any, bigTask.id, null);
-    const text = await readSSEUntil(response.body!, (t) => (t.match(/event: log/g) || []).length >= 50);
+    const text = await readSSEUntil(response.body!, (t) => (t.match(/event: note/g) || []).length >= 50);
 
-    const logEventCount = (text.match(/event: log/g) || []).length;
+    const logEventCount = (text.match(/event: note/g) || []).length;
     expect(logEventCount).toBeLessThanOrEqual(50);
     expect(text).not.toContain("Bulk log 0");
     expect(text).toContain("Bulk log 54");

--- a/tests/task-dependencies.test.ts
+++ b/tests/task-dependencies.test.ts
@@ -19,7 +19,7 @@ const env = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/task-json-fields.test.ts
+++ b/tests/task-json-fields.test.ts
@@ -11,7 +11,7 @@ let db: D1Database;
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/task-state-machine.test.ts
+++ b/tests/task-state-machine.test.ts
@@ -22,7 +22,7 @@ const env = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql


### PR DESCRIPTION
## Summary
- Renames the `task_logs` concept to `task_notes` throughout the entire stack — a breaking change affecting database, API endpoints, shared types, CLI, SSE events, and frontend
- Adds migration `0002` to rename the `task_logs` table to `task_notes` and recreate the index
- Updates all API endpoints from `/api/tasks/:id/logs` to `/api/tasks/:id/notes`, SSE event type from `"log"` to `"note"`, and all related function/type/variable names

## Test plan
- [x] All 502 existing tests pass after rename
- [x] Build succeeds (`pnpm build`)
- [x] Type check passes (`pnpm tsc --noEmit`)
- [x] Migration correctly uses `ALTER TABLE RENAME` to preserve existing data
- [ ] Verify no downstream consumers (other repos/skills) reference the old `/logs` endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)