### PR TITLE
Rename task_notes to task_actions with actor_type/actor_id

### DIFF
--- a/apps/web/functions/api/agentRepo.ts
+++ b/apps/web/functions/api/agentRepo.ts
@@ -74,7 +74,7 @@ export async function listAgents(db: D1, ownerId: string): Promise<AgentWithActi
     SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.kind, a.handoff_to, a.runtime, a.model, a.skills,
       a.public_key, a.fingerprint, a.builtin, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
-      (SELECT MAX(tl.created_at) FROM task_notes tl WHERE tl.agent_id = a.id) as last_active_at,
+      (SELECT MAX(tl.created_at) FROM task_actions tl WHERE tl.actor_id = a.id) as last_active_at,
       (SELECT COUNT(*) FROM tasks t WHERE t.assigned_to = a.id) as task_count,
       COALESCE((SELECT SUM(s.input_tokens) FROM agent_sessions s WHERE s.agent_id = a.id), 0) as input_tokens,
       COALESCE((SELECT SUM(s.output_tokens) FROM agent_sessions s WHERE s.agent_id = a.id), 0) as output_tokens,
@@ -96,7 +96,7 @@ export async function getAgent(db: D1, agentId: string, ownerId: string): Promis
     SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.kind, a.handoff_to, a.runtime, a.model, a.skills,
       a.public_key, a.fingerprint, a.builtin, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
-      (SELECT MAX(tl.created_at) FROM task_notes tl WHERE tl.agent_id = a.id) as last_active_at,
+      (SELECT MAX(tl.created_at) FROM task_actions tl WHERE tl.actor_id = a.id) as last_active_at,
       (SELECT COUNT(*) FROM tasks t WHERE t.assigned_to = a.id) as task_count,
       COALESCE((SELECT SUM(s.input_tokens) FROM agent_sessions s WHERE s.agent_id = a.id), 0) as input_tokens,
       COALESCE((SELECT SUM(s.output_tokens) FROM agent_sessions s WHERE s.agent_id = a.id), 0) as output_tokens,
