### PR TITLE
fix: clear scheduler pause when rate-limited agent completes successfully

### DIFF
--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -69,6 +69,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     {
       onSlotFreed: () => scheduler.onSlotFreed(),
       onRateLimited: (resetAt) => scheduler.pauseForRateLimit(resetAt),
+      onRateLimitCleared: () => scheduler.clearRateLimit(),
       onProcessStarted: savePid,
       onProcessExited: removePid,
     },

--- a/packages/cli/src/processManager.ts
+++ b/packages/cli/src/processManager.ts
@@ -46,6 +46,7 @@ interface AgentProcess {
 export interface ProcessManagerCallbacks {
   onSlotFreed: () => void;
   onRateLimited: (resetAt: string) => void;
+  onRateLimitCleared?: () => void;
   onProcessStarted?: (sessionId: string, pid: number) => void;
   onProcessExited?: (sessionId: string) => void;
 }
@@ -286,6 +287,10 @@ export class ProcessManager {
         const agent = this.agents.get(taskId);
         if (agent) {
           agent.resultReceived = true;
+          // Rate limit was transient — agent completed despite the warning
+          if (agent.rateLimited) {
+            this.callbacks.onRateLimitCleared?.();
+          }
           const task = (await this.client.getTask(taskId)) as any;
           if (task?.status === "in_review") {
             updateSessionStatus(taskId, "in_review");

--- a/packages/cli/src/scheduler.ts
+++ b/packages/cli/src/scheduler.ts
@@ -58,6 +58,18 @@ export class Scheduler {
     this.schedulePoll(this.opts.pollInterval);
   }
 
+  clearRateLimit(): void {
+    if (!this.paused) return;
+    logger.info("Rate limit cleared — agent completed despite rate limit warning, resuming dispatch");
+    this.paused = false;
+    this.resumeTargetMs = 0;
+    if (this.resumeTimer) {
+      clearTimeout(this.resumeTimer);
+      this.resumeTimer = null;
+    }
+    this.schedulePoll(0);
+  }
+
   private schedulePoll(delayMs: number): void {
     if (!this.running) return;
     if (this.pollTimer) clearTimeout(this.pollTimer);


### PR DESCRIPTION
## Summary

- `rate_limit` events from the Claude CLI are sometimes transient — the agent keeps running and can complete the task successfully
- Previously, the scheduler would remain paused for the full reset window (e.g. 1931 minutes) even after the agent finished normally
- This PR adds a recovery path: when a `result` event arrives for an agent that was rate-limited, it signals the scheduler to clear the pause immediately

## Changes

- **`processManager.ts`**: Added `onRateLimitCleared?` to `ProcessManagerCallbacks` interface; calls it in `handleEvent` case `"result"` when `agent.rateLimited` is true
- **`scheduler.ts`**: Added `clearRateLimit()` public method — clears the pause, cancels the resume timer, and reschedules a poll immediately
- **`daemon.ts`**: Wires `onRateLimitCleared: () => scheduler.clearRateLimit()` callback

## Test plan

- [ ] Verify daemon no longer stays paused after a rate-limited agent completes successfully
- [ ] Verify dispatch resumes immediately after `clearRateLimit()` is called
- [ ] Verify genuine rate limits (agent exits non-zero with `rateLimited=true`) still pause correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)