### PR TITLE
feat: show real agent identicon and name in activity log

### DIFF
--- a/apps/web/functions/api/taskRepo.ts
+++ b/apps/web/functions/api/taskRepo.ts
@@ -186,7 +186,7 @@ export async function getTask(db: D1, taskId: string): Promise<TaskWithNotes | n
   const [notes, deps, blockedSet] = await Promise.all([
     db
       .prepare(
-        "SELECT n.*, a.name as agent_name FROM task_notes n LEFT JOIN agents a ON n.agent_id = a.id WHERE n.task_id = ? ORDER BY n.created_at ASC",
+        "SELECT n.*, a.name as agent_name, a.public_key as agent_public_key FROM task_notes n LEFT JOIN agents a ON n.agent_id = a.id WHERE n.task_id = ? ORDER BY n.created_at ASC",
       )
       .bind(taskId)
       .all<TaskNote>(),
@@ -409,11 +409,22 @@ export async function addTaskNote(db: D1, taskId: string, agentId: string | null
     .bind(noteId, taskId, agentId, null, action, detail, now)
     .run();
 
-  return { id: noteId, task_id: taskId, agent_id: agentId, agent_name: null, session_id: null, action: action as any, detail, created_at: now };
+  return {
+    id: noteId,
+    task_id: taskId,
+    agent_id: agentId,
+    agent_name: null,
+    agent_public_key: null,
+    session_id: null,
+    action: action as any,
+    detail,
+    created_at: now,
+  };
 }
 
 export async function getTaskNotes(db: D1, taskId: string, since?: string): Promise<TaskNote[]> {
-  let query = "SELECT n.*, a.name as agent_name FROM task_notes n LEFT JOIN agents a ON n.agent_id = a.id WHERE n.task_id = ?";
+  let query =
+    "SELECT n.*, a.name as agent_name, a.public_key as agent_public_key FROM task_notes n LEFT JOIN agents a ON n.agent_id = a.id WHERE n.task_id = ?";
   const binds: unknown[] = [taskId];
 
   if (since) {

--- a/apps/web/src/components/ActivityLog.tsx
+++ b/apps/web/src/components/ActivityLog.tsx
@@ -1,5 +1,6 @@
-import { Bot, User } from "lucide-react";
+import { User } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { AgentIdenticon } from "./AgentIdenticon";
 import { formatRelative } from "./TaskDetailFields";
 import { Button } from "./ui/button";
 
@@ -51,7 +52,7 @@ function buildSentence(log: any): { prefix: string; actionText: string; suffix: 
     case "cancelled":
       return { prefix: name ?? "System", actionText: "cancelled this task", suffix: log.detail ? `— ${log.detail}` : "" };
     case "rejected":
-      return { prefix: "Reviewer", actionText: "rejected — sent back to agent", suffix: log.detail ? `(${log.detail})` : "" };
+      return { prefix: name ?? "Reviewer", actionText: "rejected — sent back to agent", suffix: log.detail ? `(${log.detail})` : "" };
     case "review_requested":
       return { prefix: name ?? "Agent", actionText: "submitted for review", suffix: "" };
     case "created":
@@ -65,13 +66,9 @@ function buildSentence(log: any): { prefix: string; actionText: string; suffix: 
   }
 }
 
-function AgentAvatar({ hasAgent }: { hasAgent: boolean }) {
-  if (hasAgent) {
-    return (
-      <span className="flex-shrink-0 w-5 h-5 rounded-full bg-accent/10 border border-accent/20 flex items-center justify-center">
-        <Bot className="w-3 h-3 text-accent" />
-      </span>
-    );
+function NoteAvatar({ agentId, agentPublicKey }: { agentId: string | null; agentPublicKey: string | null }) {
+  if (agentId && agentPublicKey) {
+    return <AgentIdenticon publicKey={agentPublicKey} size={20} />;
   }
   return (
     <span className="flex-shrink-0 w-5 h-5 rounded-full bg-zinc-500/10 border border-zinc-500/20 flex items-center justify-center">
@@ -142,7 +139,7 @@ export function ActivityLog({ initialNotes, sseNotes, reconnecting }: ActivityLo
 
           {displayed.map((log: any) => {
             const { prefix, actionText, suffix } = buildSentence(log);
-            const isAgent = !!log.agent_id;
+            const isAgent = !!log.agent_id && !!log.agent_public_key;
             const dot = dotColors[log.action] || "bg-zinc-500 border-zinc-500/30";
             const actionColor = actionStyles[log.action] || "text-content-secondary";
             const isComment = log.action === "commented";
@@ -153,7 +150,7 @@ export function ActivityLog({ initialNotes, sseNotes, reconnecting }: ActivityLo
                 <span className={`absolute left-0 -translate-x-1/2 mt-[3px] w-2 h-2 rounded-full border ${dot}`} style={{ top: "4px" }} />
 
                 <div className="flex items-center gap-1.5 flex-wrap">
-                  <AgentAvatar hasAgent={isAgent} />
+                  <NoteAvatar agentId={log.agent_id} agentPublicKey={log.agent_public_key} />
 
                   {/* Sentence: prefix (agent name) + action + suffix */}
                   <span className="text-[12px] leading-snug">

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -56,6 +56,7 @@ export interface TaskNote {
   task_id: string;
   agent_id: string | null;
   agent_name: string | null;
+  agent_public_key: string | null;
   session_id: string | null;
   action: TaskAction;
   detail: string | null;


### PR DESCRIPTION
## Summary

- Adds `agent_public_key` to `TaskNote` shared type
- Updates both `task_notes` SQL queries in `taskRepo.ts` to `LEFT JOIN agents` on `public_key`, so notes carry the agent's public key
- Replaces the generic `AgentAvatar` (Bot/User icon) in `ActivityLog.tsx` with `NoteAvatar` — renders `AgentIdenticon` when `agent_id` + `agent_public_key` are present, falls back to `User` icon for System entries
- Fixes `rejected` action in `buildSentence` to use `agent_name ?? "Reviewer"` instead of hardcoded `"Reviewer"`
- SSE path is automatically covered since it calls `getTaskNotes`, which now includes `agent_public_key`

## Test plan

- [ ] Verify activity log entries from agents show their identicon avatar instead of the Bot icon
- [ ] Verify system actions (created, moved, assigned) still show the User/System icon
- [ ] Verify `rejected` entries show the reviewer's actual name when available
- [ ] All 555 unit tests pass (`npx vitest run`)
- [ ] Build passes (`pnpm build`)
- [ ] Type check passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)