### PR TITLE
feat(cli): add XDG_STATE_HOME support and migrate PID_FILE

### DIFF
--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -7,7 +7,7 @@ import { AgentClient, ApiError, MachineClient } from "./client.js";
 import { getConfigValue, PID_FILE, setConfigValue } from "./config.js";
 import { findPathForRepository, getLinks, setLink } from "./links.js";
 import { createLogger } from "./logger.js";
-import { REPOS_DIR, SESSION_PIDS_FILE, WORKTREES_DIR } from "./paths.js";
+import { REPOS_DIR, SESSION_PIDS_FILE, STATE_DIR, WORKTREES_DIR } from "./paths.js";
 import { PrMonitor } from "./prMonitor.js";
 import { ProcessManager } from "./processManager.js";
 import { getAvailableProviders, getProvider } from "./providers/registry.js";
@@ -48,6 +48,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
       unlinkSync(PID_FILE);
     }
   }
+  mkdirSync(STATE_DIR, { recursive: true });
   writeFileSync(PID_FILE, String(process.pid));
 
   // Preflight: gh must be installed and authenticated

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -7,8 +7,14 @@ export const CONFIG_DIR = process.env.XDG_CONFIG_HOME ? join(process.env.XDG_CON
 
 export const DATA_DIR = process.env.XDG_DATA_HOME ? join(process.env.XDG_DATA_HOME, "agent-kanban") : join(home, ".local", "share", "agent-kanban");
 
+export const STATE_DIR = process.env.XDG_STATE_HOME
+  ? join(process.env.XDG_STATE_HOME, "agent-kanban")
+  : join(home, ".local", "state", "agent-kanban");
+
+export const LOGS_DIR = join(STATE_DIR, "logs");
+
 export const CONFIG_FILE = join(CONFIG_DIR, "config.json");
-export const PID_FILE = join(CONFIG_DIR, "daemon.pid");
+export const PID_FILE = join(STATE_DIR, "daemon.pid");
 export const LINKS_FILE = join(DATA_DIR, "links.json");
 export const REPOS_DIR = join(DATA_DIR, "repos");
 export const WORKTREES_DIR = join(DATA_DIR, "worktrees");


### PR DESCRIPTION
## Summary
- Add `STATE_DIR` export to `paths.ts` following XDG Base Directory spec (`$XDG_STATE_HOME/agent-kanban` or `~/.local/state/agent-kanban`)
- Add `LOGS_DIR` export (`STATE_DIR/logs`) for future use
- Move `PID_FILE` from `CONFIG_DIR` to `STATE_DIR` — runtime state doesn't belong in config
- Ensure `STATE_DIR` is created with `mkdirSync({ recursive: true })` before writing PID file in daemon

## Test plan
- [x] `pnpm build` passes
- [x] `tsc --noEmit` passes (CLI package)
- [x] All 502 vitest tests pass
- [x] Biome format/lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)