### PR TITLE
fix: clean up saved sessions when task is deleted (404)

### DIFF
--- a/packages/cli/src/scheduler.ts
+++ b/packages/cli/src/scheduler.ts
@@ -111,7 +111,18 @@ export class Scheduler {
     for (const s of loadSessions("active")) {
       if (this.pm.hasTask(s.taskId)) continue;
       // Session marked active but no process running — stale from crash
-      const task = (await this.client.getTask(s.taskId)) as any;
+      let task: any;
+      try {
+        task = await this.client.getTask(s.taskId);
+      } catch (err: any) {
+        if (err instanceof ApiError && err.status === 404) {
+          logger.warn(`Task ${s.taskId} not found (deleted), cleaning up orphaned session`);
+          removeWorktree(s.repoDir, s.cwd, s.branchName);
+          removeSession(s.taskId);
+          continue;
+        }
+        throw err;
+      }
       if (!task || task.status === "done" || task.status === "cancelled") {
         removeWorktree(s.repoDir, s.cwd, s.branchName);
         removeSession(s.taskId);
@@ -137,7 +148,18 @@ export class Scheduler {
     for (const s of loadSessions("in_review")) {
       if (this.pm.activeCount >= this.opts.maxConcurrent) return;
       if (this.pm.hasTask(s.taskId)) continue;
-      const task = (await this.client.getTask(s.taskId)) as any;
+      let task: any;
+      try {
+        task = await this.client.getTask(s.taskId);
+      } catch (err: any) {
+        if (err instanceof ApiError && err.status === 404) {
+          logger.warn(`Task ${s.taskId} not found (deleted), cleaning up review session`);
+          removeWorktree(s.repoDir, s.cwd, s.branchName);
+          removeSession(s.taskId);
+          continue;
+        }
+        throw err;
+      }
 
       if (!task || task.status === "done" || task.status === "cancelled") {
         removeSession(s.taskId);

--- a/packages/cli/src/taskRunner.ts
+++ b/packages/cli/src/taskRunner.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { AgentClient, type MachineClient } from "./client.js";
+import { ApiError, AgentClient, type MachineClient } from "./client.js";
 import { getConfigValue } from "./config.js";
 import { createLogger } from "./logger.js";
 import type { ProcessManager } from "./processManager.js";
@@ -119,7 +119,18 @@ export class TaskRunner {
 
   /** Resume a saved session (rate-limited or rejected). */
   async resumeSession(session: SavedSession, message: string): Promise<boolean> {
-    const task = (await this.client.getTask(session.taskId)) as any;
+    let task: any;
+    try {
+      task = await this.client.getTask(session.taskId);
+    } catch (err: any) {
+      if (err instanceof ApiError && err.status === 404) {
+        logger.warn(`Task ${session.taskId} not found (deleted), cleaning up session`);
+        removeWorktree(session.repoDir, session.cwd, session.branchName);
+        removeSession(session.taskId);
+        return false;
+      }
+      throw err;
+    }
     if (!task || task.status === "cancelled" || task.status === "done") {
       removeWorktree(session.repoDir, session.cwd, session.branchName);
       removeSession(session.taskId);


### PR DESCRIPTION
## Summary

- **Bug**: When a task is deleted via API, `saved-sessions.json` still holds a session. The daemon's scheduler keeps trying to resume it, `getTask` throws `ApiError(404)`, the error propagates uncaught, and dispatch of new tasks is blocked.
- **Fix**: Wrap `getTask` calls in `resumeSession` (taskRunner.ts) and `resumeSavedSessions` (scheduler.ts) with a try/catch that handles `ApiError` 404. On 404, log at WARN level, remove the worktree, and call `removeSession` — then continue processing other sessions.
- Covers all three code paths: active orphan cleanup, rate-limited session resume, and in-review session resume.

## Test plan

- [ ] Delete a task via API while the daemon has a saved session for it
- [ ] Verify the daemon logs a WARN message like `Task <id> not found (deleted), cleaning up session`
- [ ] Verify `saved-sessions.json` no longer contains the deleted task's entry
- [ ] Verify the daemon continues dispatching other tasks normally (no blocked loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)