### PR TITLE
feat: add leader crown badge to agent list and detail pages

### DIFF
--- a/apps/web/src/routes/AgentDetailPage.tsx
+++ b/apps/web/src/routes/AgentDetailPage.tsx
@@ -139,6 +139,23 @@ export function AgentDetailPage() {
                   <h1 className="font-mono text-2xl font-bold text-content-primary" style={{ letterSpacing: "-0.02em" }}>
                     {agent.name}
                   </h1>
+                  {agent.kind === "leader" ? (
+                    <svg
+                      width="16"
+                      height="16"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="#EAB308"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="shrink-0"
+                    >
+                      <title>Leader agent</title>
+                      <path d="m2 4 3 12h14l3-12-6 5-4-5-4 5-6-5z" />
+                      <path d="M5 20h14" />
+                    </svg>
+                  ) : null}
                   {agent.builtin ? (
                     <svg
                       width="14"

--- a/apps/web/src/routes/AgentsPage.tsx
+++ b/apps/web/src/routes/AgentsPage.tsx
@@ -93,6 +93,23 @@ function AgentCard({ agent }: { agent: any }) {
 
         <div className="mt-3 flex items-center gap-1.5">
           <h2 className="font-mono text-base font-bold tracking-tight text-content-primary">{agent.name}</h2>
+          {agent.kind === "leader" ? (
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#EAB308"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="shrink-0"
+            >
+              <title>Leader agent</title>
+              <path d="m2 4 3 12h14l3-12-6 5-4-5-4 5-6-5z" />
+              <path d="M5 20h14" />
+            </svg>
+          ) : null}
           {agent.builtin ? (
             <svg
               width="12"


### PR DESCRIPTION
## Summary

- Added a crown icon (amber `#EAB308`) next to agent names when `agent.kind === "leader"`
- Applied to `AgentCard` in `AgentsPage.tsx` (12×12px) and the identity hero in `AgentDetailPage.tsx` (16×16px)
- Follows the exact same pattern as the existing `builtin` lock icon — inline SVG with `<title>` for accessibility

## Design decisions

- **Amber (#EAB308)** — the design system's warning/gold color, appropriate for a crown; makes leader status immediately legible against the dark background
- **Crown SVG** — minimal 2-path Lucide-style crown; matches the utilitarian icon aesthetic
- **Size scaled to context** — 12px on cards (compact), 16px on detail hero (prominent)
- No changes to data layer or `AgentIdenticon` component

## Test plan

- [ ] View Agents list — leader agents should show a small amber crown after their name
- [ ] View worker agents — no crown should appear
- [ ] Click into a leader agent detail — crown appears at 16px next to the name in the hero
- [ ] Hover shows tooltip "Leader agent" via SVG `<title>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)