### PR TITLE
feat: add GET /api/ping health check endpoint

### DIFF
--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -52,6 +52,9 @@ api.onError((err, c) => {
   return c.json({ error: { code: "INTERNAL_ERROR", message: err.message || "Internal server error" } }, 500);
 });
 
+// Health check — no auth required
+api.get("/api/ping", (c) => c.json({ pong: true }));
+
 // Better Auth handler — must be before auth middleware
 api.on(["GET", "POST"], "/api/auth/**", async (c) => {
   try {


### PR DESCRIPTION
## Summary
- Adds `GET /api/ping` route returning `{ pong: true }`
- Placed before the auth middleware so no authentication is required
- Minimal change with no tests as specified

## Test plan
- [ ] `curl /api/ping` returns `{"pong":true}` with HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)