### PR TITLE
feat: per-column independent scrolling on kanban board

### DIFF
--- a/apps/web/src/components/KanbanColumn.tsx
+++ b/apps/web/src/components/KanbanColumn.tsx
@@ -14,31 +14,33 @@ export function KanbanColumn({ column, onTaskClick, onAgentClick }: KanbanColumn
   });
 
   return (
-    <div data-column-status={column.status} className="min-w-0 border-r border-border last:border-r-0 p-4">
-      <div className="flex items-center justify-between mb-3">
+    <div data-column-status={column.status} className="min-w-0 border-r border-border last:border-r-0 flex flex-col h-full">
+      <div className="flex items-center justify-between flex-shrink-0 px-4 pt-4 pb-3">
         <span className={`text-xs font-semibold uppercase tracking-wide ${hasRecentUpdate ? "text-accent" : "text-content-tertiary"}`}>
           {column.name}
         </span>
         <span className="font-mono text-[11px] text-content-tertiary bg-surface-tertiary px-1.5 py-0.5 rounded">{column.tasks.length}</span>
       </div>
 
-      <LayoutGroup>
-        <AnimatePresence initial={false} mode="popLayout">
-          {column.tasks.map((task: any) => (
-            <motion.div
-              key={task.id}
-              layout
-              initial={{ opacity: 0, scale: 0.95, y: -8 }}
-              animate={{ opacity: 1, scale: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.95 }}
-              transition={{ duration: 0.25, layout: { duration: 0.3 } }}
-              className="mb-2"
-            >
-              <TaskCard task={task} onClick={() => onTaskClick(task.id)} onAgentClick={onAgentClick} />
-            </motion.div>
-          ))}
-        </AnimatePresence>
-      </LayoutGroup>
+      <div className="flex-1 overflow-y-auto scrollbar-column px-4 pb-4">
+        <LayoutGroup>
+          <AnimatePresence initial={false} mode="popLayout">
+            {column.tasks.map((task: any) => (
+              <motion.div
+                key={task.id}
+                layout
+                initial={{ opacity: 0, scale: 0.95, y: -8 }}
+                animate={{ opacity: 1, scale: 1, y: 0 }}
+                exit={{ opacity: 0, scale: 0.95 }}
+                transition={{ duration: 0.25, layout: { duration: 0.3 } }}
+                className="mb-2"
+              >
+                <TaskCard task={task} onClick={() => onTaskClick(task.id)} onAgentClick={onAgentClick} />
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </LayoutGroup>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/globals.css
+++ b/apps/web/src/globals.css
@@ -123,6 +123,30 @@ body {
   }
 }
 
+/* ── Column scrollbar — thin and subtle ── */
+
+.scrollbar-column {
+  scrollbar-width: thin;
+  scrollbar-color: var(--bg-tertiary) transparent;
+}
+
+.scrollbar-column::-webkit-scrollbar {
+  width: 4px;
+}
+
+.scrollbar-column::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scrollbar-column::-webkit-scrollbar-thumb {
+  background-color: var(--bg-tertiary);
+  border-radius: 9999px;
+}
+
+.scrollbar-column::-webkit-scrollbar-thumb:hover {
+  background-color: var(--text-tertiary);
+}
+
 /* ── shadcn color tokens (mapped to our design system) ── */
 
 @layer base {

--- a/apps/web/src/routes/BoardPage.tsx
+++ b/apps/web/src/routes/BoardPage.tsx
@@ -113,14 +113,17 @@ export function BoardPage() {
       </div>
 
       {/* Desktop: 5-column grid */}
-      <div className="hidden md:grid min-h-[calc(100vh-100px)]" style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))` }}>
+      <div
+        className="hidden md:grid h-[calc(100vh-100px)] overflow-hidden"
+        style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))` }}
+      >
         {columns.map((col) => (
           <KanbanColumn key={col.status} column={col} onTaskClick={setSelectedTask} onAgentClick={setSelectedAgent} />
         ))}
       </div>
 
       {/* Mobile: single column based on tab */}
-      <div className="md:hidden min-h-[calc(100vh-160px)]">
+      <div className="md:hidden h-[calc(100vh-160px)] overflow-hidden">
         {columns
           .filter((_, i) => i === mobileTab)
           .map((col) => (


### PR DESCRIPTION
## Summary

- **BoardPage.tsx**: Changed `min-h-[calc(100vh-100px)]` → `h-[calc(100vh-100px)] overflow-hidden` on the desktop grid container, and same pattern for the mobile single-column container, so the board fills the viewport exactly without page scrolling.
- **KanbanColumn.tsx**: Made the column a `flex flex-col h-full` container. The header is now `flex-shrink-0` (stays pinned). The task list area is wrapped in `flex-1 overflow-y-auto scrollbar-column` so each column scrolls independently.
- **globals.css**: Added `.scrollbar-column` — 4px wide, using design-token colours (`--bg-tertiary` / `--text-tertiary`), transparent track. Supports both Firefox (`scrollbar-width: thin`) and WebKit (`::-webkit-scrollbar`).

Framer Motion animations are fully preserved.

## Test plan

- [ ] Open the board with many tasks in one column — that column scrolls while others stay fixed
- [ ] Column headers (Todo, In Progress…) stay pinned as tasks scroll
- [ ] Desktop: all 5 columns are visible; board does not cause page scroll
- [ ] Mobile: tab view shows one column at a time, scrolls independently
- [ ] Scrollbar appears on hover as a thin (4px) subtle bar matching the design system

🤖 Generated with [Claude Code](https://claude.com/claude-code)