@@ -149,7 +149,7 @@ export async function deleteAgent(db: D1, agentId: string): Promise<boolean> {
 export async function getAgentLogs(db: D1, agentId: string): Promise<any[]> {
   const result = await db
     .prepare(
-      "SELECT tl.*, t.title as task_title FROM task_notes tl JOIN tasks t ON tl.task_id = t.id WHERE tl.agent_id = ? ORDER BY tl.created_at DESC LIMIT 100",
+      "SELECT tl.*, t.title as task_title FROM task_actions tl JOIN tasks t ON tl.task_id = t.id WHERE tl.actor_id = ? ORDER BY tl.created_at DESC LIMIT 100",
     )
     .bind(agentId)
     .all();

--- a/apps/web/functions/api/boardSSE.ts
+++ b/apps/web/functions/api/boardSSE.ts
@@ -1,6 +1,6 @@
-import type { BoardNote } from "@agent-kanban/shared";
+import type { BoardAction } from "@agent-kanban/shared";
 import { createLogger } from "./logger";
-import { getBoardNotes } from "./taskRepo";
+import { getBoardActions } from "./taskRepo";
 import type { Env } from "./types";
 
 const INITIAL_LOOKBACK_MS = 5 * 60 * 1000;
@@ -26,7 +26,7 @@ export async function createBoardSSEResponse(env: Env, boardId: string, ownerId:
     return writer.write(encoder.encode(msg));
   };
 
-  const toEvent = (note: BoardNote): BoardSSEEvent => ({
+  const toEvent = (note: BoardAction): BoardSSEEvent => ({
     id: note.id,
     data: JSON.stringify(note),
     created_at: note.created_at,
@@ -35,7 +35,7 @@ export async function createBoardSSEResponse(env: Env, boardId: string, ownerId:
   const run = async () => {
     let lastSeen = new Date(Date.now() - INITIAL_LOOKBACK_MS).toISOString();
 
-    const initial = await getBoardNotes(db, boardId, ownerId, lastSeen);
+    const initial = await getBoardActions(db, boardId, ownerId, lastSeen);
     for (const note of initial) {
       await write(toEvent(note));
     }
@@ -48,7 +48,7 @@ export async function createBoardSSEResponse(env: Env, boardId: string, ownerId:
     while (Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 2000));
 
-      const notes = await getBoardNotes(db, boardId, ownerId, lastSeen);
+      const notes = await getBoardActions(db, boardId, ownerId, lastSeen);
       for (const note of notes) {
         await write(toEvent(note));
       }

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -13,7 +13,7 @@ import { createMessage, listMessages } from "./messageRepo";
 import { createRepository, deleteRepository, getRepository, listRepositories } from "./repositoryRepo";
 import { createSSEResponse } from "./sse";
 import {
-  addTaskNote,
+  addTaskAction,
   assignTask,
   cancelTask,
   claimTask,
@@ -21,7 +21,7 @@ import {
   createTask,
   deleteTask,
   getTask,
-  getTaskNotes,
+  getTaskActions,
   listTasks,
   rejectTask,
   releaseTask,
@@ -33,6 +33,15 @@ import type { Env } from "./types";
 
 const api = new Hono<{ Bindings: Env }>();
 const logger = createLogger("api");
+
+function resolveActor(c: { get: (key: string) => any }): { actorType: string; actorId: string } {
+  const identity: string = c.get("identityType") || "machine";
+  let actorId: string;
+  if (identity === "user") actorId = c.get("ownerId") || "unknown";
+  else if (identity === "machine") actorId = c.get("machineId") || c.get("apiKeyId") || "unknown";
+  else actorId = c.get("agentId") || "unknown";
+  return { actorType: identity, actorId };
+}
 
 // Access log
 api.use("*", async (c, next) => {
@@ -235,7 +244,8 @@ api.post("/api/tasks", async (c) => {
     throw new HTTPException(400, { message: "input must be a JSON object or null" });
   }
 
-  const task = await createTask(c.env.DB, c.get("ownerId"), { ...body, agentId: c.get("agentId") || null });
+  const { actorType, actorId } = resolveActor(c);
+  const task = await createTask(c.env.DB, c.get("ownerId"), { ...body, actorType, actorId });
   return c.json(task, 201);
 });
 
@@ -295,15 +305,15 @@ api.post("/api/tasks/:id/claim", async (c) => {
 
 api.post("/api/tasks/:id/complete", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as { result?: string; pr_url?: string };
-  const agentId = c.get("agentId") || null;
+  const { actorType, actorId } = resolveActor(c);
 
-  const task = await completeTask(c.env.DB, c.req.param("id"), agentId, body.result || null, body.pr_url || null, c.get("identityType"));
+  const task = await completeTask(c.env.DB, c.req.param("id"), actorType, actorId, body.result || null, body.pr_url || null, c.get("identityType"));
   return c.json(task);
 });
 
 api.post("/api/tasks/:id/release", async (c) => {
-  const agentId = c.get("agentId") || null;
-  const task = await releaseTask(c.env.DB, c.req.param("id"), agentId, c.get("identityType"));
+  const { actorType, actorId } = resolveActor(c);
+  const task = await releaseTask(c.env.DB, c.req.param("id"), actorType, actorId, c.get("identityType"));
   return c.json(task);
 });
 
@@ -317,29 +327,29 @@ api.post("/api/tasks/:id/assign", async (c) => {
     await detectAndReleaseStale(c.env.DB, existing.board_id);
   }
 
-  const task = await assignTask(c.env.DB, c.req.param("id"), targetAgentId);
+  const { actorType, actorId } = resolveActor(c);
+  const task = await assignTask(c.env.DB, c.req.param("id"), targetAgentId, actorType, actorId);
   return c.json(task);
 });
 
 api.post("/api/tasks/:id/cancel", async (c) => {
-  const agentId = c.get("agentId") || null;
-
-  const task = await cancelTask(c.env.DB, c.req.param("id"), agentId, c.get("identityType"));
+  const { actorType, actorId } = resolveActor(c);
+  const task = await cancelTask(c.env.DB, c.req.param("id"), actorType, actorId, c.get("identityType"));
   return c.json(task);
 });
 
 api.post("/api/tasks/:id/review", async (c) => {
   const body = (await c.req.json().catch(() => ({}))) as { pr_url?: string };
-  const agentId = c.get("agentId");
+  const { actorType, actorId } = resolveActor(c);
 
-  const task = await reviewTask(c.env.DB, c.req.param("id"), agentId ?? null, body.pr_url || null, c.get("identityType"));
+  const task = await reviewTask(c.env.DB, c.req.param("id"), actorType, actorId, body.pr_url || null, c.get("identityType"));
   return c.json(task);
 });
 
 api.post("/api/tasks/:id/reject", async (c) => {
-  const agentId = c.get("agentId") || null;
+  const { actorType, actorId } = resolveActor(c);
   const body = await c.req.json<{ reason?: string }>().catch(() => ({}) as { reason?: string });
-  const task = await rejectTask(c.env.DB, c.req.param("id"), agentId, c.get("identityType"), body.reason);
+  const task = await rejectTask(c.env.DB, c.req.param("id"), actorType, actorId, c.get("identityType"), body.reason);
   return c.json(task);
 });
 
@@ -352,9 +362,9 @@ api.post("/api/tasks/:id/notes", async (c) => {
   const task = await c.env.DB.prepare("SELECT id FROM tasks WHERE id = ?").bind(c.req.param("id")).first();
   if (!task) throw new HTTPException(404, { message: "Task not found" });
 
-  const agentId = c.get("agentId") || null;
-  const note = await addTaskNote(c.env.DB, c.req.param("id"), agentId || null, "commented", body.detail);
-  return c.json(note, 201);
+  const { actorType, actorId } = resolveActor(c);
+  const action = await addTaskAction(c.env.DB, c.req.param("id"), actorType, actorId, "commented", body.detail);
+  return c.json(action, 201);
 });
 
 api.get("/api/tasks/:id/notes", async (c) => {
@@ -362,8 +372,8 @@ api.get("/api/tasks/:id/notes", async (c) => {
   if (!task) throw new HTTPException(404, { message: "Task not found" });
 
   const since = c.req.query("since");
-  const notes = await getTaskNotes(c.env.DB, c.req.param("id"), since || undefined);
-  return c.json(notes);
+  const actions = await getTaskActions(c.env.DB, c.req.param("id"), since || undefined);
+  return c.json(actions);
 });
 
 // ─── Messages ───

--- a/apps/web/functions/api/sse.ts
+++ b/apps/web/functions/api/sse.ts
@@ -1,5 +1,5 @@
 import { listMessages } from "./messageRepo";
-import { getTaskNotes } from "./taskRepo";
+import { getTaskActions } from "./taskRepo";
 import type { Env } from "./types";
 
 interface SSEEvent {
@@ -29,7 +29,7 @@ export async function createSSEResponse(env: Env, taskId: string, lastEventId: s
   let since: string | undefined;
   if (lastEventId) {
     const ref = await db
-      .prepare("SELECT created_at FROM task_notes WHERE id = ? UNION SELECT created_at FROM messages WHERE id = ?")
+      .prepare("SELECT created_at FROM task_actions WHERE id = ? UNION SELECT created_at FROM messages WHERE id = ?")
       .bind(lastEventId, lastEventId)
       .first<{ created_at: string }>();
     if (!ref) {
@@ -58,7 +58,7 @@ export async function createSSEResponse(env: Env, taskId: string, lastEventId: s
   };
 
   const run = async () => {
-    const [initialNotes, initialMessages] = await Promise.all([getTaskNotes(db, taskId, since), listMessages(db, taskId, since)]);
+    const [initialNotes, initialMessages] = await Promise.all([getTaskActions(db, taskId, since), listMessages(db, taskId, since)]);
 
     const noteEvents: SSEEvent[] = (since ? initialNotes : initialNotes.slice(-50)).map((l) => ({
       id: l.id,
@@ -85,7 +85,7 @@ export async function createSSEResponse(env: Env, taskId: string, lastEventId: s
     while (Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, 2000));
 
-      const [newNotes, newMessages] = await Promise.all([getTaskNotes(db, taskId, lastSeen), listMessages(db, taskId, lastSeen)]);
+      const [newNotes, newMessages] = await Promise.all([getTaskActions(db, taskId, lastSeen), listMessages(db, taskId, lastSeen)]);
 
       const newNoteEvents = newNotes.map((l) => ({
         id: l.id,

--- a/apps/web/functions/api/taskRepo.ts
+++ b/apps/web/functions/api/taskRepo.ts
@@ -1,4 +1,4 @@
-import type { BoardNote, CreateTaskInput, IdentityType, Task, TaskNote, TaskStatus, TaskTransition, TaskWithNotes } from "@agent-kanban/shared";
+import type { BoardAction, CreateTaskInput, IdentityType, Task, TaskAction, TaskActionType, TaskStatus, TaskWithNotes } from "@agent-kanban/shared";
 import { validateTransition } from "@agent-kanban/shared";
 import { HTTPException } from "hono/http-exception";
 import { getDefaultBoard } from "./boardRepo";
@@ -7,8 +7,8 @@ import { computeBlocked, detectCycle, getDependencies, setDependencies } from ".
 
 const parseTask = <T extends Task>(row: T) => parseJsonFields(row, ["labels", "input"]);
 
-function enforceTransition(action: TaskTransition, currentStatus: TaskStatus, identity: IdentityType): void {
-  const error = validateTransition(action, currentStatus, identity);
+function enforceTransition(action: TaskActionType, currentStatus: TaskStatus, identity: IdentityType): void {
+  const error = validateTransition(action as any, currentStatus, identity);
   if (error) {
     const status = error.code === "FORBIDDEN" ? 403 : 409;
     throw new HTTPException(status, { message: error.message });
@@ -21,7 +21,13 @@ async function assertAssignableWorkerAgent(db: D1, agentId: string, missingStatu
   if (agent.kind === "leader") throw new HTTPException(400, { message: "Cannot assign tasks to leader agents" });
 }
 
-export async function createTask(db: D1, ownerId: string, input: CreateTaskInput & { agentId?: string; assigned_to?: string }): Promise<Task> {
+export async function createTask(
+  db: D1,
+  ownerId: string,
+  input: CreateTaskInput & { actorType?: string; actorId?: string; assigned_to?: string },
+): Promise<Task> {
+  const actorType = input.actorType ?? "machine";
+  const actorId = input.actorId ?? "system";
   const board = input.board_id ? { id: input.board_id } : await getDefaultBoard(db, ownerId);
 
   if (!board) throw new HTTPException(400, { message: "No board exists. Create a board first." });
@@ -66,7 +72,7 @@ export async function createTask(db: D1, ownerId: string, input: CreateTaskInput
         input.repository_id || null,
         labelsJson,
         input.priority || null,
-        input.agentId || "human",
+        actorId,
         input.assigned_to || null,
         inputJson,
         input.created_from || null,
@@ -75,15 +81,15 @@ export async function createTask(db: D1, ownerId: string, input: CreateTaskInput
         now,
       ),
     db
-      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'created', NULL, ?)")
-      .bind(logId, taskId, input.agentId || null, null, now),
+      .prepare("INSERT INTO task_actions (id, task_id, actor_type, actor_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'created', NULL, ?)")
+      .bind(logId, taskId, actorType, actorId, now),
     ...(input.assigned_to
       ? [
           db
             .prepare(
-              "INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)",
+              "INSERT INTO task_actions (id, task_id, actor_type, actor_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)",
             )
-            .bind(newLongId(), taskId, input.assigned_to, null, now),
+            .bind(newLongId(), taskId, actorType, actorId, now),
         ]
       : []),
     ...(input.depends_on || []).map((depId) => db.prepare("INSERT INTO task_dependencies (task_id, depends_on) VALUES (?, ?)").bind(taskId, depId)),
@@ -100,7 +106,7 @@ export async function createTask(db: D1, ownerId: string, input: CreateTaskInput
     repository_id: input.repository_id || null,
     labels: input.labels || null,
     priority: input.priority || null,
-    created_by: input.agentId || "human",
+    created_by: actorId,
     assigned_to: input.assigned_to || null,
     result: null,
     pr_url: null,
@@ -193,21 +199,21 @@ export async function getTask(db: D1, taskId: string): Promise<TaskWithNotes | n
   if (!task) return null;
   parseTask(task);
 
-  const [notes, deps, blockedSet] = await Promise.all([
+  const [actions, deps, blockedSet] = await Promise.all([
     db
       .prepare(
-        "SELECT n.*, a.name as agent_name, a.public_key as agent_public_key FROM task_notes n LEFT JOIN agents a ON n.agent_id = a.id WHERE n.task_id = ? ORDER BY n.created_at ASC",
+        "SELECT n.*, ag.name as actor_name, ag.public_key as actor_public_key FROM task_actions n LEFT JOIN agents ag ON n.actor_type LIKE 'agent:%' AND n.actor_id = ag.id WHERE n.task_id = ? ORDER BY n.created_at ASC",
       )
       .bind(taskId)
-      .all<TaskNote>(),
+      .all<TaskAction>(),
     getDependencies(db, taskId),
     computeBlocked(db, [taskId]),
   ]);
 
-  const duration = computeDuration(notes.results);
+  const duration = computeDuration(actions.results);
   task.blocked = blockedSet.has(taskId);
 
-  return { ...task, notes: notes.results, duration_minutes: duration, depends_on: deps, subtask_count: task.subtask_count };
+  return { ...task, notes: actions.results, duration_minutes: duration, depends_on: deps, subtask_count: task.subtask_count };
 }
 
 export async function updateTask(
@@ -271,7 +277,7 @@ export async function claimTask(db: D1, taskId: string, agentId: string, identit
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
   if (task.assigned_to !== agentId) throw new HTTPException(409, { message: "Task is not assigned to this agent" });
-  enforceTransition("claim", task.status as TaskStatus, identity);
+  enforceTransition("claim" as any, task.status as TaskStatus, identity);
 
   const now = new Date().toISOString();
   const logId = newLongId();
@@ -279,45 +285,46 @@ export async function claimTask(db: D1, taskId: string, agentId: string, identit
   await db.batch([
     db.prepare("UPDATE tasks SET status = 'in_progress', updated_at = ? WHERE id = ?").bind(now, taskId),
     db
-      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'claimed', NULL, ?)")
-      .bind(logId, taskId, agentId, null, now),
+      .prepare("INSERT INTO task_actions (id, task_id, actor_type, actor_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'claimed', NULL, ?)")
+      .bind(logId, taskId, identity, agentId, now),
   ]);
 
   return parseTask({ ...task, status: "in_progress" as const, updated_at: now });
 }
 
-export async function assignTask(db: D1, taskId: string, agentId: string): Promise<Task | null> {
+export async function assignTask(db: D1, taskId: string, targetAgentId: string, actorType: string, actorId: string): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
   if (task.status !== "todo") throw new HTTPException(409, { message: "Can only assign tasks in todo status" });
   if (task.assigned_to) throw new HTTPException(409, { message: "Task is already assigned" });
 
-  await assertAssignableWorkerAgent(db, agentId, 404);
+  await assertAssignableWorkerAgent(db, targetAgentId, 404);
 
   const now = new Date().toISOString();
   const logId = newLongId();
 
   await db.batch([
-    db.prepare("UPDATE tasks SET assigned_to = ?, updated_at = ? WHERE id = ? AND assigned_to IS NULL").bind(agentId, now, taskId),
+    db.prepare("UPDATE tasks SET assigned_to = ?, updated_at = ? WHERE id = ? AND assigned_to IS NULL").bind(targetAgentId, now, taskId),
     db
-      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)")
-      .bind(logId, taskId, agentId, null, now),
+      .prepare("INSERT INTO task_actions (id, task_id, actor_type, actor_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'assigned', NULL, ?)")
+      .bind(logId, taskId, actorType, actorId, now),
   ]);
 
-  return parseTask({ ...task, assigned_to: agentId, updated_at: now } as Task);
+  return parseTask({ ...task, assigned_to: targetAgentId, updated_at: now } as Task);
 }
 
 export async function completeTask(
   db: D1,
   taskId: string,
-  agentId: string | null,
+  actorType: string,
+  actorId: string,
   result: string | null,
   prUrl: string | null,
   identity: IdentityType,
 ): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
-  enforceTransition("complete", task.status as TaskStatus, identity);
+  enforceTransition("complete" as any, task.status as TaskStatus, identity);
 
   const now = new Date().toISOString();
   const logId = newLongId();
@@ -325,17 +332,17 @@ export async function completeTask(
   await db.batch([
     db.prepare("UPDATE tasks SET status = 'done', result = ?, pr_url = ?, updated_at = ? WHERE id = ?").bind(result, prUrl, now, taskId),
     db
-      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'completed', ?, ?)")
-      .bind(logId, taskId, agentId, null, result, now),
+      .prepare("INSERT INTO task_actions (id, task_id, actor_type, actor_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'completed', ?, ?)")
+      .bind(logId, taskId, actorType, actorId, result, now),
   ]);
 
   return parseTask({ ...task, status: "done" as const, result, pr_url: prUrl, updated_at: now });
 }
 
-export async function cancelTask(db: D1, taskId: string, agentId: string | null, identity: IdentityType): Promise<Task | null> {
+export async function cancelTask(db: D1, taskId: string, actorType: string, actorId: string, identity: IdentityType): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
-  enforceTransition("cancel", task.status as TaskStatus, identity);
+  enforceTransition("cancel" as any, task.status as TaskStatus, identity);
 
   const now = new Date().toISOString();
   const logId = newLongId();
@@ -343,17 +350,24 @@ export async function cancelTask(db: D1, taskId: string, agentId: string | null,
   await db.batch([
     db.prepare("UPDATE tasks SET status = 'cancelled', assigned_to = NULL, updated_at = ? WHERE id = ?").bind(now, taskId),
     db
-      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'cancelled', NULL, ?)")
-      .bind(logId, taskId, agentId, null, now),
+      .prepare("INSERT INTO task_actions (id, task_id, actor_type, actor_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'cancelled', NULL, ?)")
+      .bind(logId, taskId, actorType, actorId, now),
   ]);
 
   return parseTask({ ...task, status: "cancelled" as const, assigned_to: null, updated_at: now });
 }
 
-export async function reviewTask(db: D1, taskId: string, agentId: string | null, prUrl: string | null, identity: IdentityType): Promise<Task | null> {
+export async function reviewTask(
+  db: D1,
+  taskId: string,
+  actorType: string,
+  actorId: string,
+  prUrl: string | null,
+  identity: IdentityType,
+): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
-  enforceTransition("review", task.status as TaskStatus, identity);
+  enforceTransition("review" as any, task.status as TaskStatus, identity);
 
   const now = new Date().toISOString();
   const logId = newLongId();
@@ -362,9 +376,9 @@ export async function reviewTask(db: D1, taskId: string, agentId: string | null,
     db.prepare("UPDATE tasks SET status = 'in_review', pr_url = COALESCE(?, pr_url), updated_at = ? WHERE id = ?").bind(prUrl, now, taskId),
     db
       .prepare(
-        "INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'review_requested', NULL, ?)",
+        "INSERT INTO task_actions (id, task_id, actor_type, actor_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'review_requested', NULL, ?)",
       )
-      .bind(logId, taskId, agentId, null, now),
+      .bind(logId, taskId, actorType, actorId, now),
   ]);
 
   return parseTask({ ...task, status: "in_review" as const, pr_url: prUrl || task.pr_url, updated_at: now });
@@ -373,13 +387,14 @@ export async function reviewTask(db: D1, taskId: string, agentId: string | null,
 export async function releaseTask(
   db: D1,
   taskId: string,
-  agentId: string | null,
+  actorType: string,
+  actorId: string,
   identity: IdentityType,
   action: "released" | "timed_out" = "released",
 ): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
-  enforceTransition("release", task.status as TaskStatus, identity);
+  enforceTransition("release" as any, task.status as TaskStatus, identity);
 
   const now = new Date().toISOString();
   const logId = newLongId();
@@ -387,17 +402,24 @@ export async function releaseTask(
   await db.batch([
     db.prepare("UPDATE tasks SET status = 'todo', updated_at = ? WHERE id = ?").bind(now, taskId),
     db
-      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, NULL, ?)")
-      .bind(logId, taskId, agentId, null, action, now),
+      .prepare("INSERT INTO task_actions (id, task_id, actor_type, actor_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, NULL, ?)")
+      .bind(logId, taskId, actorType, actorId, action, now),
   ]);
 
   return parseTask({ ...task, status: "todo" as const, updated_at: now });
 }
 
-export async function rejectTask(db: D1, taskId: string, agentId: string | null, identity: IdentityType, reason?: string): Promise<Task | null> {
+export async function rejectTask(
+  db: D1,
+  taskId: string,
+  actorType: string,
+  actorId: string,
+  identity: IdentityType,
+  reason?: string,
+): Promise<Task | null> {
   const task = await db.prepare("SELECT * FROM tasks WHERE id = ?").bind(taskId).first<Task>();
   if (!task) return null;
-  enforceTransition("reject", task.status as TaskStatus, identity);
+  enforceTransition("reject" as any, task.status as TaskStatus, identity);
 
   const now = new Date().toISOString();
   const logId = newLongId();
@@ -405,38 +427,45 @@ export async function rejectTask(db: D1, taskId: string, agentId: string | null,
   await db.batch([
     db.prepare("UPDATE tasks SET status = 'in_progress', updated_at = ? WHERE id = ?").bind(now, taskId),
     db
-      .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'rejected', ?, ?)")
-      .bind(logId, taskId, agentId, null, reason || null, now),
+      .prepare("INSERT INTO task_actions (id, task_id, actor_type, actor_id, action, detail, created_at) VALUES (?, ?, ?, ?, 'rejected', ?, ?)")
+      .bind(logId, taskId, actorType, actorId, reason || null, now),
   ]);
 
   return parseTask({ ...task, status: "in_progress" as const, updated_at: now });
 }
 
-export async function addTaskNote(db: D1, taskId: string, agentId: string | null, action: string, detail: string | null): Promise<TaskNote> {
-  const noteId = newLongId();
+export async function addTaskAction(
+  db: D1,
+  taskId: string,
+  actorType: string,
+  actorId: string,
+  action: string,
+  detail: string | null,
+): Promise<TaskAction> {
+  const actionId = newLongId();
   const now = new Date().toISOString();
 
   await db
-    .prepare("INSERT INTO task_notes (id, task_id, agent_id, session_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)")
-    .bind(noteId, taskId, agentId, null, action, detail, now)
+    .prepare("INSERT INTO task_actions (id, task_id, actor_type, actor_id, action, detail, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)")
+    .bind(actionId, taskId, actorType, actorId, action, detail, now)
     .run();
 
   return {
-    id: noteId,
+    id: actionId,
     task_id: taskId,
-    agent_id: agentId,
-    agent_name: null,
-    agent_public_key: null,
-    session_id: null,
+    actor_type: actorType as any,
+    actor_id: actorId,
+    actor_name: null,
+    actor_public_key: null,
     action: action as any,
     detail,
     created_at: now,
   };
 }
 
-export async function getTaskNotes(db: D1, taskId: string, since?: string): Promise<TaskNote[]> {
+export async function getTaskActions(db: D1, taskId: string, since?: string): Promise<TaskAction[]> {
   let query =
-    "SELECT n.*, a.name as agent_name, a.public_key as agent_public_key FROM task_notes n LEFT JOIN agents a ON n.agent_id = a.id WHERE n.task_id = ?";
+    "SELECT n.*, ag.name as actor_name, ag.public_key as actor_public_key FROM task_actions n LEFT JOIN agents ag ON n.actor_type LIKE 'agent:%' AND n.actor_id = ag.id WHERE n.task_id = ?";
   const binds: unknown[] = [taskId];
 
   if (since) {
@@ -449,31 +478,31 @@ export async function getTaskNotes(db: D1, taskId: string, since?: string): Prom
   const result = await db
     .prepare(query)
     .bind(...binds)
-    .all<TaskNote>();
+    .all<TaskAction>();
   return result.results;
 }
 
-export async function getBoardNotes(db: D1, boardId: string, ownerId: string, since: string): Promise<BoardNote[]> {
+export async function getBoardActions(db: D1, boardId: string, ownerId: string, since: string): Promise<BoardAction[]> {
   const result = await db
     .prepare(`
-      SELECT n.*, a.name as agent_name, a.public_key as agent_public_key, a.kind as agent_kind
-      FROM task_notes n
+      SELECT n.*, ag.name as actor_name, ag.public_key as actor_public_key, ag.kind as agent_kind
+      FROM task_actions n
       JOIN tasks t ON n.task_id = t.id
       JOIN boards b ON t.board_id = b.id
-      LEFT JOIN agents a ON n.agent_id = a.id
+      LEFT JOIN agents ag ON n.actor_type LIKE 'agent:%' AND n.actor_id = ag.id
       WHERE t.board_id = ? AND b.owner_id = ? AND n.created_at > ?
       ORDER BY n.created_at ASC
       LIMIT 100
     `)
     .bind(boardId, ownerId, since)
-    .all<BoardNote>();
+    .all<BoardAction>();
   return result.results;
 }
 
-function computeDuration(notes: TaskNote[]): number | null {
-  const claimed = notes.find((l) => l.action === "claimed");
+function computeDuration(actions: TaskAction[]): number | null {
+  const claimed = actions.find((l) => l.action === "claimed");
   if (!claimed) return null;
-  const end = notes.find((l) => l.action === "completed" || l.action === "cancelled");
+  const end = actions.find((l) => l.action === "completed" || l.action === "cancelled");
   if (!end) return null;
   return Math.round((new Date(end.created_at).getTime() - new Date(claimed.created_at).getTime()) / 60000);
 }

--- a/apps/web/functions/api/taskStale.ts
+++ b/apps/web/functions/api/taskStale.ts
@@ -10,13 +10,13 @@ export async function detectAndReleaseStale(db: D1, boardId: string): Promise<vo
     SELECT t.id, t.assigned_to FROM tasks t
     WHERE t.board_id = ? AND t.status IN ('in_progress', 'in_review') AND t.assigned_to IS NOT NULL
     AND (
-      SELECT MAX(tl.created_at) FROM task_notes tl WHERE tl.task_id = t.id
+      SELECT MAX(tl.created_at) FROM task_actions tl WHERE tl.task_id = t.id
     ) < ?
   `)
     .bind(boardId, cutoff)
     .all<{ id: string; assigned_to: string }>();
 
   for (const stale of staleTasks.results) {
-    await releaseTask(db, stale.id, stale.assigned_to, "machine", "timed_out");
+    await releaseTask(db, stale.id, "machine", "system", "machine", "timed_out");
   }
 }

--- a/apps/web/migrations/0004_rename_task_notes_to_task_actions.sql
+++ b/apps/web/migrations/0004_rename_task_notes_to_task_actions.sql
@@ -1,0 +1,26 @@
+-- Create new table
+CREATE TABLE task_actions (
+  id          TEXT PRIMARY KEY,
+  task_id     TEXT NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+  actor_type  TEXT NOT NULL CHECK(actor_type IN ('user', 'machine', 'agent:worker', 'agent:leader')),
+  actor_id    TEXT NOT NULL,
+  action      TEXT NOT NULL CHECK(action IN (
+    'created', 'claimed', 'moved', 'commented', 'completed',
+    'assigned', 'released', 'timed_out', 'cancelled', 'rejected', 'review_requested'
+  )),
+  detail      TEXT,
+  created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX idx_task_actions_task ON task_actions(task_id, created_at);
+CREATE INDEX idx_task_actions_actor ON task_actions(actor_id);
+
+-- Migrate data from task_notes
+INSERT INTO task_actions (id, task_id, actor_type, actor_id, action, detail, created_at)
+SELECT id, task_id,
+  CASE WHEN agent_id IS NOT NULL THEN 'agent:worker' ELSE 'machine' END,
+  COALESCE(agent_id, 'system'),
+  action, detail, created_at
+FROM task_notes;
+
+-- Drop old table
+DROP TABLE task_notes;

--- a/apps/web/src/components/ActivityLog.tsx
+++ b/apps/web/src/components/ActivityLog.tsx
@@ -36,39 +36,41 @@ const dotColors: Record<string, string> = {
 };
 
 function buildSentence(log: any): { prefix: string; actionText: string; suffix: string } {
-  const name = log.agent_name || null;
+  const name = log.actor_name || null;
+  const isAgent = log.actor_type?.startsWith("agent:");
+  const defaultPrefix = isAgent ? "Agent" : log.actor_type === "user" ? "User" : "System";
 
   switch (log.action) {
     case "claimed":
-      return { prefix: name ?? "Agent", actionText: "claimed this task", suffix: "" };
+      return { prefix: name ?? defaultPrefix, actionText: "claimed this task", suffix: "" };
     case "assigned":
-      return { prefix: "System", actionText: "assigned to", suffix: name ?? log.detail ?? "agent" };
+      return { prefix: name ?? "System", actionText: "assigned to", suffix: log.detail ?? "agent" };
     case "completed":
-      return { prefix: name ?? "Agent", actionText: "completed this task", suffix: log.detail ? `— ${log.detail}` : "" };
+      return { prefix: name ?? defaultPrefix, actionText: "completed this task", suffix: log.detail ? `— ${log.detail}` : "" };
     case "released":
-      return { prefix: name ?? "Agent", actionText: "released this task", suffix: "" };
+      return { prefix: name ?? defaultPrefix, actionText: "released this task", suffix: "" };
     case "timed_out":
-      return { prefix: name ?? "Agent", actionText: "timed out", suffix: "" };
+      return { prefix: name ?? defaultPrefix, actionText: "timed out", suffix: "" };
     case "cancelled":
       return { prefix: name ?? "System", actionText: "cancelled this task", suffix: log.detail ? `— ${log.detail}` : "" };
     case "rejected":
       return { prefix: name ?? "Reviewer", actionText: "rejected — sent back to agent", suffix: log.detail ? `(${log.detail})` : "" };
     case "review_requested":
-      return { prefix: name ?? "Agent", actionText: "submitted for review", suffix: "" };
+      return { prefix: name ?? defaultPrefix, actionText: "submitted for review", suffix: "" };
     case "created":
       return { prefix: "System", actionText: "created this task", suffix: "" };
     case "moved":
       return { prefix: "System", actionText: "moved", suffix: log.detail ?? "" };
     case "commented":
-      return { prefix: name ?? "Agent", actionText: "commented", suffix: "" };
+      return { prefix: name ?? defaultPrefix, actionText: "commented", suffix: "" };
     default:
       return { prefix: name ?? "System", actionText: log.action, suffix: log.detail ?? "" };
   }
 }
 
-function NoteAvatar({ agentId, agentPublicKey }: { agentId: string | null; agentPublicKey: string | null }) {
-  if (agentId && agentPublicKey) {
-    return <AgentIdenticon publicKey={agentPublicKey} size={20} />;
+function NoteAvatar({ actorType, actorPublicKey }: { actorType: string | null; actorPublicKey: string | null }) {
+  if (actorType?.startsWith("agent:") && actorPublicKey) {
+    return <AgentIdenticon publicKey={actorPublicKey} size={20} />;
   }
   return (
     <span className="flex-shrink-0 w-5 h-5 rounded-full bg-zinc-500/10 border border-zinc-500/20 flex items-center justify-center">
@@ -139,7 +141,7 @@ export function ActivityLog({ initialNotes, sseNotes, reconnecting }: ActivityLo
 
           {displayed.map((log: any) => {
             const { prefix, actionText, suffix } = buildSentence(log);
-            const isAgent = !!log.agent_id && !!log.agent_public_key;
+            const isAgent = log.actor_type?.startsWith("agent:") && !!log.actor_public_key;
             const dot = dotColors[log.action] || "bg-zinc-500 border-zinc-500/30";
             const actionColor = actionStyles[log.action] || "text-content-secondary";
             const isComment = log.action === "commented";
@@ -150,7 +152,7 @@ export function ActivityLog({ initialNotes, sseNotes, reconnecting }: ActivityLo
                 <span className={`absolute left-0 -translate-x-1/2 mt-[3px] w-2 h-2 rounded-full border ${dot}`} style={{ top: "4px" }} />
 
                 <div className="flex items-center gap-1.5 flex-wrap">
-                  <NoteAvatar agentId={log.agent_id} agentPublicKey={log.agent_public_key} />
+                  <NoteAvatar actorType={log.actor_type} actorPublicKey={log.actor_public_key} />
 
                   {/* Sentence: prefix (agent name) + action + suffix */}
                   <span className="text-[12px] leading-snug">

--- a/apps/web/src/hooks/useAgentPresence.ts
+++ b/apps/web/src/hooks/useAgentPresence.ts
@@ -1,4 +1,4 @@
-import type { BoardNote, Task, TaskAction } from "@agent-kanban/shared";
+import type { BoardAction, Task, TaskActionType } from "@agent-kanban/shared";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { liftCard, resetCard, slideCard } from "../lib/cardEffects";
@@ -16,7 +16,7 @@ export interface AgentAvatar {
 
 // ─── Choreography definitions ───
 
-const DRAG_TARGETS: Partial<Record<TaskAction, string>> = {
+const DRAG_TARGETS: Partial<Record<TaskActionType, string>> = {
   claimed: "in_progress",
   review_requested: "in_review",
   completed: "done",
@@ -52,7 +52,7 @@ const MOVE_SEQUENCE: ChoreographyStep[] = [
   { delay: 2100, remove: true },
 ];
 
-function getSequence(action: TaskAction): ChoreographyStep[] | null {
+function getSequence(action: TaskActionType): ChoreographyStep[] | null {
   if (action === "claimed") return CLAIM_SEQUENCE;
   if (action === "review_requested" || action === "completed" || action === "rejected" || action === "cancelled") return MOVE_SEQUENCE;
   return null;
@@ -77,12 +77,12 @@ export function useAgentPresence(boardId: string | undefined, tasks: Task[]) {
   }, []);
 
   const runChoreography = useCallback(
-    (event: BoardNote, sequence: ChoreographyStep[]) => {
-      const agentId = event.agent_id!;
+    (event: BoardAction, sequence: ChoreographyStep[]) => {
+      const actorId = event.actor_id;
       const taskId = event.task_id;
       const target = DRAG_TARGETS[event.action] || "";
 
-      cancelChoreography(agentId);
+      cancelChoreography(actorId);
       const scheduled: ReturnType<typeof setTimeout>[] = [];
 
       for (const step of sequence) {
@@ -91,16 +91,16 @@ export function useAgentPresence(boardId: string | undefined, tasks: Task[]) {
             setAvatars((prev) => {
               const next = new Map(prev);
               if (step.phase === "spawning" || step.phase === "emerging") {
-                next.set(agentId, {
-                  agentId,
-                  agentName: event.agent_name,
-                  publicKey: event.agent_public_key!,
+                next.set(actorId, {
+                  agentId: actorId,
+                  agentName: event.actor_name ?? null,
+                  publicKey: event.actor_public_key!,
                   taskId,
                   phase: step.phase!,
                 });
               } else {
-                const a = next.get(agentId);
-                if (a) next.set(agentId, { ...a, phase: step.phase! });
+                const a = next.get(actorId);
+                if (a) next.set(actorId, { ...a, phase: step.phase! });
               }
               return next;
             });
@@ -109,10 +109,10 @@ export function useAgentPresence(boardId: string | undefined, tasks: Task[]) {
           if (step.remove) {
             setAvatars((prev) => {
               const next = new Map(prev);
-              next.delete(agentId);
+              next.delete(actorId);
               return next;
             });
-            timersRef.current.delete(agentId);
+            timersRef.current.delete(actorId);
           }
           if (step.invalidate) {
             queryClient.invalidateQueries({ queryKey: ["board", boardId] });
@@ -121,7 +121,7 @@ export function useAgentPresence(boardId: string | undefined, tasks: Task[]) {
         scheduled.push(timer);
       }
 
-      timersRef.current.set(agentId, scheduled);
+      timersRef.current.set(actorId, scheduled);
     },
     [boardId, cancelChoreography, queryClient],
   );
@@ -153,7 +153,7 @@ export function useAgentPresence(boardId: string | undefined, tasks: Task[]) {
     processedRef.current = events.length;
 
     for (const event of unprocessed) {
-      if (!event.agent_id || !event.agent_public_key) continue;
+      if (!event.actor_type?.startsWith("agent:") || !event.actor_public_key) continue;
       const sequence = getSequence(event.action);
       if (sequence) runChoreography(event, sequence);
     }

--- a/apps/web/src/hooks/useBoardSSE.ts
+++ b/apps/web/src/hooks/useBoardSSE.ts
@@ -1,11 +1,11 @@
-import type { BoardNote } from "@agent-kanban/shared";
+import type { BoardAction } from "@agent-kanban/shared";
 import { useEffect, useRef, useState } from "react";
 import { getAuthToken } from "../lib/auth-client";
 
 const MAX_EVENTS = 50;
 
 export function useBoardSSE(boardId: string | undefined) {
-  const [events, setEvents] = useState<BoardNote[]>([]);
+  const [events, setEvents] = useState<BoardAction[]>([]);
   const [connected, setConnected] = useState(false);
   const esRef = useRef<EventSource | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -29,7 +29,7 @@ export function useBoardSSE(boardId: string | undefined) {
       };
 
       es.addEventListener("board_note", (e: MessageEvent) => {
-        const note: BoardNote = JSON.parse(e.data);
+        const note: BoardAction = JSON.parse(e.data);
         setEvents((prev) => {
           if (prev.some((existing) => existing.id === note.id)) return prev;
           const next = [...prev, note];

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -48,28 +48,10 @@ export interface TaskWithMeta extends Task {
 }
 
 export interface TaskWithNotes extends TaskWithMeta {
-  notes: TaskNote[];
+  notes: TaskAction[];
 }
 
-export interface TaskNote {
-  id: string;
-  task_id: string;
-  agent_id: string | null;
-  agent_name: string | null;
-  agent_public_key: string | null;
-  session_id: string | null;
-  action: TaskAction;
-  detail: string | null;
-  created_at: string;
-}
-
-export interface BoardNote extends TaskNote {
-  agent_kind: AgentKind | null;
-}
-
-export type Priority = "low" | "medium" | "high" | "urgent";
-
-export type TaskAction =
+export type TaskActionType =
   | "created"
   | "claimed"
   | "moved"
@@ -81,6 +63,26 @@ export type TaskAction =
   | "cancelled"
   | "rejected"
   | "review_requested";
+
+export type ActorType = "user" | "machine" | "agent:worker" | "agent:leader";
+
+export interface TaskAction {
+  id: string;
+  task_id: string;
+  actor_type: ActorType;
+  actor_id: string;
+  actor_name?: string | null;
+  actor_public_key?: string | null;
+  action: TaskActionType;
+  detail: string | null;
+  created_at: string;
+}
+
+export interface BoardAction extends TaskAction {
+  agent_kind?: AgentKind | null;
+}
+
+export type Priority = "low" | "medium" | "high" | "urgent";
 
 // ─── Machine ───
 

--- a/tests/agent-auth.test.ts
+++ b/tests/agent-auth.test.ts
@@ -18,7 +18,7 @@ let db: D1Database;
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql", "0004_rename_task_notes_to_task_actions.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     const statements = sql

--- a/tests/agent-json-fields.test.ts
+++ b/tests/agent-json-fields.test.ts
@@ -11,7 +11,7 @@ let db: D1Database;
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql", "0004_rename_task_notes_to_task_actions.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/agent-redesign.test.ts
+++ b/tests/agent-redesign.test.ts
@@ -30,7 +30,7 @@ const env = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql", "0004_rename_task_notes_to_task_actions.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql
@@ -409,21 +409,21 @@ describe("user assigns task to agent", () => {
 
   it("assigns task via repo function", async () => {
     const { assignTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await assignTask(env.DB, taskId, agentId);
+    const task = await assignTask(env.DB, taskId, agentId, "machine", "system");
     expect(task!.assigned_to).toBe(agentId);
     expect(task!.status).toBe("todo"); // assign doesn't change status
   });
 
   it("task logs record assignment with persistent agent ID", async () => {
-    const logs = await env.DB.prepare("SELECT * FROM task_notes WHERE task_id = ? AND action = 'assigned'").bind(taskId).all();
+    const logs = await env.DB.prepare("SELECT * FROM task_actions WHERE task_id = ? AND action = 'assigned'").bind(taskId).all();
     expect(logs.results.length).toBe(1);
-    expect((logs.results[0] as any).agent_id).toBe(agentId);
+    expect((logs.results[0] as any).actor_id).toBe("system");
   });
 
   it("release resets status from in_progress to todo", async () => {
     const { claimTask, releaseTask } = await import("../apps/web/functions/api/taskRepo");
     await claimTask(env.DB, taskId, agentId, "agent:worker");
-    const task = await releaseTask(env.DB, taskId, agentId, "machine");
+    const task = await releaseTask(env.DB, taskId, "machine", "system", "machine");
     expect(task!.status).toBe("todo");
   });
 });

--- a/tests/boardSSE.test.ts
+++ b/tests/boardSSE.test.ts
@@ -25,7 +25,7 @@ afterAll(async () => {
   await mf.dispose();
 });
 
-describe("getBoardNotes", () => {
+describe("getBoardActions", () => {
   const userId = "board-sse-unit-user";
   let boardId: string;
   let agentId: string;
@@ -43,35 +43,35 @@ describe("getBoardNotes", () => {
     agentId = agent.id;
 
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
-    const task = await createTask(env.DB, userId, { title: "SSE Unit Task", board_id: boardId, agentId });
+    const task = await createTask(env.DB, userId, { title: "SSE Unit Task", board_id: boardId, actorType: "agent:worker", actorId: agentId });
     taskId = task.id;
   });
 
-  it("returns notes for a board with agent_public_key populated", async () => {
+  it("returns notes for a board with actor_public_key populated", async () => {
     const since = new Date(Date.now() - 60 * 1000).toISOString();
-    const { getBoardNotes } = await import("../apps/web/functions/api/taskRepo");
-    const notes = await getBoardNotes(env.DB, boardId, userId, since);
+    const { getBoardActions } = await import("../apps/web/functions/api/taskRepo");
+    const notes = await getBoardActions(env.DB, boardId, userId, since);
 
     expect(notes.length).toBeGreaterThan(0);
     const note = notes[0];
     expect(note.task_id).toBe(taskId);
-    expect(note.agent_public_key).toBeTruthy();
+    expect(note.actor_public_key).toBeTruthy();
   });
 
   it("returns notes with agent_kind populated", async () => {
     const since = new Date(Date.now() - 60 * 1000).toISOString();
-    const { getBoardNotes } = await import("../apps/web/functions/api/taskRepo");
-    const notes = await getBoardNotes(env.DB, boardId, userId, since);
+    const { getBoardActions } = await import("../apps/web/functions/api/taskRepo");
+    const notes = await getBoardActions(env.DB, boardId, userId, since);
 
-    const note = notes.find((n) => n.agent_id === agentId);
+    const note = notes.find((n) => n.actor_id === agentId);
     expect(note).toBeDefined();
     expect(note!.agent_kind).toBe("worker");
   });
 
   it("returns empty array when no notes exist after since timestamp", async () => {
     const future = new Date(Date.now() + 60 * 1000).toISOString();
-    const { getBoardNotes } = await import("../apps/web/functions/api/taskRepo");
-    const notes = await getBoardNotes(env.DB, boardId, userId, future);
+    const { getBoardActions } = await import("../apps/web/functions/api/taskRepo");
+    const notes = await getBoardActions(env.DB, boardId, userId, future);
 
     expect(notes).toEqual([]);
   });
@@ -84,8 +84,8 @@ describe("getBoardNotes", () => {
     await createTask(env.DB, userId, { title: "Other Board Task", board_id: otherBoard.id });
 
     const since = new Date(Date.now() - 60 * 1000).toISOString();
-    const { getBoardNotes } = await import("../apps/web/functions/api/taskRepo");
-    const notes = await getBoardNotes(env.DB, boardId, userId, since);
+    const { getBoardActions } = await import("../apps/web/functions/api/taskRepo");
+    const notes = await getBoardActions(env.DB, boardId, userId, since);
 
     const ids = notes.map((n) => n.task_id);
     const otherTasks = await env.DB.prepare("SELECT id FROM tasks WHERE board_id = ?").bind(otherBoard.id).all<{ id: string }>();
@@ -94,17 +94,17 @@ describe("getBoardNotes", () => {
     }
   });
 
-  it("returns null agent_public_key for notes without an agent", async () => {
-    const { createTask, getBoardNotes } = await import("../apps/web/functions/api/taskRepo");
+  it("returns null actor_public_key for notes without an agent actor", async () => {
+    const { createTask, getBoardActions } = await import("../apps/web/functions/api/taskRepo");
     const since = new Date(Date.now() - 1).toISOString();
-    // Create a task with no agentId — the created note has no agent_id
+    // Create a task with no agentId — the created action has actor_type 'machine'
     await createTask(env.DB, userId, { title: "No Agent Task", board_id: boardId });
 
-    const notes = await getBoardNotes(env.DB, boardId, userId, since);
-    const noAgentNote = notes.find((n) => n.agent_id === null || n.agent_id === "human");
-    if (noAgentNote) {
-      expect(noAgentNote.agent_public_key).toBeNull();
-      expect(noAgentNote.agent_kind).toBeNull();
+    const notes = await getBoardActions(env.DB, boardId, userId, since);
+    const machineNote = notes.find((n) => n.actor_type === "machine");
+    if (machineNote) {
+      expect(machineNote.actor_public_key).toBeNull();
+      expect(machineNote.agent_kind).toBeNull();
     }
   });
 });
@@ -146,7 +146,7 @@ describe("GET /api/boards/:id/stream", () => {
     const agent = await createAgent(env.DB, userId, { name: "SSE Route Agent", runtime: "Claude Code" });
 
     const { createTask } = await import("../apps/web/functions/api/taskRepo");
-    await createTask(env.DB, userId, { title: "SSE Stream Task", board_id: boardId, agentId: agent.id });
+    await createTask(env.DB, userId, { title: "SSE Stream Task", board_id: boardId, actorType: "agent:worker", actorId: agent.id });
 
     const res = await apiRequest("GET", `/api/boards/${boardId}/stream`, undefined, apiKey);
     expect(res.body).not.toBeNull();

--- a/tests/builtin-agents.test.ts
+++ b/tests/builtin-agents.test.ts
@@ -20,7 +20,7 @@ const env = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql", "0004_rename_task_notes_to_task_actions.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/cli-agent-jwt.test.ts
+++ b/tests/cli-agent-jwt.test.ts
@@ -24,7 +24,7 @@ const testEnv = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql", "0004_rename_task_notes_to_task_actions.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql
@@ -171,7 +171,7 @@ describe("CLI ApiClient agent JWT passthrough", () => {
     taskId = task.id;
 
     // Assign task to the worker agent so the worker can claim it in subsequent tests
-    await assignTask(testEnv.DB, taskId, agentId);
+    await assignTask(testEnv.DB, taskId, agentId, "machine", "system");
   });
 
   it("ApiClient constructs valid session JWT that server accepts for claim", async () => {

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -15,7 +15,7 @@ export function createTestEnv() {
 }
 
 export async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql", "0004_rename_task_notes_to_task_actions.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/machine-agent-flow.test.ts
+++ b/tests/machine-agent-flow.test.ts
@@ -25,7 +25,7 @@ const env = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql", "0004_rename_task_notes_to_task_actions.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql
@@ -213,7 +213,7 @@ describe("machine → agent session flow", () => {
     // Re-assign the task to the worker agent directly via repo so the worker can claim it
     const { assignTask } = await import("../apps/web/functions/api/taskRepo");
     await env.DB.prepare("UPDATE tasks SET status = 'todo', assigned_to = NULL WHERE id = ?").bind(taskId).run();
-    await assignTask(env.DB, taskId, agentId);
+    await assignTask(env.DB, taskId, agentId, "machine", "system");
 
     const jwt = await signSessionJWT();
     const res = await apiRequest("POST", `/api/tasks/${taskId}/claim`, { agent_id: agentId }, jwt);
@@ -285,7 +285,7 @@ describe("machine → agent session flow", () => {
     expect(task.status).toBe("in_review");
     expect(task.assigned_to).toBe(agentId);
 
-    const logs = await env.DB.prepare("SELECT action FROM task_notes WHERE task_id = ? ORDER BY created_at").bind(taskId).all();
+    const logs = await env.DB.prepare("SELECT action FROM task_actions WHERE task_id = ? ORDER BY created_at").bind(taskId).all();
     const actions = logs.results.map((r: any) => r.action);
     expect(actions).toContain("created");
     expect(actions).toContain("assigned");

--- a/tests/machine-usage.test.ts
+++ b/tests/machine-usage.test.ts
@@ -12,7 +12,7 @@ let db: D1Database;
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql", "0004_rename_task_notes_to_task_actions.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -434,7 +434,7 @@ describe("routes", () => {
   it("POST /api/tasks/:id/release releases a task", async () => {
     const { createTask, assignTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Release Task", board_id: boardId });
-    await assignTask(env.DB, task.id, agentId);
+    await assignTask(env.DB, task.id, agentId, "machine", "system");
     await env.DB.prepare("UPDATE tasks SET status = 'in_progress' WHERE id = ?").bind(task.id).run();
     const res = await apiRequest("POST", `/api/tasks/${task.id}/release`, {}, apiKey);
     expect(res.status).toBe(200);
@@ -489,9 +489,9 @@ describe("routes", () => {
   });
 
   it("GET /api/tasks/:id/notes returns notes", async () => {
-    const { createTask, addTaskNote } = await import("../apps/web/functions/api/taskRepo");
+    const { createTask, addTaskAction } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Get Notes Task", board_id: boardId });
-    await addTaskNote(env.DB, task.id, null, "commented", "Test note");
+    await addTaskAction(env.DB, task.id, "machine", "system", "commented", "Test note");
     const res = await apiRequest("GET", `/api/tasks/${task.id}/notes`, undefined, apiKey);
     expect(res.status).toBe(200);
     const body = (await res.json()) as any;
@@ -678,7 +678,7 @@ describe("routes", () => {
 
     const { createTask, assignTask } = await import("../apps/web/functions/api/taskRepo");
     const task = await createTask(env.DB, userId, { title: "Agent Claim Task", board_id: boardId });
-    await assignTask(env.DB, task.id, agentId);
+    await assignTask(env.DB, task.id, agentId, "machine", "system");
     const jwt = await signSessionJWT();
     const res = await apiRequest("POST", `/api/tasks/${task.id}/claim`, {}, jwt);
     expect(res.status).toBe(200);

--- a/tests/sse.test.ts
+++ b/tests/sse.test.ts
@@ -59,9 +59,9 @@ describe("createSSEResponse", () => {
   });
 
   it("streams initial logs as SSE events", async () => {
-    const { addTaskNote } = await import("../apps/web/functions/api/taskRepo");
-    await addTaskNote(env.DB, taskId, null, "commented", "Log entry 1");
-    await addTaskNote(env.DB, taskId, null, "commented", "Log entry 2");
+    const { addTaskAction } = await import("../apps/web/functions/api/taskRepo");
+    await addTaskAction(env.DB, taskId, "machine", "system", "commented", "Log entry 1");
+    await addTaskAction(env.DB, taskId, "machine", "system", "commented", "Log entry 2");
 
     const { createSSEResponse } = await import("../apps/web/functions/api/sse");
     const response = await createSSEResponse(env as any, taskId, null);
@@ -87,14 +87,14 @@ describe("createSSEResponse", () => {
   });
 
   it("resumes from lastEventId", async () => {
-    const { addTaskNote, getTaskNotes } = await import("../apps/web/functions/api/taskRepo");
-    await addTaskNote(env.DB, taskId, null, "commented", "Before resume");
-    const logsBeforeResume = await getTaskNotes(env.DB, taskId);
+    const { addTaskAction, getTaskActions } = await import("../apps/web/functions/api/taskRepo");
+    await addTaskAction(env.DB, taskId, "machine", "system", "commented", "Before resume");
+    const logsBeforeResume = await getTaskActions(env.DB, taskId);
     const lastLogId = logsBeforeResume[logsBeforeResume.length - 1].id;
 
     // Small delay to ensure distinct timestamp in D1 (millisecond resolution)
     await new Promise((r) => setTimeout(r, 50));
-    await addTaskNote(env.DB, taskId, null, "commented", "After resume");
+    await addTaskAction(env.DB, taskId, "machine", "system", "commented", "After resume");
 
     const { createSSEResponse } = await import("../apps/web/functions/api/sse");
     const response = await createSSEResponse(env as any, taskId, lastLogId);
@@ -122,7 +122,7 @@ describe("createSSEResponse", () => {
   });
 
   it("merges logs and messages by time order", async () => {
-    const { createTask, addTaskNote } = await import("../apps/web/functions/api/taskRepo");
+    const { createTask, addTaskAction } = await import("../apps/web/functions/api/taskRepo");
     const { createMessage } = await import("../apps/web/functions/api/messageRepo");
     const mergeTask = await createTask(env.DB, "sse-user", {
       title: "Merge SSE Task",
@@ -132,7 +132,7 @@ describe("createSSEResponse", () => {
     await createMessage(env.DB, mergeTask.id, "user", "sse-user", "Message first");
     // Small delay to ensure distinct timestamp in D1 (millisecond resolution)
     await new Promise((r) => setTimeout(r, 50));
-    await addTaskNote(env.DB, mergeTask.id, null, "commented", "Log second");
+    await addTaskAction(env.DB, mergeTask.id, "machine", "system", "commented", "Log second");
 
     const { createSSEResponse } = await import("../apps/web/functions/api/sse");
     const response = await createSSEResponse(env as any, mergeTask.id, null);
@@ -149,14 +149,14 @@ describe("createSSEResponse", () => {
   });
 
   it("poll loop picks up new events after initial batch", async () => {
-    const { createTask, addTaskNote } = await import("../apps/web/functions/api/taskRepo");
+    const { createTask, addTaskAction } = await import("../apps/web/functions/api/taskRepo");
     const pollTask = await createTask(env.DB, "sse-user", {
       title: "Poll SSE Task",
       board_id: boardId,
     });
 
     setTimeout(async () => {
-      await addTaskNote(env.DB, pollTask.id, null, "commented", "Polled event from loop");
+      await addTaskAction(env.DB, pollTask.id, "machine", "system", "commented", "Polled event from loop");
     }, 500);
 
     const { createSSEResponse } = await import("../apps/web/functions/api/sse");
@@ -188,14 +188,14 @@ describe("createSSEResponse", () => {
   });
 
   it("limits initial events to 50 per type", async () => {
-    const { createTask, addTaskNote } = await import("../apps/web/functions/api/taskRepo");
+    const { createTask, addTaskAction } = await import("../apps/web/functions/api/taskRepo");
     const bigTask = await createTask(env.DB, "sse-user", {
       title: "Big SSE Task",
       board_id: boardId,
     });
 
     for (let i = 0; i < 55; i++) {
-      await addTaskNote(env.DB, bigTask.id, null, "commented", `Bulk log ${i}`);
+      await addTaskAction(env.DB, bigTask.id, "machine", "system", "commented", `Bulk log ${i}`);
     }
 
     const { createSSEResponse } = await import("../apps/web/functions/api/sse");

--- a/tests/task-dependencies.test.ts
+++ b/tests/task-dependencies.test.ts
@@ -19,7 +19,7 @@ const env = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql", "0004_rename_task_notes_to_task_actions.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql

--- a/tests/task-json-fields.test.ts
+++ b/tests/task-json-fields.test.ts
@@ -11,7 +11,7 @@ let db: D1Database;
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql", "0004_rename_task_notes_to_task_actions.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql
@@ -134,14 +134,14 @@ describe("task JSON field parsing (labels, input)", () => {
     const { assignTask, claimTask, reviewTask } = await import("../apps/web/functions/api/taskRepo");
 
     const agent = await createAgent(db, ownerId, { name: "worker" });
-    const assigned = await assignTask(db, taskId, agent.id);
+    const assigned = await assignTask(db, taskId, agent.id, "machine", "system");
     expect(Array.isArray(assigned!.labels)).toBe(true);
 
     const claimed = await claimTask(db, taskId, agent.id, "agent:worker");
     expect(Array.isArray(claimed!.labels)).toBe(true);
     expect(typeof claimed!.input).toBe("object");
 
-    const reviewed = await reviewTask(db, taskId, agent.id, "https://github.com/pr/1", "agent:worker");
+    const reviewed = await reviewTask(db, taskId, "agent:worker", agent.id, "https://github.com/pr/1", "agent:worker");
     expect(Array.isArray(reviewed!.labels)).toBe(true);
     expect(typeof reviewed!.input).toBe("object");
   });

--- a/tests/task-state-machine.test.ts
+++ b/tests/task-state-machine.test.ts
@@ -22,7 +22,7 @@ const env = {
 let mf: Miniflare;
 
 async function applyMigrations(db: D1Database) {
-  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql"];
+  const files = ["0001_initial.sql", "0002_rename_task_logs_to_task_notes.sql", "0003_agent_kind.sql", "0004_rename_task_notes_to_task_actions.sql"];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");
     for (const stmt of sql
@@ -285,7 +285,7 @@ describe("task lifecycle repo functions", () => {
     it("succeeds: todo → in_progress (agent:worker)", async () => {
       const { claimTask, assignTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
-      await assignTask(env.DB, task.id, testAgentId);
+      await assignTask(env.DB, task.id, testAgentId, "machine", "system");
       const result = await claimTask(env.DB, task.id, testAgentId, "agent:worker");
       expect(result!.status).toBe("in_progress");
     });
@@ -293,7 +293,7 @@ describe("task lifecycle repo functions", () => {
     it("rejects claim from in_progress", async () => {
       const { claimTask, assignTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
-      await assignTask(env.DB, task.id, testAgentId);
+      await assignTask(env.DB, task.id, testAgentId, "machine", "system");
       await forceStatus(task.id, "in_progress");
       await expect(claimTask(env.DB, task.id, testAgentId, "agent:worker")).rejects.toThrow();
     });
@@ -301,7 +301,7 @@ describe("task lifecycle repo functions", () => {
     it("rejects claim by wrong agent", async () => {
       const { claimTask, assignTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
-      await assignTask(env.DB, task.id, testAgentId);
+      await assignTask(env.DB, task.id, testAgentId, "machine", "system");
       await expect(claimTask(env.DB, task.id, otherAgentId, "agent:worker")).rejects.toThrow("not assigned");
     });
   });
@@ -311,21 +311,21 @@ describe("task lifecycle repo functions", () => {
       const { reviewTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_progress");
-      const result = await reviewTask(env.DB, task.id, testAgentId, null, "agent:worker");
+      const result = await reviewTask(env.DB, task.id, "agent:worker", testAgentId, null, "agent:worker");
       expect(result!.status).toBe("in_review");
     });
 
     it("rejects review from todo", async () => {
       const { reviewTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
-      await expect(reviewTask(env.DB, task.id, testAgentId, null, "agent:worker")).rejects.toThrow();
+      await expect(reviewTask(env.DB, task.id, "agent:worker", testAgentId, null, "agent:worker")).rejects.toThrow();
     });
 
     it("rejects review by machine", async () => {
       const { reviewTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_progress");
-      await expect(reviewTask(env.DB, task.id, null, null, "machine")).rejects.toThrow();
+      await expect(reviewTask(env.DB, task.id, "machine", "system", null, "machine")).rejects.toThrow();
     });
   });
 
@@ -334,7 +334,7 @@ describe("task lifecycle repo functions", () => {
       const { rejectTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_review");
-      const result = await rejectTask(env.DB, task.id, null, "agent:leader");
+      const result = await rejectTask(env.DB, task.id, "agent:leader", "system", "agent:leader");
       expect(result!.status).toBe("in_progress");
     });
 
@@ -342,14 +342,14 @@ describe("task lifecycle repo functions", () => {
       const { rejectTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_progress");
-      await expect(rejectTask(env.DB, task.id, null, "agent:leader")).rejects.toThrow();
+      await expect(rejectTask(env.DB, task.id, "agent:leader", "system", "agent:leader")).rejects.toThrow();
     });
 
     it("rejects reject by agent:worker", async () => {
       const { rejectTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_review");
-      await expect(rejectTask(env.DB, task.id, null, "agent:worker")).rejects.toThrow();
+      await expect(rejectTask(env.DB, task.id, "agent:worker", "system", "agent:worker")).rejects.toThrow();
     });
   });
 
@@ -358,28 +358,28 @@ describe("task lifecycle repo functions", () => {
       const { completeTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_review");
-      const result = await completeTask(env.DB, task.id, null, "done", null, "agent:leader");
+      const result = await completeTask(env.DB, task.id, "agent:leader", "system", "done", null, "agent:leader");
       expect(result!.status).toBe("done");
     });
 
     it("rejects complete from todo", async () => {
       const { completeTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
-      await expect(completeTask(env.DB, task.id, null, null, null, "agent:leader")).rejects.toThrow();
+      await expect(completeTask(env.DB, task.id, "agent:leader", "system", null, null, "agent:leader")).rejects.toThrow();
     });
 
     it("rejects complete from in_progress", async () => {
       const { completeTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_progress");
-      await expect(completeTask(env.DB, task.id, null, null, null, "agent:leader")).rejects.toThrow();
+      await expect(completeTask(env.DB, task.id, "agent:leader", "system", null, null, "agent:leader")).rejects.toThrow();
     });
 
     it("rejects complete by agent:worker", async () => {
       const { completeTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_review");
-      await expect(completeTask(env.DB, task.id, null, null, null, "agent:worker")).rejects.toThrow();
+      await expect(completeTask(env.DB, task.id, "agent:worker", "system", null, null, "agent:worker")).rejects.toThrow();
     });
   });
 
@@ -388,7 +388,7 @@ describe("task lifecycle repo functions", () => {
       const { cancelTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_progress");
-      const result = await cancelTask(env.DB, task.id, null, "agent:leader");
+      const result = await cancelTask(env.DB, task.id, "agent:leader", "system", "agent:leader");
       expect(result!.status).toBe("cancelled");
     });
 
@@ -396,35 +396,35 @@ describe("task lifecycle repo functions", () => {
       const { cancelTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_review");
-      const result = await cancelTask(env.DB, task.id, null, "agent:leader");
+      const result = await cancelTask(env.DB, task.id, "agent:leader", "system", "agent:leader");
       expect(result!.status).toBe("cancelled");
     });
 
     it("rejects cancel from todo", async () => {
       const { cancelTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
-      await expect(cancelTask(env.DB, task.id, null, "agent:leader")).rejects.toThrow();
+      await expect(cancelTask(env.DB, task.id, "agent:leader", "system", "agent:leader")).rejects.toThrow();
     });
 
     it("rejects cancel from done", async () => {
       const { cancelTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "done");
-      await expect(cancelTask(env.DB, task.id, null, "agent:leader")).rejects.toThrow();
+      await expect(cancelTask(env.DB, task.id, "agent:leader", "system", "agent:leader")).rejects.toThrow();
     });
 
     it("rejects cancel from cancelled", async () => {
       const { cancelTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "cancelled");
-      await expect(cancelTask(env.DB, task.id, null, "agent:leader")).rejects.toThrow();
+      await expect(cancelTask(env.DB, task.id, "agent:leader", "system", "agent:leader")).rejects.toThrow();
     });
 
     it("rejects cancel by agent:worker", async () => {
       const { cancelTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_progress");
-      await expect(cancelTask(env.DB, task.id, null, "agent:worker")).rejects.toThrow();
+      await expect(cancelTask(env.DB, task.id, "agent:worker", "system", "agent:worker")).rejects.toThrow();
     });
   });
 
@@ -433,7 +433,7 @@ describe("task lifecycle repo functions", () => {
       const { releaseTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_progress");
-      const result = await releaseTask(env.DB, task.id, null, "machine");
+      const result = await releaseTask(env.DB, task.id, "machine", "system", "machine");
       expect(result!.status).toBe("todo");
     });
 
@@ -441,28 +441,28 @@ describe("task lifecycle repo functions", () => {
       const { releaseTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_review");
-      const result = await releaseTask(env.DB, task.id, null, "machine");
+      const result = await releaseTask(env.DB, task.id, "machine", "system", "machine");
       expect(result!.status).toBe("todo");
     });
 
     it("rejects release from todo", async () => {
       const { releaseTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
-      await expect(releaseTask(env.DB, task.id, null, "machine")).rejects.toThrow();
+      await expect(releaseTask(env.DB, task.id, "machine", "system", "machine")).rejects.toThrow();
     });
 
     it("rejects release by agent:worker", async () => {
       const { releaseTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_progress");
-      await expect(releaseTask(env.DB, task.id, null, "agent:worker")).rejects.toThrow();
+      await expect(releaseTask(env.DB, task.id, "agent:worker", "system", "agent:worker")).rejects.toThrow();
     });
 
     it("rejects release by agent:leader", async () => {
       const { releaseTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_progress");
-      await expect(releaseTask(env.DB, task.id, null, "agent:leader")).rejects.toThrow();
+      await expect(releaseTask(env.DB, task.id, "agent:leader", "system", "agent:leader")).rejects.toThrow();
     });
   });
 
@@ -470,35 +470,35 @@ describe("task lifecycle repo functions", () => {
     it("succeeds: assign in todo with no existing assignment", async () => {
       const { assignTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
-      const result = await assignTask(env.DB, task.id, testAgentId);
+      const result = await assignTask(env.DB, task.id, testAgentId, "machine", "system");
       expect(result!.assigned_to).toBe(testAgentId);
     });
 
     it("rejects assign when already assigned", async () => {
       const { assignTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
-      await assignTask(env.DB, task.id, testAgentId);
-      await expect(assignTask(env.DB, task.id, otherAgentId)).rejects.toThrow("already assigned");
+      await assignTask(env.DB, task.id, testAgentId, "machine", "system");
+      await expect(assignTask(env.DB, task.id, otherAgentId, "machine", "system")).rejects.toThrow("already assigned");
     });
 
     it("rejects assign in in_progress", async () => {
       const { assignTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "in_progress");
-      await expect(assignTask(env.DB, task.id, testAgentId)).rejects.toThrow("todo");
+      await expect(assignTask(env.DB, task.id, testAgentId, "machine", "system")).rejects.toThrow("todo");
     });
 
     it("rejects assign in done", async () => {
       const { assignTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
       await forceStatus(task.id, "done");
-      await expect(assignTask(env.DB, task.id, testAgentId)).rejects.toThrow("todo");
+      await expect(assignTask(env.DB, task.id, testAgentId, "machine", "system")).rejects.toThrow("todo");
     });
 
     it("rejects assign to leader agent", async () => {
       const { assignTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
-      await expect(assignTask(env.DB, task.id, leaderAgentId)).rejects.toThrow("Cannot assign tasks to leader agents");
+      await expect(assignTask(env.DB, task.id, leaderAgentId, "machine", "system")).rejects.toThrow("Cannot assign tasks to leader agents");
     });
 
     it("rejects createTask with assigned_to leader agent", async () => {
@@ -528,7 +528,7 @@ describe("task lifecycle repo functions", () => {
     it("allows delete of assigned todo", async () => {
       const { deleteTask, assignTask } = await import("../apps/web/functions/api/taskRepo");
       const task = await createTestTask();
-      await assignTask(env.DB, task.id, testAgentId);
+      await assignTask(env.DB, task.id, testAgentId, "machine", "system");
       const result = await deleteTask(env.DB, task.id);
       expect(result).toBe(true);
     });
@@ -673,7 +673,7 @@ describe("task lifecycle HTTP permissions", () => {
   it("machine can release a task (200)", async () => {
     const task = await createTestTask();
     const { assignTask } = await import("../apps/web/functions/api/taskRepo");
-    await assignTask(env.DB, task.id, agentId);
+    await assignTask(env.DB, task.id, agentId, "machine", "system");
     await forceStatus(task.id, "in_progress");
     const res = await apiRequest("POST", `/api/tasks/${task.id}/release`, {}, apiKey);
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary

- Adds DB migration `0004` to rename `task_notes` → `task_actions`, replacing `agent_id`/`session_id` columns with `actor_type`/`actor_id` that supports all identity types (`user`, `machine`, `agent:worker`, `agent:leader`)
- Updates all backend functions (`taskRepo`, `agentRepo`, `sse`, `boardSSE`, `taskStale`, `routes`) to use the new schema with proper actor tracking per request identity
- Renames `TaskNote` → `TaskAction` and `BoardNote` → `BoardAction` in shared types; renames action union type `TaskAction` → `TaskActionType` to avoid collision
- Updates frontend hooks (`useAgentPresence`, `useBoardSSE`) and `ActivityLog` component to render based on `actor_type`/`actor_id` instead of `agent_id`, enabling user/machine actions to show in the activity timeline and trigger board animations

## Test plan

- [x] All 567 tests pass (`pnpm test`)
- [x] Build succeeds (`pnpm build`)
- [x] Type check passes (`pnpm tsc --noEmit`)
- [x] Pre-commit hooks (biome lint + typecheck) pass
- [ ] Verify DB migration applies cleanly in dev/staging environment
- [ ] Manually verify activity log shows correct actor for user-triggered actions (complete, cancel, reject)

🤖 Generated with [Claude Code](https://claude.com/claude-code)