### PR TITLE
Reject task assignment to leader agents

### DIFF
--- a/apps/web/functions/api/auth.ts
+++ b/apps/web/functions/api/auth.ts
@@ -37,7 +37,7 @@ const ROUTE_RULES: { method: string; pattern: RegExp; rule: RouteRule }[] = [
   // Task lifecycle — agents operate, machine manages
   { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/claim$/, rule: { allow: ["agent:worker"], capability: "task:claim" } },
   { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/review$/, rule: { allow: ["agent:worker"], capability: "task:review" } },
-  { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/assign$/, rule: { allow: ["agent:leader"] } },
+  { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/assign$/, rule: { allow: ["machine", "agent:leader"] } },
   { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/release$/, rule: { allow: ["machine"] } },
   { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/complete$/, rule: { allow: ["user", "machine", "agent:leader"], capability: "task:complete" } },
   { method: "POST", pattern: /^\/api\/tasks\/[^/]+\/cancel$/, rule: { allow: ["user", "machine", "agent:leader"], capability: "task:cancel" } },

--- a/apps/web/functions/api/taskRepo.ts
+++ b/apps/web/functions/api/taskRepo.ts
@@ -15,6 +15,12 @@ function enforceTransition(action: TaskTransition, currentStatus: TaskStatus, id
   }
 }
 
