### PR TITLE
feat: agent avatar + clickable name, chat nested drawer, remove tabs

### DIFF
--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -20,6 +20,7 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
   const [sending, setSending] = useState(false);
   const [sendError, setSendError] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const isNearBottomRef = useRef(true);
 
   // Merge initial + SSE messages, dedup by ID
   const allMessages = (() => {
@@ -34,12 +35,20 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
     return merged.sort((a: any, b: any) => a.created_at.localeCompare(b.created_at));
   })();
 
-  // Auto-scroll to bottom on new messages
+  // Track whether user is near the bottom
+  function handleScroll() {
+    const el = containerRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    isNearBottomRef.current = distanceFromBottom < 80;
+  }
+
+  // Auto-scroll to bottom when messages arrive, only if user was already at bottom
   useEffect(() => {
-    if (containerRef.current) {
+    if (isNearBottomRef.current && containerRef.current) {
       containerRef.current.scrollTop = containerRef.current.scrollHeight;
     }
-  }, []);
+  }, [allMessages]);
 
   async function handleSend() {
     if (!input.trim() || !agentId) return;
@@ -77,10 +86,10 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
 
   return (
     <div className="flex flex-col flex-1 min-h-0 gap-3">
-      {/* Session ID for resume */}
-      <div className="flex items-center gap-2 text-[11px] font-mono text-content-tertiary shrink-0">
+      {/* Session ID for resume — subtle */}
+      <div className="flex items-center gap-2 text-[11px] font-mono text-content-tertiary shrink-0 opacity-60">
         <span>Session:</span>
-        <Badge variant="secondary" className="font-mono text-accent select-all">
+        <Badge variant="secondary" className="font-mono text-[10px] select-all">
           {agentId}
         </Badge>
         <Tooltip>
@@ -94,7 +103,7 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
       </div>
 
       {/* Messages — fills available space */}
-      <div ref={containerRef} className="flex-1 min-h-0 overflow-y-auto space-y-2">
+      <div ref={containerRef} onScroll={handleScroll} className="flex-1 min-h-0 overflow-y-auto space-y-2">
         {allMessages.length === 0 && (
           <div className="flex items-center justify-center h-full">
             <p className="text-sm text-content-tertiary">

--- a/apps/web/src/components/TaskDetail.tsx
+++ b/apps/web/src/components/TaskDetail.tsx
@@ -1,10 +1,12 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useSSE } from "../hooks/useSSE";
 import { api } from "../lib/api";
 import { useSession } from "../lib/auth-client";
 import { ActivityLog } from "./ActivityLog";
+import { AgentIdenticon } from "./AgentIdenticon";
 import { ChatPanel } from "./ChatPanel";
 import { SubtaskList } from "./SubtaskList";
 import { EditableText, Field, FieldLabel } from "./TaskDetailFields";
@@ -13,7 +15,6 @@ import { Button } from "./ui/button";
 import { Separator } from "./ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetTitle } from "./ui/sheet";
 import { Skeleton } from "./ui/skeleton";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "./ui/tabs";
 
 const TASK_STATUS_LABELS: Record<string, string> = {
   todo: "Todo",
@@ -42,9 +43,10 @@ const PRIORITY_CLASSES: Record<string, string> = {
   low: "bg-zinc-500/10 text-zinc-400 border-zinc-500/20",
 };
 
-export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDetailProps) {
+export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick: _onAgentClick }: TaskDetailProps) {
   const { data: session } = useSession();
   const queryClient = useQueryClient();
+  const [chatOpen, setChatOpen] = useState(false);
   const { notes: sseNotes, messages: sseMessages, reconnecting } = useSSE({ taskId, enabled: true });
 
   const { data: task, isLoading: loading } = useQuery({
@@ -123,8 +125,16 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
     );
   }
 
-  const hasAgent = !!task.assigned_to;
   const repo = repositories.find((r: any) => r.id === task.repository_id);
+
+  const agentDisplay = task.agent_name ? (
+    <button className="flex items-center gap-1.5 cursor-pointer group" onClick={() => setChatOpen(true)} type="button">
+      {task.agent_public_key && <AgentIdenticon publicKey={task.agent_public_key} size={20} />}
+      <span className="font-mono text-[13px] text-accent group-hover:underline">{task.agent_name}</span>
+    </button>
+  ) : (
+    <span className="text-content-tertiary">—</span>
+  );
 
   const detailsContent = (
     <div className="p-5 space-y-4">
@@ -133,12 +143,7 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
           <FieldLabel>Status</FieldLabel>
           <span className="text-sm font-medium text-accent">{TASK_STATUS_LABELS[task.status] || task.status}</span>
         </div>
-        <Field
-          label="Assigned to"
-          value={
-            task.agent_name ? <span className="font-mono text-[13px]">{task.agent_name}</span> : <span className="text-content-tertiary">—</span>
-          }
-        />
+        <Field label="Assigned to" value={agentDisplay} />
         <Field
           label="Duration"
           value={
@@ -238,70 +243,79 @@ export function TaskDetail({ taskId, onClose, onRefresh, onAgentClick }: TaskDet
     </div>
   );
 
-  const chatContent = (
-    <div className="flex flex-col h-[calc(100%-8rem)] p-5">
-      <ChatPanel
-        taskId={taskId}
-        agentId={task.assigned_to}
-        userId={session?.user?.id || null}
-        taskDone={task.status === "done" || task.status === "cancelled"}
-        initialMessages={initialMessages}
-        sseMessages={sseMessages}
-      />
-    </div>
-  );
-
   return (
-    <Sheet
-      open
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
-    >
-      <SheetContent showCloseButton={false} className="overflow-y-auto p-0 gap-0">
-        <SheetTitle className="sr-only">{task.title}</SheetTitle>
-        <SheetDescription className="sr-only">Task detail panel</SheetDescription>
+    <>
+      <Sheet
+        open
+        onOpenChange={(open) => {
+          if (!open) onClose();
+        }}
+      >
+        <SheetContent showCloseButton={false} className="overflow-y-auto p-0 gap-0">
+          <SheetTitle className="sr-only">{task.title}</SheetTitle>
+          <SheetDescription className="sr-only">Task detail panel</SheetDescription>
 
-        {/* Header */}
-        <div className="flex items-start justify-between p-5 border-b border-border">
-          <div className="flex-1 min-w-0 mr-4">
-            <div className="flex items-center gap-2">
-              <EditableText value={task.title} onSave={(v) => handleUpdate("title", v)} className="text-lg font-semibold text-content-primary" />
-              {task.blocked && (
-                <Badge variant="destructive" className="text-[10px] font-mono font-semibold uppercase">
-                  Blocked
-                </Badge>
-              )}
+          {/* Header */}
+          <div className="flex items-start justify-between p-5 border-b border-border">
+            <div className="flex-1 min-w-0 mr-4">
+              <div className="flex items-center gap-2">
+                <EditableText value={task.title} onSave={(v) => handleUpdate("title", v)} className="text-lg font-semibold text-content-primary" />
+                {task.blocked && (
+                  <Badge variant="destructive" className="text-[10px] font-mono font-semibold uppercase">
+                    Blocked
+                  </Badge>
+                )}
+              </div>
+              <div className="flex gap-1.5 mt-2 flex-wrap">
+                {repo && (
+                  <Badge variant="secondary" className="text-[11px] font-mono">
+                    {repo.name}
+                  </Badge>
+                )}
+                {task.priority && PRIORITY_CLASSES[task.priority] && (
+                  <Badge className={`text-[11px] font-mono border ${PRIORITY_CLASSES[task.priority]}`}>{task.priority}</Badge>
+                )}
+              </div>
             </div>
-            <div className="flex gap-1.5 mt-2 flex-wrap">
-              {repo && (
-                <Badge variant="secondary" className="text-[11px] font-mono">
-                  {repo.name}
-                </Badge>
-              )}
-              {task.priority && PRIORITY_CLASSES[task.priority] && (
-                <Badge className={`text-[11px] font-mono border ${PRIORITY_CLASSES[task.priority]}`}>{task.priority}</Badge>
-              )}
-            </div>
+            <Button variant="ghost" size="icon-sm" onClick={onClose}>
+              ✕
+            </Button>
           </div>
-          <Button variant="ghost" size="icon-sm" onClick={onClose}>
-            ✕
-          </Button>
-        </div>
 
-        {hasAgent ? (
-          <Tabs defaultValue="details">
-            <TabsList variant="line" className="w-full justify-start border-b border-border px-5">
-              <TabsTrigger value="details">Details</TabsTrigger>
-              <TabsTrigger value="chat">Chat</TabsTrigger>
-            </TabsList>
-            <TabsContent value="details">{detailsContent}</TabsContent>
-            <TabsContent value="chat">{chatContent}</TabsContent>
-          </Tabs>
-        ) : (
-          detailsContent
-        )}
-      </SheetContent>
-    </Sheet>
+          {detailsContent}
+        </SheetContent>
+      </Sheet>
+
+      {/* Nested chat drawer — overlays on top of task detail */}
+      {task.assigned_to && (
+        <Sheet open={chatOpen} onOpenChange={(open) => setChatOpen(open)}>
+          <SheetContent showCloseButton={false} className="flex flex-col p-0 gap-0 z-[60]">
+            <SheetTitle className="sr-only">Chat with {task.agent_name}</SheetTitle>
+            <SheetDescription className="sr-only">Chat panel</SheetDescription>
+
+            {/* Chat drawer header */}
+            <div className="flex items-center gap-3 p-4 border-b border-border shrink-0">
+              {task.agent_public_key && <AgentIdenticon publicKey={task.agent_public_key} size={28} />}
+              <span className="font-mono text-[13px] text-accent flex-1">{task.agent_name}</span>
+              <Button variant="ghost" size="icon-sm" onClick={() => setChatOpen(false)}>
+                ✕
+              </Button>
+            </div>
+
+            {/* Chat panel body */}
+            <div className="flex flex-col flex-1 min-h-0 p-4">
+              <ChatPanel
+                taskId={taskId}
+                agentId={task.assigned_to}
+                userId={session?.user?.id || null}
+                taskDone={task.status === "done" || task.status === "cancelled"}
+                initialMessages={initialMessages}
+                sseMessages={sseMessages}
+              />
+            </div>
+          </SheetContent>
+        </Sheet>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- **Agent display**: Replaced plain text agent name with identicon (24×24 SVG avatar) + clickable accent-colored name in the "Assigned to" field. Clicking either opens the chat drawer.
- **Remove tabs**: Eliminated the Tabs/TabsList/TabsTrigger/TabsContent wrapper entirely — details content always renders directly, no tab switching required.
- **Nested chat drawer**: Added a second `Sheet` that overlays on top of the task detail drawer (`z-[60]`), with a header showing agent identicon + name + close button, and ChatPanel as the body.
- **ChatPanel scroll fix**: Auto-scroll now triggers on `allMessages` changes (not just mount), and only scrolls when user is already near the bottom (within 80px) — tracked via `onScroll` + `isNearBottomRef`.
- **Session badge**: Made more subtle with `opacity-60` and smaller text to reduce visual noise.

## Files Changed
- `apps/web/src/components/TaskDetail.tsx` — main refactor
- `apps/web/src/components/ChatPanel.tsx` — scroll fix + subtle session badge

## Test plan
- [ ] Open a task with an assigned agent — verify identicon + cyan name appear in "Assigned to"
- [ ] Click agent avatar or name — verify chat drawer slides in from the right over the task detail
- [ ] Chat drawer header shows identicon + agent name + close button
- [ ] Close button on chat drawer dismisses it, task detail remains open
- [ ] Tasks without agents show "—" in "Assigned to", no chat drawer trigger
- [ ] Scrolling up in chat history pauses auto-scroll; new messages don't force-scroll
- [ ] Scrolling back to bottom resumes auto-scroll on new messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)