### PR TITLE
feat(api): add GET /api/ping unauthenticated health check

### DIFF
--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -63,6 +63,9 @@ api.on(["GET", "POST"], "/api/auth/**", async (c) => {
   }
 });
 
+// Ping — unauthenticated health check
+api.get("/api/ping", (c) => c.json({ pong: true }));
+
 // Auth middleware for all API routes (except Better Auth's own endpoints)
 api.use("/api/*", async (c, next) => {
   if (c.req.path.startsWith("/api/auth/")) return next();


### PR DESCRIPTION
## Summary
- Adds `GET /api/ping` route returning `{ pong: true }`
- Route is placed before the auth middleware so it requires no authentication
- Minimal change — 3 lines added to routes.ts

## Test plan
- [ ] `curl https://<host>/api/ping` returns `{"pong":true}` with HTTP 200
- [ ] No auth header required

🤖 Generated with [Claude Code](https://claude.com/claude-code)