+async function assertAssignableWorkerAgent(db: D1, agentId: string, missingStatus: 400 | 404): Promise<void> {
+  const agent = await db.prepare("SELECT kind FROM agents WHERE id = ?").bind(agentId).first<{ kind: string }>();
+  if (!agent) throw new HTTPException(missingStatus, { message: "Agent not found" });
+  if (agent.kind === "leader") throw new HTTPException(400, { message: "Cannot assign tasks to leader agents" });
+}
+
 export async function createTask(db: D1, ownerId: string, input: CreateTaskInput & { agentId?: string; assigned_to?: string }): Promise<Task> {
   const board = input.board_id ? { id: input.board_id } : await getDefaultBoard(db, ownerId);
 
@@ -40,6 +46,10 @@ export async function createTask(db: D1, ownerId: string, input: CreateTaskInput
   if (input.created_from) {
     const parent = await db.prepare("SELECT id FROM tasks WHERE id = ?").bind(input.created_from).first();
     if (!parent) throw new HTTPException(400, { message: "Parent task not found" });
+  }
+
+  if (input.assigned_to) {
+    await assertAssignableWorkerAgent(db, input.assigned_to, 400);
   }
 
   const stmts = [
@@ -281,6 +291,8 @@ export async function assignTask(db: D1, taskId: string, agentId: string): Promi
   if (!task) return null;
   if (task.status !== "todo") throw new HTTPException(409, { message: "Can only assign tasks in todo status" });
   if (task.assigned_to) throw new HTTPException(409, { message: "Task is already assigned" });
+
+  await assertAssignableWorkerAgent(db, agentId, 404);
 
   const now = new Date().toISOString();
   const logId = newLongId();

--- a/tests/cli-agent-jwt.test.ts
+++ b/tests/cli-agent-jwt.test.ts
@@ -173,18 +173,7 @@ describe("CLI ApiClient agent JWT passthrough", () => {
     const task = await createTask(testEnv.DB, userId, { title: "JWT test task", board_id: boardId });
     taskId = task.id;
 
-    // Verify leader agent can call the assign route (assigns task to itself)
-    const leaderJwt = await new SignJWT({ sub: leaderSessionId, aid: leaderAgentId, jti: randomUUID(), aud: BETTER_AUTH_URL })
-      .setProtectedHeader({ alg: "EdDSA", typ: "agent+jwt" })
-      .setIssuedAt()
-      .setExpirationTime("60s")
-      .sign(leaderSessionPrivateKey);
-    const assignRes = await honoRequest("POST", `/api/tasks/${taskId}/assign`, {}, leaderJwt);
-    expect(assignRes.status).toBe(200);
-    expect(((await assignRes.json()) as any).assigned_to).toBe(leaderAgentId);
-
-    // Re-assign to the worker agent via repo so the worker can claim it in subsequent tests
-    await testEnv.DB.prepare("UPDATE tasks SET status = 'todo', assigned_to = NULL WHERE id = ?").bind(taskId).run();
+    // Assign task to the worker agent so the worker can claim it in subsequent tests
     await assignTask(testEnv.DB, taskId, agentId);
   });
 

--- a/tests/cli-agent-jwt.test.ts
+++ b/tests/cli-agent-jwt.test.ts
@@ -3,7 +3,6 @@
 import { randomUUID } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { SignJWT } from "jose";
 import { Miniflare } from "miniflare";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -89,7 +88,6 @@ describe("CLI ApiClient agent JWT passthrough", () => {
   let sessionPrivKeyJwk: JsonWebKey;
   let leaderAgentId: string;
   let leaderSessionId: string;
-  let leaderSessionPrivateKey: CryptoKey;
 
   const savedEnv: Record<string, string | undefined> = {};
 
@@ -155,7 +153,6 @@ describe("CLI ApiClient agent JWT passthrough", () => {
     leaderAgentId = leaderAgent.id;
     leaderSessionId = randomUUID();
     const leaderKeypair = await crypto.subtle.generateKey({ name: "Ed25519" } as any, true, ["sign", "verify"]);
-    leaderSessionPrivateKey = (leaderKeypair as any).privateKey;
     const leaderPubJwk = await crypto.subtle.exportKey("jwk", (leaderKeypair as any).publicKey);
     const leaderSessionRes = await honoRequest(
       "POST",

--- a/tests/machine-agent-flow.test.ts
+++ b/tests/machine-agent-flow.test.ts
@@ -203,13 +203,10 @@ describe("machine → agent session flow", () => {
     taskId = task.id;
   });
 
-  it("leader agent self-assigns task via assign route", async () => {
+  it("leader agent self-assign is rejected (400)", async () => {
     const leaderJwt = await signLeaderSessionJWT();
     const res = await apiRequest("POST", `/api/tasks/${taskId}/assign`, {}, leaderJwt);
-    expect(res.status).toBe(200);
-    const task = (await res.json()) as any;
-    // Route assigns to the caller (leader agent), not a body-provided agent
-    expect(task.assigned_to).toBe(leaderAgentId);
+    expect(res.status).toBe(400);
   });
 
   it("agent claims the worker-assigned task via session JWT", async () => {

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -393,15 +393,21 @@ describe("routes", () => {
 
   // ─── Task Lifecycle ───
 
-  it("POST /api/tasks/:id/assign assigns a task to the calling leader agent", async () => {
+  it("POST /api/tasks/:id/assign assigns a task to a worker agent via machine", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Assign Task", board_id: boardId });
-    const leaderJwt = await signLeaderSessionJWT();
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/assign`, {}, leaderJwt);
+    const res = await apiRequest("POST", `/api/tasks/${task.id}/assign`, { agent_id: agentId }, apiKey);
     expect(res.status).toBe(200);
     const body = (await res.json()) as any;
-    // Route assigns to the calling agent (leader), not a body-provided agent_id
-    expect(body.assigned_to).toBe(leaderAgentId);
+    expect(body.assigned_to).toBe(agentId);
+  });
+
+  it("POST /api/tasks/:id/assign rejects leader agents (400)", async () => {
+    const { createTask } = await import("../apps/web/functions/api/taskRepo");
+    const task = await createTask(env.DB, userId, { title: "Leader Assign Task", board_id: boardId });
+    const leaderJwt = await signLeaderSessionJWT();
+    const res = await apiRequest("POST", `/api/tasks/${task.id}/assign`, {}, leaderJwt);
+    expect(res.status).toBe(400);
   });
 
   it("POST /api/tasks/:id/complete completes a task", async () => {
@@ -683,8 +689,7 @@ describe("routes", () => {
   it("POST /api/tasks/:id/assign triggers stale detection", async () => {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Assign Stale Task", board_id: boardId });
-    const leaderJwt = await signLeaderSessionJWT();
-    const res = await apiRequest("POST", `/api/tasks/${task.id}/assign`, { agent_id: agentId }, leaderJwt);
+    const res = await apiRequest("POST", `/api/tasks/${task.id}/assign`, { agent_id: agentId }, apiKey);
     expect(res.status).toBe(200);
   });
 });

--- a/tests/task-state-machine.test.ts
+++ b/tests/task-state-machine.test.ts
@@ -256,6 +256,7 @@ describe("task lifecycle repo functions", () => {
   let boardId: string;
   let testAgentId: string;
   let otherAgentId: string;
+  let leaderAgentId: string;
 
   async function createTestTask() {
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
@@ -276,6 +277,8 @@ describe("task lifecycle repo functions", () => {
     testAgentId = agent.id;
     const agent2 = await createAgent(env.DB, userId, { name: "SM Agent 2" });
     otherAgentId = agent2.id;
+    const leaderAgent = await createAgent(env.DB, userId, { name: "SM Leader Agent", kind: "leader" });
+    leaderAgentId = leaderAgent.id;
   });
 
   describe("claim", () => {
@@ -490,6 +493,19 @@ describe("task lifecycle repo functions", () => {
       const task = await createTestTask();
       await forceStatus(task.id, "done");
       await expect(assignTask(env.DB, task.id, testAgentId)).rejects.toThrow("todo");
+    });
+
+    it("rejects assign to leader agent", async () => {
+      const { assignTask } = await import("../apps/web/functions/api/taskRepo");
+      const task = await createTestTask();
+      await expect(assignTask(env.DB, task.id, leaderAgentId)).rejects.toThrow("Cannot assign tasks to leader agents");
+    });
+
+    it("rejects createTask with assigned_to leader agent", async () => {
+      const { createTask } = await import("../apps/web/functions/api/taskRepo");
+      await expect(createTask(env.DB, userId, { title: "Leader Task", board_id: boardId, assigned_to: leaderAgentId })).rejects.toThrow(
+        "Cannot assign tasks to leader agents",
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Added `assertAssignableWorkerAgent` validation helper in `taskRepo.ts` that rejects assignment to leader agents with a 400 error
- Called the validator in `createTask` (when `assigned_to` is set) and `assignTask`
- Updated `auth.ts` to allow machine identity on the assign endpoint, enabling machines to assign tasks to worker agents
- Updated `cli-agent-jwt.test.ts`, `machine-agent-flow.test.ts`, and `routes.test.ts` to use worker agents instead of leader agents for assignment
- Added new tests in `task-state-machine.test.ts` covering the rejection cases

## Test plan

- [x] `assignTask` rejects leader agents with "Cannot assign tasks to leader agents" (400)
- [x] `createTask` with `assigned_to` = leader agent rejects (400)
- [x] Machine identity can assign tasks to worker agents via the assign route
- [x] Leader agent self-assign returns 400
- [x] All 567 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)