### PR TITLE
feat: add GET /api/ping endpoint

### DIFF
--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -64,7 +64,7 @@ api.on(["GET", "POST"], "/api/auth/**", async (c) => {
 });
 
 // Ping — public health check
-api.get("/api/ping", (c) => c.json({ pong: true }));
+api.get("/api/ping", (c) => c.json({ pong: true }, 200, { "Content-Type": "application/json" }));
 
 // Auth middleware for all API routes (except Better Auth's own endpoints)
 api.use("/api/*", async (c, next) => {

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -63,6 +63,9 @@ api.on(["GET", "POST"], "/api/auth/**", async (c) => {
   }
 });
 
+// Ping — public health check
+api.get("/api/ping", (c) => c.json({ pong: true }));
+
 // Auth middleware for all API routes (except Better Auth's own endpoints)
 api.use("/api/*", async (c, next) => {
   if (c.req.path.startsWith("/api/auth/")) return next();


### PR DESCRIPTION
## Summary
- Adds `GET /api/ping` route that returns `{ pong: true }`
- Registered before the auth middleware — no authentication required
- Minimal one-liner implementation following existing Hono patterns

## Test plan
- [ ] `curl https://<host>/api/ping` → `{"pong":true}` with HTTP 200
- [ ] No auth header needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)