### PR TITLE
Migrate all frontend API requests to TanStack Query

### DIFF
--- a/apps/web/src/components/AddMachineSteps.tsx
+++ b/apps/web/src/components/AddMachineSteps.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "../lib/api";
 import { getAuthToken } from "../lib/auth-client";
@@ -14,6 +15,7 @@ export function AddMachineSteps({ apiKey, apiKeyId, onDone, onConnected }: AddMa
   const [connected, setConnected] = useState(false);
   const [connectedMachine, setConnectedMachine] = useState<any>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const queryClient = useQueryClient();
   const apiUrl = window.location.origin;
 
   const stopPolling = useCallback(() => {
@@ -34,6 +36,7 @@ export function AddMachineSteps({ apiKey, apiKeyId, onDone, onConnected }: AddMa
       if (!machineId) return;
       const m = await api.machines.get(machineId);
       if (m && m.status === "online") {
+        queryClient.invalidateQueries({ queryKey: ["machines"] });
         setConnected(true);
         setConnectedMachine(m);
         stopPolling();
@@ -41,7 +44,7 @@ export function AddMachineSteps({ apiKey, apiKeyId, onDone, onConnected }: AddMa
       }
     }, 3000);
     return stopPolling;
-  }, [apiKeyId, stopPolling, onConnected]);
+  }, [apiKeyId, stopPolling, onConnected, queryClient]);
 
   if (connected && connectedMachine) {
     return (

--- a/apps/web/src/components/AgentProfile.tsx
+++ b/apps/web/src/components/AgentProfile.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from "react";
+import { useAgent } from "../hooks/useAgents";
 import { agentFingerprint } from "../lib/agentIdentity";
-import { api } from "../lib/api";
 import { AgentIdenticon } from "./AgentIdenticon";
 import { formatRelative } from "./TaskDetailFields";
 import { Button } from "./ui/button";
@@ -33,15 +32,7 @@ const actionStyles: Record<string, string> = {
 };
 
 export function AgentProfile({ agentId, onClose, onTaskClick }: AgentProfileProps) {
-  const [agent, setAgent] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    api.agents
-      .get(agentId)
-      .then(setAgent)
-      .finally(() => setLoading(false));
-  }, [agentId]);
+  const { agent, loading } = useAgent(agentId);
 
   return (
     <Sheet

--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -1,3 +1,4 @@
+import { useMutation } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { api } from "../lib/api";
 import { formatRelative } from "./TaskDetailFields";
@@ -17,10 +18,17 @@ interface ChatPanelProps {
 
 export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, sseMessages }: ChatPanelProps) {
   const [input, setInput] = useState("");
-  const [sending, setSending] = useState(false);
-  const [sendError, setSendError] = useState<string | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const isNearBottomRef = useRef(true);
+
+  const sendMessage = useMutation({
+    mutationFn: (content: string) =>
+      api.messages.create(taskId, {
+        sender_type: "user",
+        sender_id: userId || "",
+        content,
+      }),
+  });
 
   // Merge initial + SSE messages, dedup by ID
   const allMessages = (() => {
@@ -52,21 +60,9 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
 
   async function handleSend() {
     if (!input.trim() || !agentId) return;
-
-    setSending(true);
-    setSendError(null);
-    try {
-      await api.messages.create(taskId, {
-        sender_type: "user",
-        sender_id: userId || "",
-        content: input.trim(),
-      });
-      setInput("");
-    } catch (_err: any) {
-      setSendError("Failed to send. Try again.");
-    } finally {
-      setSending(false);
-    }
+    const content = input.trim();
+    setInput("");
+    await sendMessage.mutateAsync(content);
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {
@@ -133,7 +129,7 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
       </div>
 
       {/* Send error */}
-      {sendError && <p className="text-xs text-error shrink-0">{sendError}</p>}
+      {sendMessage.isError && <p className="text-xs text-error shrink-0">Failed to send. Try again.</p>}
 
       {/* Input — pinned at bottom, hidden when task is done */}
       {!taskDone && (
@@ -144,10 +140,10 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Message the agent..."
-            disabled={sending}
+            disabled={sendMessage.isPending}
           />
-          <Button onClick={handleSend} disabled={!input.trim() || sending}>
-            {sending ? "..." : "Send"}
+          <Button onClick={handleSend} disabled={!input.trim() || sendMessage.isPending}>
+            {sendMessage.isPending ? "..." : "Send"}
           </Button>
         </div>
       )}

--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -61,8 +61,8 @@ export function ChatPanel({ taskId, agentId, userId, taskDone, initialMessages, 
   async function handleSend() {
     if (!input.trim() || !agentId) return;
     const content = input.trim();
-    setInput("");
     await sendMessage.mutateAsync(content);
+    setInput("");
   }
 
   function handleKeyDown(e: React.KeyboardEvent) {

--- a/apps/web/src/components/Onboarding.tsx
+++ b/apps/web/src/components/Onboarding.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { api } from "../lib/api";
+import { useCreateBoard } from "../hooks/useBoard";
 import { authClient } from "../lib/auth-client";
 import { AddMachineSteps } from "./AddMachineSteps";
 import { Button } from "./ui/button";
@@ -14,24 +14,20 @@ export function Onboarding({ onComplete }: OnboardingProps) {
   const [boardName, setBoardName] = useState("My Board");
   const [apiKeyDisplay, setApiKeyDisplay] = useState("");
   const [apiKeyId, setApiKeyId] = useState("");
-  const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const createBoard = useCreateBoard();
 
   async function handleCreateBoard() {
-    setLoading(true);
     setError("");
-    await api.boards.create({ name: boardName });
+    await createBoard.mutateAsync({ name: boardName });
 
     const { data, error: keyError } = await authClient.apiKey.create({ name: "onboarding" });
     if (keyError || !data?.key) {
       setError("Failed to create API key. You can create one later from Machines page.");
-      setLoading(false);
       return;
     }
     setApiKeyDisplay(data.key);
     setApiKeyId(data.id);
-
-    setLoading(false);
     setStep(1);
   }
 
@@ -57,8 +53,8 @@ export function Onboarding({ onComplete }: OnboardingProps) {
             <label className="block text-xs font-medium text-content-tertiary uppercase tracking-wide">Board name</label>
             <Input value={boardName} onChange={(e) => setBoardName(e.target.value)} />
             {error && <p className="text-xs text-red-400">{error}</p>}
-            <Button onClick={handleCreateBoard} disabled={loading || !boardName.trim()} className="w-full">
-              {loading ? "Creating..." : "Create Board"}
+            <Button onClick={handleCreateBoard} disabled={createBoard.isPending || !boardName.trim()} className="w-full">
+              {createBoard.isPending ? "Creating..." : "Create Board"}
             </Button>
           </div>
         )}

--- a/apps/web/src/hooks/useAgents.ts
+++ b/apps/web/src/hooks/useAgents.ts
@@ -1,24 +1,64 @@
-import { useCallback, useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../lib/api";
 
 export function useAgents() {
-  const [agents, setAgents] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
+  const {
+    data: agents = [],
+    isLoading: loading,
+    refetch,
+  } = useQuery({
+    queryKey: ["agents"],
+    queryFn: () => api.agents.list(),
+    refetchInterval: 15_000,
+  });
 
-  const load = useCallback(async () => {
-    try {
-      const result = await api.agents.list();
-      setAgents(result);
-    } catch {
-      /* ignore */
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  return { agents, loading, refresh: refetch };
+}
 
-  useEffect(() => {
-    load();
-  }, [load]);
+export function useAgent(id: string | undefined) {
+  const {
+    data: agent = null,
+    isLoading: loading,
+    refetch,
+  } = useQuery({
+    queryKey: ["agent", id],
+    queryFn: () => api.agents.get(id!),
+    enabled: !!id,
+    refetchInterval: 15_000,
+  });
 
-  return { agents, loading, refresh: load };
+  return { agent, loading, refresh: refetch };
+}
+
+export function useAgentSessions(agentId: string | undefined) {
+  const { data: sessions = [] } = useQuery({
+    queryKey: ["agent-sessions", agentId],
+    queryFn: () => api.agents.sessions(agentId!),
+    enabled: !!agentId,
+    refetchInterval: 15_000,
+  });
+
+  return { sessions };
+}
+
+export function useAgentTasks(agentId: string | undefined) {
+  const { data: tasks = [] } = useQuery({
+    queryKey: ["tasks", { assigned_to: agentId }],
+    queryFn: () => api.tasks.list({ assigned_to: agentId! }),
+    enabled: !!agentId,
+    refetchInterval: 15_000,
+  });
+
+  return { tasks };
+}
+
+export function useCreateAgent() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: api.agents.create,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["agents"] });
+    },
+  });
 }

--- a/apps/web/src/hooks/useBoard.ts
+++ b/apps/web/src/hooks/useBoard.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect } from "react";
 import { api } from "../lib/api";
 
@@ -49,4 +49,37 @@ export function useBoards() {
   });
 
   return { boards, loading, refresh: refetch };
+}
+
+export function useCreateBoard() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: { name: string; description?: string }) => api.boards.create(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["boards"] });
+    },
+  });
+}
+
+export function useUpdateBoard() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, ...body }: { id: string; name?: string; description?: string }) => api.boards.update(id, body),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["boards"] });
+    },
+  });
+}
+
+export function useDeleteBoard() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => api.boards.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["boards"] });
+    },
+  });
 }

