### PR TITLE
feat(api): add ping endpoint

### DIFF
--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -64,6 +64,8 @@ api.on(["GET", "POST"], "/api/auth/**", async (c) => {
   }
 });
 
+api.get("/api/ping", (c) => c.json({ pong: true }));
+
 // Auth middleware for all API routes (except Better Auth's own endpoints)
 api.use("/api/*", async (c, next) => {
   if (c.req.path.startsWith("/api/auth/")) return next();


### PR DESCRIPTION
## Summary
- add an unauthenticated  route returning 
- place the route before the  auth middleware so it remains reachable for smoke tests

## Testing
- not run locally; pre-commit hooks require missing / binaries because dependencies are not installed in this worktree