### PR TITLE
refactor: unify UsageInfo to generic multi-runtime window array

### DIFF
--- a/apps/web/src/routes/MachineDetailPage.tsx
+++ b/apps/web/src/routes/MachineDetailPage.tsx
@@ -1,4 +1,4 @@
-import type { UsageWindow } from "@agent-kanban/shared";
+import { RUNTIME_LABELS, type UsageWindow } from "@agent-kanban/shared";
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { Header } from "../components/Header";
@@ -6,13 +6,6 @@ import { formatRelative } from "../components/TaskDetailFields";
 import { Button } from "../components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "../components/ui/dialog";
 import { useDeleteMachine, useMachine } from "../hooks/useMachines";
-
-const USAGE_LABELS: Record<string, string> = {
-  five_hour: "5-Hour",
-  seven_day: "7-Day",
-  seven_day_sonnet: "7-Day Sonnet",
-  seven_day_opus: "7-Day Opus",
-};
 
 function usageBarColor(pct: number): string {
   if (pct >= 75) return "bg-error";
@@ -157,42 +150,40 @@ export function MachineDetailPage() {
         </div>
 
         {/* Usage quota */}
-        {machine.usage_info &&
-          (() => {
-            const windows = Object.entries(machine.usage_info)
-              .filter(([k]) => k !== "updated_at" && USAGE_LABELS[k])
-              .map(([k, v]) => ({ key: k, label: USAGE_LABELS[k], ...(v as UsageWindow) }));
-            if (windows.length === 0) return null;
-            return (
-              <div className="bg-surface-secondary border border-border rounded-lg px-5 py-4 space-y-3">
-                <div className="flex items-center justify-between">
-                  <span className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide">Usage</span>
-                  <span className="text-[11px] font-mono text-content-tertiary">
-                    {machine.usage_info.updated_at ? formatRelative(machine.usage_info.updated_at) : ""}
-                  </span>
-                </div>
-                <div className="space-y-2.5">
-                  {windows.map((w) => (
-                    <div key={w.key}>
-                      <div className="flex items-center justify-between mb-1">
-                        <span className="text-xs text-content-secondary">{w.label}</span>
-                        <div className="flex items-center gap-2">
-                          <span className="font-mono text-xs text-content-primary">{Math.round(w.utilization)}%</span>
-                          <span className="text-[11px] text-content-tertiary">resets {formatResetCountdown(w.resets_at)}</span>
-                        </div>
-                      </div>
-                      <div className="h-1.5 bg-surface-tertiary rounded-full overflow-hidden">
-                        <div
-                          className={`h-full rounded-full transition-all ${usageBarColor(w.utilization)}`}
-                          style={{ width: `${Math.min(w.utilization, 100)}%` }}
-                        />
-                      </div>
+        {machine.usage_info && machine.usage_info.windows.length > 0 && (
+          <div className="bg-surface-secondary border border-border rounded-lg px-5 py-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-[11px] font-medium text-content-tertiary uppercase tracking-wide">Usage</span>
+              <span className="text-[11px] font-mono text-content-tertiary">
+                {machine.usage_info.updated_at ? formatRelative(machine.usage_info.updated_at) : ""}
+              </span>
+            </div>
+            <div className="space-y-2.5">
+              {(machine.usage_info.windows as UsageWindow[]).map((w, i) => (
+                <div key={`${w.runtime}-${i}`}>
+                  <div className="flex items-center justify-between mb-1">
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-[10px] font-medium text-content-tertiary bg-surface-tertiary border border-border rounded px-1 py-0.5">
+                        {RUNTIME_LABELS[w.runtime] ?? w.runtime}
+                      </span>
+                      <span className="text-xs text-content-secondary">{w.label}</span>
                     </div>
-                  ))}
+                    <div className="flex items-center gap-2">
+                      <span className="font-mono text-xs text-content-primary">{Math.round(w.utilization)}%</span>
+                      <span className="text-[11px] text-content-tertiary">resets {formatResetCountdown(w.resets_at)}</span>
+                    </div>
+                  </div>
+                  <div className="h-1.5 bg-surface-tertiary rounded-full overflow-hidden">
+                    <div
+                      className={`h-full rounded-full transition-all ${usageBarColor(w.utilization)}`}
+                      style={{ width: `${Math.min(w.utilization, 100)}%` }}
+                    />
+                  </div>
                 </div>
-              </div>
-            );
-          })()}
+              ))}
+            </div>
+          </div>
+        )}
 
         {/* Offline reconnect */}
         {isOffline && (

--- a/packages/cli/src/daemon.ts
+++ b/packages/cli/src/daemon.ts
@@ -8,12 +8,22 @@ import { createLogger } from "./logger.js";
 import { PID_FILE, STATE_DIR } from "./paths.js";
 import { PrMonitor } from "./prMonitor.js";
 import { ProcessManager } from "./processManager.js";
-import { getAvailableProviders, getProvider } from "./providers/registry.js";
+import { getAvailableProviders } from "./providers/registry.js";
+import type { AgentProvider, UsageInfo } from "./providers/types.js";
 import { Scheduler } from "./scheduler.js";
 import { cleanupStale, clearAll as clearSessionPids, removePid, savePid } from "./sessionPids.js";
 import { TaskRunner } from "./taskRunner.js";
 
 const logger = createLogger("daemon");
+
+async function collectUsage(providers: AgentProvider[]): Promise<UsageInfo | null> {
+  const results = await Promise.allSettled(providers.filter((p) => p.getUsage).map((p) => p.getUsage!()));
+  const windows = results
+    .filter((r): r is PromiseFulfilledResult<UsageInfo | null> => r.status === "fulfilled" && r.value !== null)
+    .flatMap((r) => r.value!.windows);
+  if (windows.length === 0) return null;
+  return { windows, updated_at: new Date().toISOString() };
+}
 
 export interface DaemonOptions {
   maxConcurrent: number;
@@ -54,7 +64,6 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   const MIN_POLL_INTERVAL = 5000;
   const pollInterval = Math.max(opts.pollInterval || 10000, MIN_POLL_INTERVAL);
   const availableProviders = getAvailableProviders();
-  const primaryProvider = availableProviders.length > 0 ? getProvider(availableProviders[0].name) : null;
 
   // Wire up components
   const prMonitor = new PrMonitor(client);
@@ -82,7 +91,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   // Heartbeat
   const heartbeatInterval = setInterval(() => {
     (async () => {
-      const usageInfo = primaryProvider?.getUsage ? await primaryProvider.getUsage() : null;
+      const usageInfo = await collectUsage(availableProviders);
       await client.heartbeat(machineId!, { version: machineInfo.version, runtimes: machineInfo.runtimes, usage_info: usageInfo });
     })().catch((err: any) => logger.warn(`Heartbeat failed: ${err.message}`));
   }, 30000);

--- a/packages/cli/src/providers/claude.ts
+++ b/packages/cli/src/providers/claude.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import { createLogger } from "../logger.js";
-import type { AgentEvent, AgentProvider, SpawnOpts, UsageInfo } from "./types.js";
+import type { AgentEvent, AgentProvider, SpawnOpts, UsageInfo, UsageWindow } from "./types.js";
 
 const logger = createLogger("claude");
 
@@ -11,6 +11,13 @@ const CREDENTIALS_PATH = join(homedir(), ".claude", ".credentials.json");
 const USAGE_API = "https://api.anthropic.com/api/oauth/usage";
 const CACHE_TTL_MS = 5 * 60 * 1000;
 const RATE_LIMIT_CODES = new Set(["rate_limit_error", "overloaded_error"]);
+
+const CLAUDE_WINDOW_LABELS: Record<string, string> = {
+  five_hour: "5-Hour",
+  seven_day: "7-Day",
+  seven_day_sonnet: "7-Day Sonnet",
+  seven_day_opus: "7-Day Opus",
+};
 
 let cachedUsage: UsageInfo | null = null;
 let cachedAt = 0;
@@ -183,13 +190,10 @@ export const claudeProvider: AgentProvider = {
       }
 
       const data = (await res.json()) as Record<string, { utilization: number; resets_at: string }>;
-      cachedUsage = {
-        ...(data.five_hour && { five_hour: data.five_hour }),
-        ...(data.seven_day && { seven_day: data.seven_day }),
-        ...(data.seven_day_sonnet && { seven_day_sonnet: data.seven_day_sonnet }),
-        ...(data.seven_day_opus && { seven_day_opus: data.seven_day_opus }),
-        updated_at: new Date().toISOString(),
-      };
+      const windows: UsageWindow[] = Object.entries(CLAUDE_WINDOW_LABELS)
+        .filter(([key]) => data[key])
+        .map(([key, label]) => ({ runtime: "claude", label, ...data[key] }));
+      cachedUsage = { windows, updated_at: new Date().toISOString() };
       cachedAt = Date.now();
       return cachedUsage;
     } catch (err: any) {

--- a/packages/cli/src/providers/codex.ts
+++ b/packages/cli/src/providers/codex.ts
@@ -1,4 +1,26 @@
-import type { AgentEvent, AgentProvider, SpawnOpts } from "./types.js";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "../logger.js";
+import type { AgentEvent, AgentProvider, SpawnOpts, UsageInfo, UsageWindow } from "./types.js";
+
+const logger = createLogger("codex");
+
+const AUTH_PATH = join(homedir(), ".codex", "auth.json");
+const USAGE_API = "https://chatgpt.com/backend-api/wham/usage";
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+let cachedUsage: UsageInfo | null = null;
+let cachedAt = 0;
+
+function readAccessToken(): string | null {
+  try {
+    const auth = JSON.parse(readFileSync(AUTH_PATH, "utf-8"));
+    return auth.access_token || null;
+  } catch {
+    return null;
+  }
+}
 
 /** Per 1M tokens, OpenAI pricing */
 const CODEX_PRICING: Record<string, { input: number; cached_input: number; output: number }> = {
@@ -108,5 +130,41 @@ export const codexProvider: AgentProvider = {
 
   buildInput(taskContext: string): string {
     return taskContext;
+  },
+
+  async getUsage(): Promise<UsageInfo | null> {
+    if (cachedUsage && Date.now() - cachedAt < CACHE_TTL_MS) {
+      return cachedUsage;
+    }
+
+    const token = readAccessToken();
+    if (!token) return cachedUsage;
+
+    try {
+      const res = await fetch(USAGE_API, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (!res.ok) {
+        logger.warn(`Codex usage API returned ${res.status}`);
+        return cachedUsage;
+      }
+
+      const data = (await res.json()) as Record<string, { utilization: number; resets_at: string } | undefined>;
+      const windows: UsageWindow[] = [];
+      if (data.primary_window) {
+        windows.push({ runtime: "codex", label: "Primary", ...data.primary_window });
+      }
+      if (data.secondary_window) {
+        windows.push({ runtime: "codex", label: "Secondary", ...data.secondary_window });
+      }
+      cachedUsage = { windows, updated_at: new Date().toISOString() };
+      cachedAt = Date.now();
+      return cachedUsage;
+    } catch (err: any) {
+      logger.warn(`Failed to fetch Codex usage: ${err.message}`);
+      return cachedUsage;
+    }
   },
 };

--- a/packages/cli/src/providers/codex.ts
+++ b/packages/cli/src/providers/codex.ts
@@ -16,7 +16,7 @@ let cachedAt = 0;
 function readAccessToken(): string | null {
   try {
     const auth = JSON.parse(readFileSync(AUTH_PATH, "utf-8"));
-    return auth.access_token || null;
+    return auth.tokens?.access_token || auth.access_token || null;
   } catch {
     return null;
   }
@@ -151,13 +151,15 @@ export const codexProvider: AgentProvider = {
         return cachedUsage;
       }
 
-      const data = (await res.json()) as Record<string, { utilization: number; resets_at: string } | undefined>;
+      type RateLimitWindow = { used_percent: number; reset_at: string };
+      const data = (await res.json()) as { rate_limit?: { primary_window?: RateLimitWindow; secondary_window?: RateLimitWindow } };
+      const rl = data.rate_limit;
       const windows: UsageWindow[] = [];
-      if (data.primary_window) {
-        windows.push({ runtime: "codex", label: "Primary", ...data.primary_window });
+      if (rl?.primary_window) {
+        windows.push({ runtime: "codex", label: "5-Hour", utilization: rl.primary_window.used_percent, resets_at: rl.primary_window.reset_at });
       }
-      if (data.secondary_window) {
-        windows.push({ runtime: "codex", label: "Secondary", ...data.secondary_window });
+      if (rl?.secondary_window) {
+        windows.push({ runtime: "codex", label: "Weekly", utilization: rl.secondary_window.used_percent, resets_at: rl.secondary_window.reset_at });
       }
       cachedUsage = { windows, updated_at: new Date().toISOString() };
       cachedAt = Date.now();

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -1,15 +1,6 @@
-export interface UsageWindow {
-  utilization: number;
-  resets_at: string;
-}
+import type { AgentRuntime, UsageInfo, UsageWindow } from "@agent-kanban/shared";
 
-export interface UsageInfo {
-  five_hour?: UsageWindow;
-  seven_day?: UsageWindow;
-  seven_day_sonnet?: UsageWindow;
-  seven_day_opus?: UsageWindow;
-  updated_at: string;
-}
+export type { AgentRuntime, UsageInfo, UsageWindow };
 
 export interface SpawnOpts {
   sessionId: string;
@@ -22,8 +13,6 @@ export type AgentEvent =
   | { type: "result"; cost?: number; usage?: Record<string, any> }
   | { type: "rate_limit"; resetAt: string }
   | { type: "error"; code?: string; detail: string };
-
-import type { AgentRuntime } from "@agent-kanban/shared";
 
 export interface AgentProvider {
   readonly name: AgentRuntime;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -89,15 +89,14 @@ export type Priority = "low" | "medium" | "high" | "urgent";
 export type MachineStatus = "online" | "offline";
 
 export interface UsageWindow {
+  runtime: AgentRuntime;
+  label: string;
   utilization: number;
   resets_at: string;
 }
 
 export interface UsageInfo {
-  five_hour?: UsageWindow;
-  seven_day?: UsageWindow;
-  seven_day_sonnet?: UsageWindow;
-  seven_day_opus?: UsageWindow;
+  windows: UsageWindow[];
   updated_at: string;
 }
 

--- a/tests/machine-usage.test.ts
+++ b/tests/machine-usage.test.ts
@@ -74,15 +74,18 @@ describe("machine usage tracking", () => {
   it("heartbeat with usage_info stores and returns parsed object", async () => {
     const { updateMachine: heartbeat } = await import("../apps/web/functions/api/machineRepo");
     const usageInfo: UsageInfo = {
-      five_hour: { utilization: 23.5, resets_at: "2026-03-21T15:00:00Z" },
-      seven_day: { utilization: 8.2, resets_at: "2026-03-25T00:00:00Z" },
+      windows: [
+        { runtime: "claude", label: "5-Hour", utilization: 23.5, resets_at: "2026-03-21T15:00:00Z" },
+        { runtime: "claude", label: "7-Day", utilization: 8.2, resets_at: "2026-03-25T00:00:00Z" },
+      ],
       updated_at: "2026-03-21T10:00:00Z",
     };
     const machine = await heartbeat(db, machineId, "user-001", { usage_info: usageInfo });
 
     expect(typeof machine.usage_info).toBe("object");
-    expect(machine.usage_info!.five_hour!.utilization).toBe(23.5);
-    expect(machine.usage_info!.seven_day!.resets_at).toBe("2026-03-25T00:00:00Z");
+    expect(machine.usage_info!.windows).toHaveLength(2);
+    expect(machine.usage_info!.windows[0].utilization).toBe(23.5);
+    expect(machine.usage_info!.windows[1].resets_at).toBe("2026-03-25T00:00:00Z");
     expect(machine.usage_info!.updated_at).toBe("2026-03-21T10:00:00Z");
   });
 
@@ -93,7 +96,7 @@ describe("machine usage tracking", () => {
     expect(machine).toBeTruthy();
     expect(machine!.runtimes).toEqual(["Claude Code"]);
     expect(typeof machine!.usage_info).toBe("object");
-    expect(machine!.usage_info!.five_hour!.utilization).toBe(23.5);
+    expect(machine!.usage_info!.windows[0].utilization).toBe(23.5);
   });
 
   it("listMachines returns parsed usage_info", async () => {
@@ -103,21 +106,24 @@ describe("machine usage tracking", () => {
     expect(machines.length).toBeGreaterThan(0);
     const m = machines.find((m) => m.id === machineId)!;
     expect(typeof m.usage_info).toBe("object");
-    expect(m.usage_info!.five_hour!.utilization).toBe(23.5);
+    expect(m.usage_info!.windows[0].utilization).toBe(23.5);
   });
 
   it("heartbeat overwrites usage_info with new data", async () => {
     const { updateMachine: heartbeat } = await import("../apps/web/functions/api/machineRepo");
     const newUsage: UsageInfo = {
-      five_hour: { utilization: 75.0, resets_at: "2026-03-21T20:00:00Z" },
-      seven_day_opus: { utilization: 45.0, resets_at: "2026-03-28T00:00:00Z" },
+      windows: [
+        { runtime: "claude", label: "5-Hour", utilization: 75.0, resets_at: "2026-03-21T20:00:00Z" },
+        { runtime: "claude", label: "7-Day Opus", utilization: 45.0, resets_at: "2026-03-28T00:00:00Z" },
+      ],
       updated_at: "2026-03-21T15:00:00Z",
     };
     const machine = await heartbeat(db, machineId, "user-001", { usage_info: newUsage });
 
-    expect(machine.usage_info!.five_hour!.utilization).toBe(75.0);
-    expect(machine.usage_info!.seven_day_opus!.utilization).toBe(45.0);
-    expect(machine.usage_info!.seven_day).toBeUndefined();
+    expect(machine.usage_info!.windows).toHaveLength(2);
+    expect(machine.usage_info!.windows[0].utilization).toBe(75.0);
+    expect(machine.usage_info!.windows[1].utilization).toBe(45.0);
+    expect(machine.usage_info!.windows[0].label).toBe("5-Hour");
   });
 
   it("heartbeat updates version and runtimes", async () => {


### PR DESCRIPTION
## Summary
- Replace Claude-hardcoded `UsageInfo` keys (`five_hour`, `seven_day`, etc.) with a flat `windows: UsageWindow[]` array where each window has `{ runtime, label, utilization, resets_at }`
- Add `getUsage()` to Codex provider — reads `~/.codex/auth.json` for `access_token`, calls `chatgpt.com/backend-api/wham/usage`, maps `primary_window`/`secondary_window`
- Daemon now collects usage from **all** available providers via `collectUsage()` and merges their windows arrays
- `MachineDetailPage` removes hardcoded `USAGE_LABELS` map, renders windows with runtime badge using `RUNTIME_LABELS` from shared package
- Update `tests/machine-usage.test.ts` fixtures to new structure

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm tsc --noEmit` passes (no type errors)
- [x] `npx vitest run` — all 567 tests pass
- [x] `tests/machine-usage.test.ts` — 9 tests pass with new fixture structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)