### PR TITLE
fix: reject leader task assignments

### DIFF
--- a/apps/web/functions/api/taskRepo.ts
+++ b/apps/web/functions/api/taskRepo.ts
@@ -7,6 +7,16 @@ import { computeBlocked, detectCycle, getDependencies, setDependencies } from ".
 
 const parseTask = <T extends Task>(row: T) => parseJsonFields(row, ["labels", "input"]);
 
+async function assertAssignableWorkerAgent(db: D1, agentId: string, missingStatus: 400 | 404): Promise<void> {
+  const agent = await db.prepare("SELECT kind FROM agents WHERE id = ?").bind(agentId).first<{ kind: string }>();
+  if (!agent) {
+    throw new HTTPException(missingStatus, { message: missingStatus === 404 ? "Agent not found" : "Assigned agent not found" });
+  }
+  if (agent.kind === "leader") {
+    throw new HTTPException(400, { message: "Cannot assign tasks to leader agents" });
+  }
+}
+
 function enforceTransition(action: TaskTransition, currentStatus: TaskStatus, identity: IdentityType): void {
   const error = validateTransition(action, currentStatus, identity);
   if (error) {
@@ -40,6 +50,10 @@ export async function createTask(db: D1, ownerId: string, input: CreateTaskInput
   if (input.created_from) {
     const parent = await db.prepare("SELECT id FROM tasks WHERE id = ?").bind(input.created_from).first();
     if (!parent) throw new HTTPException(400, { message: "Parent task not found" });
+  }
+
+  if (input.assigned_to) {
+    await assertAssignableWorkerAgent(db, input.assigned_to, 400);
   }
 
   const stmts = [
@@ -281,6 +295,7 @@ export async function assignTask(db: D1, taskId: string, agentId: string): Promi
   if (!task) return null;
   if (task.status !== "todo") throw new HTTPException(409, { message: "Can only assign tasks in todo status" });
   if (task.assigned_to) throw new HTTPException(409, { message: "Task is already assigned" });
+  await assertAssignableWorkerAgent(db, agentId, 404);
 
   const now = new Date().toISOString();
   const logId = newLongId();

--- a/tests/task-state-machine.test.ts
+++ b/tests/task-state-machine.test.ts
@@ -256,6 +256,7 @@ describe("task lifecycle repo functions", () => {
   let boardId: string;
   let testAgentId: string;
   let otherAgentId: string;
+  let leaderAgentId: string;
 
   async function createTestTask() {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
@@ -276,6 +277,8 @@ describe("task lifecycle repo functions", () => {
     testAgentId = agent.id;
     const agent2 = await createAgent(env.DB, userId, { name: "SM Agent 2" });
     otherAgentId = agent2.id;
+    const leader = await createAgent(env.DB, userId, { name: "SM Leader Agent", kind: "leader" });
+    leaderAgentId = leader.id;
   });
 
   describe("claim", () => {
@@ -471,6 +474,12 @@ describe("task lifecycle repo functions", () => {
       expect(result!.assigned_to).toBe(testAgentId);
     });
 
+    it("rejects assign to leader agents", async () => {
+      const { assignTask } = await import("../apps/web/functions/api/taskRepo");
+      const task = await createTestTask();
+      await expect(assignTask(env.DB, task.id, leaderAgentId)).rejects.toThrow("Cannot assign tasks to leader agents");
+    });
+
     it("rejects assign when already assigned", async () => {
       const { assignTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
@@ -490,6 +499,19 @@ describe("task lifecycle repo functions", () => {
       const task = await createTestTask();
       await forceStatus(task.id, "done");
       await expect(assignTask(env.DB, task.id, testAgentId)).rejects.toThrow("todo");
+    });
+  });
+
+  describe("create restrictions", () => {
+    it("rejects createTask assigned_to leader agents", async () => {
+      const { createTask } = await import("../apps/web/functions/api/taskRepo");
+      await expect(
+        createTask(env.DB, userId, {
+          title: `Task ${randomUUID().slice(0, 8)}`,
+          board_id: boardId,
+          assigned_to: leaderAgentId,
+        }),
+      ).rejects.toThrow("Cannot assign tasks to leader agents");
     });
   });
 


### PR DESCRIPTION
## Summary
- reject leader agents during task creation when `assigned_to` is provided
- reject leader agents during task assignment before writing task/task_note updates
- add regression tests covering both guarded paths

## Verification
- pnpm exec vitest tests/task-state-machine.test.ts
- pnpm exec vitest tests/task-json-fields.test.ts
- pnpm --filter @agent-kanban/web lint