### PR TITLE
feat: add GET /api/health endpoint

### DIFF
--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -63,6 +63,9 @@ api.on(["GET", "POST"], "/api/auth/**", async (c) => {
   }
 });
 
+// Health check — no auth required
+api.get("/api/health", (c) => c.json({ status: "ok", timestamp: Date.now() }));
+
 // Auth middleware for all API routes (except Better Auth's own endpoints)
 api.use("/api/*", async (c, next) => {
   if (c.req.path.startsWith("/api/auth/")) return next();


### PR DESCRIPTION
## Summary
- Adds `GET /api/health` endpoint that returns `{ status: 'ok', timestamp: Date.now() }`
- Placed before the auth middleware so it is publicly accessible without a token

## Test plan
- [ ] `curl https://<host>/api/health` returns `{"status":"ok","timestamp":<ms>}` with HTTP 200
- [ ] No auth header needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)