### PR TITLE
feat(board): per-column independent scrolling

### DIFF
--- a/apps/web/src/components/KanbanColumn.tsx
+++ b/apps/web/src/components/KanbanColumn.tsx
@@ -14,31 +14,33 @@ export function KanbanColumn({ column, onTaskClick, onAgentClick }: KanbanColumn
   });
 
   return (
-    <div data-column-status={column.status} className="min-w-0 border-r border-border last:border-r-0 p-4">
-      <div className="flex items-center justify-between mb-3">
+    <div data-column-status={column.status} className="min-w-0 border-r border-border last:border-r-0 flex flex-col h-full">
+      <div className="flex items-center justify-between flex-shrink-0 px-4 pt-4 pb-3">
         <span className={`text-xs font-semibold uppercase tracking-wide ${hasRecentUpdate ? "text-accent" : "text-content-tertiary"}`}>
           {column.name}
         </span>
         <span className="font-mono text-[11px] text-content-tertiary bg-surface-tertiary px-1.5 py-0.5 rounded">{column.tasks.length}</span>
       </div>
 
-      <LayoutGroup>
-        <AnimatePresence initial={false} mode="popLayout">
-          {column.tasks.map((task: any) => (
-            <motion.div
-              key={task.id}
-              layout
-              initial={{ opacity: 0, scale: 0.95, y: -8 }}
-              animate={{ opacity: 1, scale: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.95 }}
-              transition={{ duration: 0.25, layout: { duration: 0.3 } }}
-              className="mb-2"
-            >
-              <TaskCard task={task} onClick={() => onTaskClick(task.id)} onAgentClick={onAgentClick} />
-            </motion.div>
-          ))}
-        </AnimatePresence>
-      </LayoutGroup>
+      <div className="flex-1 overflow-y-auto scrollbar-column px-4 pb-4">
+        <LayoutGroup>
+          <AnimatePresence initial={false} mode="popLayout">
+            {column.tasks.map((task: any) => (
+              <motion.div
+                key={task.id}
+                layout
+                initial={{ opacity: 0, scale: 0.95, y: -8 }}
+                animate={{ opacity: 1, scale: 1, y: 0 }}
+                exit={{ opacity: 0, scale: 0.95 }}
+                transition={{ duration: 0.25, layout: { duration: 0.3 } }}
+                className="mb-2"
+              >
+                <TaskCard task={task} onClick={() => onTaskClick(task.id)} onAgentClick={onAgentClick} />
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </LayoutGroup>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/globals.css
+++ b/apps/web/src/globals.css
@@ -123,6 +123,34 @@ body {
   }
 }
 
+/* ── Kanban column scrollbar — thin, subtle, auto-hide ── */
+
+.scrollbar-column {
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.scrollbar-column:hover {
+  scrollbar-color: var(--bg-tertiary) transparent;
+}
+
+.scrollbar-column::-webkit-scrollbar {
+  width: 4px;
+}
+
+.scrollbar-column::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-column::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 2px;
+}
+
+.scrollbar-column:hover::-webkit-scrollbar-thumb {
+  background: var(--bg-tertiary);
+}
+
 /* ── shadcn color tokens (mapped to our design system) ── */
 
 @layer base {

--- a/apps/web/src/routes/BoardPage.tsx
+++ b/apps/web/src/routes/BoardPage.tsx
@@ -84,7 +84,7 @@ export function BoardPage() {
   }
 
   return (
-    <div className="min-h-screen bg-surface-primary">
+    <div className="h-screen overflow-hidden bg-surface-primary flex flex-col">
       <Header />
       <FilterBar repositories={repositories} activeRepository={activeRepository} onRepositoryChange={setActiveRepository} />
 
@@ -113,14 +113,14 @@ export function BoardPage() {
       </div>
 
       {/* Desktop: 5-column grid */}
-      <div className="hidden md:grid min-h-[calc(100vh-100px)]" style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))` }}>
+      <div className="hidden md:grid flex-1 overflow-hidden" style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))` }}>
         {columns.map((col) => (
           <KanbanColumn key={col.status} column={col} onTaskClick={setSelectedTask} onAgentClick={setSelectedAgent} />
         ))}
       </div>
 
       {/* Mobile: single column based on tab */}
-      <div className="md:hidden min-h-[calc(100vh-160px)]">
+      <div className="md:hidden flex-1 overflow-hidden">
         {columns
           .filter((_, i) => i === mobileTab)
           .map((col) => (


### PR DESCRIPTION
## Summary

- **BoardPage**: outer wrapper is now `h-screen overflow-hidden flex flex-col` — the viewport is capped so no page-level scroll occurs. Desktop and mobile board containers use `flex-1 overflow-hidden` to fill remaining height naturally.
- **KanbanColumn**: column root is `flex flex-col h-full`. The header gets `flex-shrink-0` so it stays pinned. The task list is wrapped in `flex-1 overflow-y-auto scrollbar-column` for independent per-column scrolling.
- **globals.css**: adds `.scrollbar-column` — a 4 px webkit scrollbar that is invisible by default and fades in (using `--bg-tertiary`) only when the column is hovered, matching the minimal aesthetic from DESIGN.md.

Framer Motion layout animations are fully preserved.

## Test plan

- [ ] Load the board with many tasks in one column — that column scrolls independently while other columns stay fixed
- [ ] Column headers (status label + count badge) remain visible at top while scrolling task list
- [ ] No page-level scrollbar appears
- [ ] Mobile tab view: single active column scrolls independently
- [ ] Scrollbar is invisible at rest, thin and subtle on hover
- [ ] All existing tests pass (`pnpm test` / `npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)