--- a/apps/web/src/hooks/useMachines.ts
+++ b/apps/web/src/hooks/useMachines.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../lib/api";
+
+export function useMachines() {
+  const {
+    data: machines = [],
+    isLoading: loading,
+    refetch,
+  } = useQuery({
+    queryKey: ["machines"],
+    queryFn: () => api.machines.list(),
+    refetchInterval: 15_000,
+  });
+
+  return { machines, loading, refresh: refetch };
+}
+
+export function useMachine(id: string | undefined) {
+  const {
+    data: machine = null,
+    isLoading: loading,
+    refetch,
+  } = useQuery({
+    queryKey: ["machine", id],
+    queryFn: () => api.machines.get(id!),
+    enabled: !!id,
+    refetchInterval: 15_000,
+  });
+
+  return { machine, loading, refresh: refetch };
+}
+
+export function useDeleteMachine() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => api.machines.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["machines"] });
+    },
+  });
+}

--- a/apps/web/src/hooks/useRepositories.ts
+++ b/apps/web/src/hooks/useRepositories.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "../lib/api";
+
+export function useRepositories() {
+  const {
+    data: repos = [],
+    isLoading: loading,
+    refetch,
+  } = useQuery({
+    queryKey: ["repositories"],
+    queryFn: () => api.repositories.list(),
+  });
+
+  return { repos, loading, refresh: refetch };
+}
+
+export function useCreateRepository() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: { name: string; url: string }) => api.repositories.create(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["repositories"] });
+    },
+  });
+}
+
+export function useDeleteRepository() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => api.repositories.delete(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["repositories"] });
+    },
+  });
+}

