### PR TITLE
feat(api): add GET /api/health endpoint

### DIFF
--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -63,6 +63,9 @@ api.on(["GET", "POST"], "/api/auth/**", async (c) => {
   }
 });
 
+// Health check — no auth required
+api.get("/api/health", (c) => c.json({ status: "ok" }));
+
 // Auth middleware for all API routes (except Better Auth's own endpoints)
 api.use("/api/*", async (c, next) => {
   if (c.req.path.startsWith("/api/auth/")) return next();


### PR DESCRIPTION
## Summary
- Adds `GET /api/health` returning `{ status: 'ok' }`
- Placed before the auth middleware so no authentication is required
- One-liner route, no new abstractions

## Test plan
- [ ] `curl <base-url>/api/health` returns `{"status":"ok"}` with HTTP 200
- [ ] Unauthenticated request succeeds (no auth header needed)