--- a/apps/web/src/routes/AccountSettingsPage.tsx
+++ b/apps/web/src/routes/AccountSettingsPage.tsx
@@ -1,17 +1,17 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Header } from "../components/Header";
-import { useBoards } from "../hooks/useBoard";
-import { api } from "../lib/api";
+import { useBoards, useDeleteBoard, useUpdateBoard } from "../hooks/useBoard";
 import { getTheme, setTheme, type Theme } from "../lib/theme";
 
-function BoardItem({ board, onUpdate, onDelete }: { board: any; onUpdate: () => void; onDelete: (id: string) => void }) {
+function BoardItem({ board }: { board: any }) {
   const [expanded, setExpanded] = useState(false);
   const [editName, setEditName] = useState(board.name);
   const [editDesc, setEditDesc] = useState(board.description || "");
-  const [saving, setSaving] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const navigate = useNavigate();
+  const updateBoard = useUpdateBoard();
+  const deleteBoard = useDeleteBoard();
 
   useEffect(() => {
     setEditName(board.name);
@@ -24,18 +24,11 @@ function BoardItem({ board, onUpdate, onDelete }: { board: any; onUpdate: () => 
 
   async function handleSave() {
     if (!editName.trim()) return;
-    setSaving(true);
-    await api.boards.update(board.id, {
-      name: editName.trim(),
-      description: editDesc.trim(),
-    });
-    setSaving(false);
-    onUpdate();
+    await updateBoard.mutateAsync({ id: board.id, name: editName.trim(), description: editDesc.trim() });
   }
 
   async function handleDelete() {
-    await api.boards.delete(board.id);
-    onDelete(board.id);
+    await deleteBoard.mutateAsync(board.id);
   }
 
   return (
@@ -110,10 +103,10 @@ function BoardItem({ board, onUpdate, onDelete }: { board: any; onUpdate: () => 
             {hasChanges && (
               <button
                 onClick={handleSave}
-                disabled={saving || !editName.trim()}
+                disabled={updateBoard.isPending || !editName.trim()}
                 className="bg-accent text-[#09090B] font-medium text-xs px-3 py-1.5 rounded-md hover:opacity-90 disabled:opacity-50"
               >
-                {saving ? "Saving..." : "Save"}
+                {updateBoard.isPending ? "Saving..." : "Save"}
               </button>
             )}
           </div>
@@ -125,15 +118,11 @@ function BoardItem({ board, onUpdate, onDelete }: { board: any; onUpdate: () => 
 
 export function AccountSettingsPage() {
   const [currentTheme, setCurrentTheme] = useState<Theme>(getTheme());
-  const { boards, refresh } = useBoards();
+  const { boards } = useBoards();
 
   function handleTheme(theme: Theme) {
     setTheme(theme);
     setCurrentTheme(theme);
-  }
-
-  function handleBoardDelete(_id: string) {
-    refresh();
   }
 
   return (
@@ -170,7 +159,7 @@ export function AccountSettingsPage() {
           ) : (
             <div className="space-y-2">
               {boards.map((board: any) => (
-                <BoardItem key={board.id} board={board} onUpdate={refresh} onDelete={handleBoardDelete} />
+                <BoardItem key={board.id} board={board} />
               ))}
             </div>
           )}

--- a/apps/web/src/routes/AgentDetailPage.tsx
+++ b/apps/web/src/routes/AgentDetailPage.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { AgentIdenticon } from "../components/AgentIdenticon";
 import { Header } from "../components/Header";
 import { formatRelative } from "../components/TaskDetailFields";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../components/ui/dialog";
+import { useAgent, useAgentSessions, useAgentTasks } from "../hooks/useAgents";
 import { agentColor, agentColorRgb, agentFingerprint } from "../lib/agentIdentity";
-import { api } from "../lib/api";
 
 const actionStyles: Record<string, string> = {
   claimed: "text-accent",
@@ -40,42 +40,13 @@ type Tab = "mission" | "activity" | "sessions";
 
 export function AgentDetailPage() {
   const { id } = useParams<{ id: string }>();
-  const [agent, setAgent] = useState<any>(null);
-  const [sessions, setSessions] = useState<any[]>([]);
-  const [task, setTask] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
+  const { agent, loading } = useAgent(id);
+  const { sessions } = useAgentSessions(id);
+  const { tasks } = useAgentTasks(id);
+  const task = tasks[0] ?? null;
+
   const [tab, setTab] = useState<Tab>("mission");
   const [showIdentity, setShowIdentity] = useState(false);
-
-  useEffect(() => {
-    if (!id) return;
-    api.agents
-      .get(id)
-      .then((a) => {
-        setAgent(a);
-        api.agents
-          .sessions(id)
-          .then(setSessions)
-          .catch(() => {});
-        api.tasks
-          .list({ assigned_to: id })
-          .then((ts) => setTask(ts[0] ?? null))
-          .catch(() => {});
-      })
-      .finally(() => setLoading(false));
-    const interval = setInterval(() => {
-      api.agents.get(id).then(setAgent);
-      api.agents
-        .sessions(id)
-        .then(setSessions)
-        .catch(() => {});
-      api.tasks
-        .list({ assigned_to: id })
-        .then((ts) => setTask(ts[0] ?? null))
-        .catch(() => {});
-    }, 15000);
-    return () => clearInterval(interval);
-  }, [id]);
 
   if (loading) {
     return (

--- a/apps/web/src/routes/AgentNewPage.tsx
+++ b/apps/web/src/routes/AgentNewPage.tsx
@@ -8,14 +8,15 @@ import { Input } from "../components/ui/input";
 import { Label } from "../components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../components/ui/select";
 import { Textarea } from "../components/ui/textarea";
+import { useAgents, useCreateAgent } from "../hooks/useAgents";
 import { agentColor } from "../lib/agentIdentity";
-import { api } from "../lib/api";
 
 type Step = "choose" | "recruit" | "form";
 
 export function AgentNewPage() {
   const navigate = useNavigate();
-  const [agents, setAgents] = useState<any[]>([]);
+  const { agents } = useAgents();
+  const createAgent = useCreateAgent();
   const [step, setStep] = useState<Step>("choose");
   const [selectedTemplate, setSelectedTemplate] = useState<AgentTemplate | null>(null);
 
@@ -27,12 +28,7 @@ export function AgentNewPage() {
   const [runtime, setRuntime] = useState("claude-code");
   const [model, setModel] = useState("");
   const [skills, setSkills] = useState<string[]>([]);
-  const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    api.agents.list().then(setAgents);
-  }, []);
 
   const existingRoles = [...new Set(agents.map((a) => a.role).filter(Boolean))];
 
@@ -64,10 +60,9 @@ export function AgentNewPage() {
 
   async function handleCreate() {
     if (!name.trim()) return;
-    setCreating(true);
     setError(null);
     try {
-      await api.agents.create({
+      await createAgent.mutateAsync({
         name: name.trim(),
         bio: bio.trim() || undefined,
         soul: soul.trim() || undefined,
@@ -80,7 +75,6 @@ export function AgentNewPage() {
       navigate("/agents");
     } catch (err: any) {
       setError(err.message);
-      setCreating(false);
     }
   }
 
@@ -110,7 +104,7 @@ export function AgentNewPage() {
             setModel={setModel}
             skills={skills}
             setSkills={setSkills}
-            creating={creating}
+            creating={createAgent.isPending}
             error={error}
             onBack={() => setStep(selectedTemplate ? "recruit" : "choose")}
             onCreate={handleCreate}

--- a/apps/web/src/routes/AgentsPage.tsx
+++ b/apps/web/src/routes/AgentsPage.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { AgentIdenticon } from "../components/AgentIdenticon";
 import { Header } from "../components/Header";
 import { formatRelative } from "../components/TaskDetailFields";
+import { useAgents } from "../hooks/useAgents";
 import { agentColor, agentColorRgb, agentFingerprint } from "../lib/agentIdentity";
-import { api } from "../lib/api";
 
 function formatTokens(n: number): string {
   if (!n) return "0";
@@ -19,17 +18,7 @@ function formatCost(microUsd: number): string {
 }
 
 export function AgentsPage() {
-  const [agents, setAgents] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  const refresh = () => api.agents.list().then(setAgents);
-
-  useEffect(() => {
-    refresh().finally(() => setLoading(false));
-    const interval = setInterval(refresh, 15000);
-    return () => clearInterval(interval);
-  }, [refresh]);
-
+  const { agents, loading } = useAgents();
   const online = agents.filter((a) => a.status === "online").length;
 
   return (

--- a/apps/web/src/routes/MachineDetailPage.tsx
+++ b/apps/web/src/routes/MachineDetailPage.tsx
@@ -1,11 +1,11 @@
 import type { UsageWindow } from "@agent-kanban/shared";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { Header } from "../components/Header";
 import { formatRelative } from "../components/TaskDetailFields";
 import { Button } from "../components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../components/ui/dialog";
-import { api } from "../lib/api";
+import { useDeleteMachine, useMachine } from "../hooks/useMachines";
 
 const USAGE_LABELS: Record<string, string> = {
   five_hour: "5-Hour",
@@ -43,27 +43,13 @@ const agentStatusDotColors: Record<string, string> = {
 export function MachineDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const [machine, setMachine] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
+  const { machine, loading } = useMachine(id);
+  const deleteMachine = useDeleteMachine();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-  const [deleting, setDeleting] = useState(false);
-
-  useEffect(() => {
-    if (!id) return;
-    api.machines
-      .get(id)
-      .then(setMachine)
-      .finally(() => setLoading(false));
-    const interval = setInterval(() => {
-      api.machines.get(id).then(setMachine);
-    }, 15000);
-    return () => clearInterval(interval);
-  }, [id]);
 
   async function handleDelete() {
     if (!id) return;
-    setDeleting(true);
-    await api.machines.delete(id);
+    await deleteMachine.mutateAsync(id);
     navigate("/machines");
   }
 
@@ -269,8 +255,8 @@ export function MachineDetailPage() {
             <Button variant="outline" onClick={() => setShowDeleteDialog(false)}>
               Cancel
             </Button>
-            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
-              {deleting ? "Deleting..." : "Delete"}
+            <Button variant="destructive" onClick={handleDelete} disabled={deleteMachine.isPending}>
+              {deleteMachine.isPending ? "Deleting..." : "Delete"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/routes/MachinesPage.tsx
+++ b/apps/web/src/routes/MachinesPage.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { Link } from "react-router-dom";
 import { AddMachineSteps } from "../components/AddMachineSteps";
 import { Header } from "../components/Header";
 import { formatRelative } from "../components/TaskDetailFields";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../components/ui/dialog";
-import { api } from "../lib/api";
+import { useMachines } from "../hooks/useMachines";
 import { authClient } from "../lib/auth-client";
 
 const statusDotColors: Record<string, string> = {
@@ -22,24 +22,12 @@ function randomName() {
 }
 
 export function MachinesPage() {
-  const [machines, setMachines] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { machines, loading, refresh } = useMachines();
   const [showDialog, setShowDialog] = useState(false);
   const [dialogStep, setDialogStep] = useState<DialogStep>("choose");
   const [createdKey, setCreatedKey] = useState<string | null>(null);
   const [createdKeyId, setCreatedKeyId] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
-
-  useEffect(() => {
-    api.machines
-      .list()
-      .then(setMachines)
-      .finally(() => setLoading(false));
-    const interval = setInterval(() => {
-      api.machines.list().then(setMachines);
-    }, 15000);
-    return () => clearInterval(interval);
-  }, []);
 
   async function handleChooseLocal() {
     const name = randomName();
@@ -52,9 +40,8 @@ export function MachinesPage() {
 
   const handleConnected = useCallback(async () => {
     setConnected(true);
-    const updated = await api.machines.list();
-    setMachines(updated);
-  }, []);
+    refresh();
+  }, [refresh]);
 
   async function closeDialog() {
     if (createdKeyId && !connected) {

--- a/apps/web/src/routes/RepositoriesPage.tsx
+++ b/apps/web/src/routes/RepositoriesPage.tsx
@@ -1,38 +1,27 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Header } from "../components/Header";
 import { formatRelative } from "../components/TaskDetailFields";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "../components/ui/dialog";
-import { api } from "../lib/api";
+import { useCreateRepository, useDeleteRepository, useRepositories } from "../hooks/useRepositories";
 
 export function RepositoriesPage() {
-  const [repos, setRepos] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { repos, loading } = useRepositories();
+  const createRepo = useCreateRepository();
+  const deleteRepo = useDeleteRepository();
   const [showDialog, setShowDialog] = useState(false);
   const [newName, setNewName] = useState("");
   const [newUrl, setNewUrl] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-
-  useEffect(() => {
-    api.repositories
-      .list()
-      .then(setRepos)
-      .finally(() => setLoading(false));
-  }, []);
 
   async function handleAdd() {
     if (!newName.trim() || !newUrl.trim()) return;
-    setSubmitting(true);
-    const repo = await api.repositories.create({ name: newName.trim(), url: newUrl.trim() });
-    setRepos((prev) => [repo, ...prev]);
+    await createRepo.mutateAsync({ name: newName.trim(), url: newUrl.trim() });
     setNewName("");
     setNewUrl("");
     setShowDialog(false);
-    setSubmitting(false);
   }
 
   async function handleDelete(id: string) {
-    await api.repositories.delete(id);
-    setRepos((prev) => prev.filter((r) => r.id !== id));
+    await deleteRepo.mutateAsync(id);
   }
 
   return (
@@ -86,7 +75,8 @@ export function RepositoriesPage() {
                   </div>
                   <button
                     onClick={() => handleDelete(repo.id)}
-                    className="text-xs text-content-tertiary hover:text-error transition-colors shrink-0 ml-3"
+                    disabled={deleteRepo.isPending}
+                    className="text-xs text-content-tertiary hover:text-error transition-colors shrink-0 ml-3 disabled:opacity-50"
                   >
                     Remove
                   </button>
@@ -140,10 +130,10 @@ export function RepositoriesPage() {
             </div>
             <button
               onClick={handleAdd}
-              disabled={!newName.trim() || !newUrl.trim() || submitting}
+              disabled={!newName.trim() || !newUrl.trim() || createRepo.isPending}
               className="w-full bg-accent text-[#09090B] font-medium text-sm py-2.5 rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
             >
-              {submitting ? "Adding..." : "Add Repository"}
+              {createRepo.isPending ? "Adding..." : "Add Repository"}
             </button>
           </div>
         </DialogContent>


### PR DESCRIPTION
## Summary

- Created `useMachines.ts` and `useRepositories.ts` hook files following the `useBoard.ts` pattern
- Rewrote `useAgents.ts` to use `useQuery` with `refetchInterval: 15_000`, added `useAgent`, `useAgentSessions`, `useAgentTasks`, and `useCreateAgent` hooks
- Added `useCreateBoard`, `useUpdateBoard`, `useDeleteBoard` mutations to `useBoard.ts`
- Replaced `setInterval` polling in `AgentsPage`, `MachinesPage`, `AgentDetailPage`, `MachineDetailPage` with `refetchInterval`
- Replaced manual state management in `RepositoriesPage` with `useRepositories` + `useCreateRepository`/`useDeleteRepository` mutations
- Converted `AccountSettingsPage`/`BoardItem` to use `useUpdateBoard`/`useDeleteBoard` mutations with cache invalidation
- Migrated `ChatPanel` message send to `useMutation`
- Migrated `Onboarding` board creation to `useCreateBoard` mutation
- Migrated `AgentProfile` to `useAgent` hook
- Migrated `AgentNewPage` to `useAgents` + `useCreateAgent` mutation
- Added `queryClient.invalidateQueries` to `AddMachineSteps` on machine connection

## Test plan

- [ ] TypeScript lint passes (`pnpm --filter web lint`)
- [ ] All 555 unit/integration tests pass (`npx vitest run`)
- [ ] Biome formatting/import order checks pass
- [ ] Agents page auto-refreshes every 15s without setInterval
- [ ] Machines page auto-refreshes every 15s without setInterval
- [ ] Repository create/delete invalidates the repos list cache
- [ ] Board update/delete in settings invalidates the boards cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)