### PR TITLE
feat: board sharing — visibility toggle, public link, badge endpoint

### DIFF
--- a/apps/web/functions/api/boardRepo.ts
+++ b/apps/web/functions/api/boardRepo.ts
@@ -1,6 +1,10 @@
 import type { Board, BoardWithTasks, Task } from "@agent-kanban/shared";
+import { customAlphabet } from "nanoid";
 import { seedBuiltinAgents } from "./agentRepo";
 import { type D1, newId, parseJsonFields } from "./db";
+
+const nanoidSlug = customAlphabet("0123456789abcdefghijklmnopqrstuvwxyz", 10);
+
 import { computeBlocked } from "./taskDeps";
 
 export async function createBoard(db: D1, ownerId: string, name: string, description?: string): Promise<Board> {
@@ -13,7 +17,7 @@ export async function createBoard(db: D1, ownerId: string, name: string, descrip
 
   await seedBuiltinAgents(db, ownerId);
 
-  return { id, owner_id: ownerId, name, description: description || null, created_at: now, updated_at: now };
+  return { id, owner_id: ownerId, name, description: description || null, visibility: "private", share_slug: null, created_at: now, updated_at: now };
 }
 
 export async function listBoards(db: D1, ownerId: string): Promise<Board[]> {
@@ -61,7 +65,11 @@ export async function getDefaultBoard(db: D1, ownerId: string): Promise<Board | 
   return db.prepare("SELECT * FROM boards WHERE owner_id = ? ORDER BY created_at ASC LIMIT 1").bind(ownerId).first<Board>();
 }
 
-export async function updateBoard(db: D1, boardId: string, updates: { name?: string; description?: string }): Promise<Board | null> {
+export async function updateBoard(
+  db: D1,
+  boardId: string,
+  updates: { name?: string; description?: string; visibility?: "private" | "public" },
+): Promise<Board | null> {
   const sets: string[] = [];
   const values: unknown[] = [];
   if (updates.name !== undefined) {
@@ -71,6 +79,17 @@ export async function updateBoard(db: D1, boardId: string, updates: { name?: str
   if (updates.description !== undefined) {
     sets.push("description = ?");
     values.push(updates.description || null);
+  }
+  if (updates.visibility !== undefined) {
+    sets.push("visibility = ?");
+    values.push(updates.visibility);
+    if (updates.visibility === "public") {
+      const existing = await db.prepare("SELECT share_slug FROM boards WHERE id = ?").bind(boardId).first<{ share_slug: string | null }>();
+      if (existing && !existing.share_slug) {
+        sets.push("share_slug = ?");
+        values.push(nanoidSlug());
+      }
+    }
   }
   if (sets.length === 0) return db.prepare("SELECT * FROM boards WHERE id = ?").bind(boardId).first<Board>();
 
@@ -83,6 +102,30 @@ export async function updateBoard(db: D1, boardId: string, updates: { name?: str
     .bind(...values)
     .run();
   return db.prepare("SELECT * FROM boards WHERE id = ?").bind(boardId).first<Board>();
+}
+
+export async function getBoardBySlug(db: D1, slug: string): Promise<BoardWithTasks | null> {
+  const board = await db.prepare("SELECT * FROM boards WHERE share_slug = ? AND visibility = 'public'").bind(slug).first<Board>();
+  if (!board) return null;
+
+  const tasks = await db
+    .prepare(`
+    SELECT t.*, a.name as agent_name, a.public_key as agent_public_key, r.name as repository_name FROM tasks t
+    LEFT JOIN agents a ON t.assigned_to = a.id
+    LEFT JOIN repositories r ON t.repository_id = r.id
+    WHERE t.board_id = ?
+    ORDER BY
+      CASE t.status WHEN 'todo' THEN 0 WHEN 'in_progress' THEN 1 WHEN 'in_review' THEN 2 WHEN 'done' THEN 3 ELSE 4 END,
+      CASE WHEN t.status = 'todo' THEN
+        CASE t.priority WHEN 'urgent' THEN 0 WHEN 'high' THEN 1 WHEN 'medium' THEN 2 WHEN 'low' THEN 3 ELSE 2 END
+      ELSE 0 END,
+      CASE WHEN t.status = 'todo' THEN t.created_at END DESC,
+      CASE WHEN t.status != 'todo' THEN t.updated_at END DESC
+  `)
+    .bind(board.id)
+    .all<Task>();
+
+  return { ...board, tasks: tasks.results.map((t) => parseJsonFields(t, ["labels", "input"])) };
 }
 
 export async function deleteBoard(db: D1, boardId: string): Promise<boolean> {

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -108,8 +108,12 @@ api.get("/api/share/:slug/badge.svg", async (c) => {
     else if (t.status === "done") counts.done++;
   }
 
-  const label = board.name;
-  const value = `${counts.todo} todo · ${counts.in_progress} active · ${counts.in_review} review · ${counts.done} done`;
+  function escapeXml(s: string): string {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+  }
+
+  const label = escapeXml(board.name);
+  const value = escapeXml(`${counts.todo} todo · ${counts.in_progress} active · ${counts.in_review} review · ${counts.done} done`);
 
   const labelWidth = Math.max(label.length * 7 + 16, 60);
   const valueWidth = value.length * 6.5 + 16;

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -5,7 +5,7 @@ import { createAgent, deleteAgent, getAgent, getAgentLogs, listAgents, updateAge
 import { closeSession, createSession, listSessions, reopenSession, updateSessionUsage } from "./agentSessionRepo";
 import { authMiddleware } from "./auth";
 import { createAuth } from "./betterAuth";
-import { createBoard, deleteBoard, getBoard, getBoardByName, listBoards, updateBoard } from "./boardRepo";
+import { createBoard, deleteBoard, getBoard, getBoardByName, getBoardBySlug, listBoards, updateBoard } from "./boardRepo";
 import { createBoardSSEResponse } from "./boardSSE";
 import { createLogger } from "./logger";
 import { deleteMachine, getMachine, listMachines, updateMachine, upsertMachine } from "./machineRepo";
@@ -74,6 +74,75 @@ api.on(["GET", "POST"], "/api/auth/**", async (c) => {
 });
 
 api.get("/api/ping", (c) => c.json({ pong: true }));
+
+// ─── Public Share Routes (no auth required) ───
+
+api.get("/api/share/:slug", async (c) => {
+  const board = await getBoardBySlug(c.env.DB, c.req.param("slug"));
+  if (!board) throw new HTTPException(404, { message: "Board not found" });
+
+  const publicTasks = board.tasks.map((t) => ({
+    id: t.id,
+    title: t.title,
+    status: t.status,
+    priority: t.priority,
+    labels: t.labels,
+    agent_name: t.agent_name,
+    agent_public_key: t.agent_public_key,
+    created_at: t.created_at,
+    updated_at: t.updated_at,
+  }));
+
+  return c.json({ ...board, tasks: publicTasks });
+});
+
+api.get("/api/share/:slug/badge.svg", async (c) => {
+  const board = await getBoardBySlug(c.env.DB, c.req.param("slug"));
+  if (!board) throw new HTTPException(404, { message: "Board not found" });
+
+  const counts = { todo: 0, in_progress: 0, in_review: 0, done: 0 };
+  for (const t of board.tasks) {
+    if (t.status === "todo") counts.todo++;
+    else if (t.status === "in_progress") counts.in_progress++;
+    else if (t.status === "in_review") counts.in_review++;
+    else if (t.status === "done") counts.done++;
+  }
+
+  const label = board.name;
+  const value = `${counts.todo} todo · ${counts.in_progress} active · ${counts.in_review} review · ${counts.done} done`;
+
+  const labelWidth = Math.max(label.length * 7 + 16, 60);
+  const valueWidth = value.length * 6.5 + 16;
+  const totalWidth = labelWidth + valueWidth;
+
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${totalWidth}" height="20">
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="${totalWidth}" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="${labelWidth}" height="20" fill="#1e293b"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="20" fill="#0891b2"/>
+    <rect width="${totalWidth}" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="${labelWidth / 2}" y="15" fill="#010101" fill-opacity=".3">${label}</text>
+    <text x="${labelWidth / 2}" y="14">${label}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="15" fill="#010101" fill-opacity=".3">${value}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="14">${value}</text>
+  </g>
+</svg>`;
+
+  return new Response(svg, {
+    headers: {
+      "Content-Type": "image/svg+xml",
+      "Cache-Control": "public, max-age=300",
+    },
+  });
+});
 
 // Auth middleware for all API routes (except Better Auth's own endpoints)
 api.use("/api/*", async (c, next) => {
@@ -472,7 +541,7 @@ api.get("/api/boards/:id", async (c) => {
 });
 
 api.patch("/api/boards/:id", async (c) => {
-  const body = await c.req.json<{ name?: string; description?: string }>();
+  const body = await c.req.json<{ name?: string; description?: string; visibility?: "private" | "public" }>();
   const board = await updateBoard(c.env.DB, c.req.param("id"), body);
   if (!board) throw new HTTPException(404, { message: "Board not found" });
   return c.json(board);

--- a/apps/web/migrations/0008_board_sharing.sql
+++ b/apps/web/migrations/0008_board_sharing.sql
@@ -1,0 +1,5 @@
+-- Board sharing: visibility toggle and public share slug
+ALTER TABLE boards ADD COLUMN visibility TEXT NOT NULL DEFAULT 'private';
+ALTER TABLE boards ADD COLUMN share_slug TEXT;
+
+CREATE UNIQUE INDEX idx_boards_share_slug ON boards(share_slug);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,7 @@ import { MachinesPage } from "./routes/MachinesPage";
 import { NewBoardPage } from "./routes/NewBoardPage";
 import { OnboardingPage } from "./routes/OnboardingPage";
 import { RepositoriesPage } from "./routes/RepositoriesPage";
+import { SharePage } from "./routes/SharePage";
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { data: session, isPending } = useSession();
@@ -39,6 +40,7 @@ export function App() {
         <Route path="/auth" element={<AuthPage />} />
         <Route path="/auth/callback" element={<AuthCallbackPage />} />
         <Route path="/landing" element={<LandingPage />} />
+        <Route path="/share/:slug" element={<SharePage />} />
         <Route path="/" element={<RootRoute />} />
         <Route
           path="/onboarding"

--- a/apps/web/src/components/BoardShareSettings.tsx
+++ b/apps/web/src/components/BoardShareSettings.tsx
@@ -1,0 +1,163 @@
+import { useState } from "react";
+import { useUpdateBoard } from "../hooks/useBoard";
+import { Button } from "./ui/button";
+
+const BASE_URL = "https://ak.tftt.cc";
+
+interface BoardShareSettingsProps {
+  board: { id: string; name: string; visibility: "private" | "public"; share_slug: string | null };
+}
+
+export function BoardShareSettings({ board }: BoardShareSettingsProps) {
+  const updateBoard = useUpdateBoard();
+  const [copiedLink, setCopiedLink] = useState(false);
+  const [copiedBadge, setCopiedBadge] = useState(false);
+
+  const isPublic = board.visibility === "public";
+
+  async function toggleVisibility() {
+    await updateBoard.mutateAsync({
+      id: board.id,
+      visibility: isPublic ? "private" : "public",
+    });
+  }
+
+  async function copyLink() {
+    if (!board.share_slug) return;
+    await navigator.clipboard.writeText(`${BASE_URL}/share/${board.share_slug}`);
+    setCopiedLink(true);
+    setTimeout(() => setCopiedLink(false), 2000);
+  }
+
+  async function copyBadge() {
+    if (!board.share_slug) return;
+    const url = `${BASE_URL}/share/${board.share_slug}`;
+    const badgeUrl = `${BASE_URL}/api/share/${board.share_slug}/badge.svg`;
+    const markdown = `[![Agent Kanban](${badgeUrl})](${url})`;
+    await navigator.clipboard.writeText(markdown);
+    setCopiedBadge(true);
+    setTimeout(() => setCopiedBadge(false), 2000);
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button variant={isPublic ? "secondary" : "outline"} size="xs" onClick={toggleVisibility} disabled={updateBoard.isPending} className="gap-1.5">
+        {isPublic ? (
+          <>
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <circle cx="12" cy="12" r="10" />
+              <line x1="2" y1="12" x2="22" y2="12" />
+              <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+            </svg>
+            Public
+          </>
+        ) : (
+          <>
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+              <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+            </svg>
+            Private
+          </>
+        )}
+      </Button>
+
+      {isPublic && board.share_slug && (
+        <>
+          <Button variant="outline" size="xs" onClick={copyLink} className="gap-1.5">
+            {copiedLink ? (
+              <>
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+                Copied!
+              </>
+            ) : (
+              <>
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                  <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+                </svg>
+                Copy Link
+              </>
+            )}
+          </Button>
+
+          <Button variant="outline" size="xs" onClick={copyBadge} className="gap-1.5">
+            {copiedBadge ? (
+              <>
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+                Copied!
+              </>
+            ) : (
+              <>
+                <svg
+                  width="12"
+                  height="12"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                  <line x1="3" y1="9" x2="21" y2="9" />
+                  <line x1="9" y1="21" x2="9" y2="9" />
+                </svg>
+                Copy Badge
+              </>
+            )}
+          </Button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/FilterBar.tsx
+++ b/apps/web/src/components/FilterBar.tsx
@@ -1,24 +1,35 @@
+import { BoardShareSettings } from "./BoardShareSettings";
 import { Button } from "./ui/button";
 
 interface FilterBarProps {
   repositories: { id: string; name: string }[];
   activeRepository: string | null;
   onRepositoryChange: (repository: string | null) => void;
+  board?: { id: string; name: string; visibility: "private" | "public"; share_slug: string | null } | null;
 }
 
-export function FilterBar({ repositories, activeRepository, onRepositoryChange }: FilterBarProps) {
-  if (repositories.length === 0) return null;
+export function FilterBar({ repositories, activeRepository, onRepositoryChange, board }: FilterBarProps) {
+  const hasRepositories = repositories.length > 0;
+
+  if (!hasRepositories && !board) return null;
 
   return (
-    <div className="flex gap-2 px-5 py-2.5 border-b border-border">
-      <Button variant={activeRepository === null ? "secondary" : "outline"} size="xs" onClick={() => onRepositoryChange(null)}>
-        All repos
-      </Button>
-      {repositories.map((r) => (
-        <Button key={r.id} variant={activeRepository === r.id ? "secondary" : "outline"} size="xs" onClick={() => onRepositoryChange(r.id)}>
-          {r.name}
-        </Button>
-      ))}
+    <div className="flex items-center justify-between gap-2 px-5 py-2.5 border-b border-border">
+      <div className="flex gap-2">
+        {hasRepositories && (
+          <>
+            <Button variant={activeRepository === null ? "secondary" : "outline"} size="xs" onClick={() => onRepositoryChange(null)}>
+              All repos
+            </Button>
+            {repositories.map((r) => (
+              <Button key={r.id} variant={activeRepository === r.id ? "secondary" : "outline"} size="xs" onClick={() => onRepositoryChange(r.id)}>
+                {r.name}
+              </Button>
+            ))}
+          </>
+        )}
+      </div>
+      {board && <BoardShareSettings board={board} />}
     </div>
   );
 }

--- a/apps/web/src/hooks/useBoard.ts
+++ b/apps/web/src/hooks/useBoard.ts
@@ -66,9 +66,11 @@ export function useUpdateBoard() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, ...body }: { id: string; name?: string; description?: string }) => api.boards.update(id, body),
-    onSuccess: () => {
+    mutationFn: ({ id, ...body }: { id: string; name?: string; description?: string; visibility?: "private" | "public" }) =>
+      api.boards.update(id, body),
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ["boards"] });
+      if (data?.id) queryClient.setQueryData(["board", data.id], data);
     },
   });
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -90,7 +90,11 @@ export const api = {
     delete: (id: string) => request<void>("DELETE", `/boards/${id}`),
   },
   share: {
-    getBoard: (slug: string) => fetch(`/api/share/${slug}`).then((r) => r.json()) as Promise<any>,
+    getBoard: (slug: string) =>
+      fetch(`/api/share/${slug}`).then((r) => {
+        if (!r.ok) throw new Error("Board not found");
+        return r.json();
+      }) as Promise<any>,
   },
   repositories: {
     list: () => request<any[]>("GET", "/repositories"),

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -85,8 +85,12 @@ export const api = {
     list: () => request<any[]>("GET", "/boards"),
     get: (id: string) => request<any>("GET", `/boards/${id}`),
     create: (input: { name: string; description?: string }) => request<any>("POST", "/boards", input),
-    update: (id: string, body: { name?: string; description?: string }) => request<any>("PATCH", `/boards/${id}`, body),
+    update: (id: string, body: { name?: string; description?: string; visibility?: "private" | "public" }) =>
+      request<any>("PATCH", `/boards/${id}`, body),
     delete: (id: string) => request<void>("DELETE", `/boards/${id}`),
+  },
+  share: {
+    getBoard: (slug: string) => fetch(`/api/share/${slug}`).then((r) => r.json()) as Promise<any>,
   },
   repositories: {
     list: () => request<any[]>("GET", "/repositories"),

--- a/apps/web/src/routes/BoardPage.tsx
+++ b/apps/web/src/routes/BoardPage.tsx
@@ -86,7 +86,7 @@ export function BoardPage() {
   return (
     <div className="h-screen overflow-hidden bg-surface-primary flex flex-col">
       <Header />
-      <FilterBar repositories={repositories} activeRepository={activeRepository} onRepositoryChange={setActiveRepository} />
+      <FilterBar repositories={repositories} activeRepository={activeRepository} onRepositoryChange={setActiveRepository} board={board} />
 
       {error && (
         <div className="mx-5 mt-3 px-4 py-2 bg-error/10 border-l-2 border-error text-error text-sm rounded">

--- a/apps/web/src/routes/SharePage.tsx
+++ b/apps/web/src/routes/SharePage.tsx
@@ -1,0 +1,122 @@
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { Link, useParams } from "react-router-dom";
+import { KanbanColumn } from "../components/KanbanColumn";
+import { api } from "../lib/api";
+
+const TASK_STATUSES = ["todo", "in_progress", "in_review", "done", "cancelled"] as const;
+
+const TASK_STATUS_LABELS: Record<string, string> = {
+  todo: "Todo",
+  in_progress: "In Progress",
+  in_review: "In Review",
+  done: "Done",
+  cancelled: "Cancelled",
+};
+
+export function SharePage() {
+  const { slug } = useParams<{ slug: string }>();
+
+  const {
+    data: board,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ["share", slug],
+    queryFn: () => api.share.getBoard(slug!),
+    enabled: !!slug,
+    refetchInterval: 60_000,
+  });
+
+  const columns = useMemo(() => {
+    if (!board?.tasks) return [];
+    return TASK_STATUSES.map((status) => ({
+      status,
+      name: TASK_STATUS_LABELS[status],
+      tasks: board.tasks.filter((t: any) => t.status === status),
+    }));
+  }, [board]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-surface-primary flex flex-col">
+        <div className="px-5 py-3 border-b border-border bg-surface-secondary">
+          <span className="text-[15px] font-bold tracking-tight text-content-primary">
+            Agent <span className="text-accent">Kanban</span>
+          </span>
+        </div>
+        <div className="grid gap-0 p-4" style={{ gridTemplateColumns: `repeat(5, minmax(0, 1fr))` }}>
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div key={i} className="p-4 space-y-3">
+              <div className="h-4 w-20 bg-surface-tertiary rounded animate-pulse" />
+              {[0, 1].map((j) => (
+                <div key={j} className="h-20 bg-surface-secondary border border-border rounded-lg animate-pulse" />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !board) {
+    return (
+      <div className="min-h-screen bg-surface-primary flex flex-col">
+        <div className="px-5 py-3 border-b border-border bg-surface-secondary">
+          <span className="text-[15px] font-bold tracking-tight text-content-primary">
+            Agent <span className="text-accent">Kanban</span>
+          </span>
+        </div>
+        <div className="flex items-center justify-center flex-1 text-content-tertiary">Board not found or not public</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-screen overflow-hidden bg-surface-primary flex flex-col">
+      {/* Minimal header */}
+      <header className="flex items-center justify-between px-5 py-3 border-b border-border bg-surface-secondary flex-shrink-0">
+        <div className="flex items-center gap-2">
+          <span className="text-[15px] font-bold tracking-tight text-content-primary">
+            Agent <span className="text-accent">Kanban</span>
+          </span>
+          <span className="text-content-tertiary text-xs">/</span>
+          <span className="text-sm font-medium text-content-primary">{board.name}</span>
+        </div>
+        <Link to="/auth" className="text-xs text-content-tertiary hover:text-accent transition-colors">
+          Sign in →
+        </Link>
+      </header>
+
+      {board.description && <div className="px-5 py-2.5 border-b border-border text-sm text-content-secondary">{board.description}</div>}
+
+      {/* Desktop: 5-column kanban */}
+      <div className="hidden md:grid flex-1 overflow-hidden" style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))` }}>
+        {columns.map((col) => (
+          <KanbanColumn key={col.status} column={col} onTaskClick={() => {}} />
+        ))}
+      </div>
+
+      {/* Mobile: stacked columns */}
+      <div className="md:hidden flex-1 overflow-y-auto">
+        {columns.map((col) => (
+          <div key={col.status}>
+            <KanbanColumn column={col} onTaskClick={() => {}} />
+          </div>
+        ))}
+      </div>
+
+      {/* Footer */}
+      <footer className="flex-shrink-0 py-3 text-center border-t border-border bg-surface-secondary">
+        <a
+          href="https://ak.tftt.cc"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-content-tertiary hover:text-accent transition-colors"
+        >
+          Powered by Agent Kanban
+        </a>
+      </footer>
+    </div>
+  );
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -5,6 +5,8 @@ export interface Board {
   owner_id: string;
   name: string;
   description: string | null;
+  visibility: "private" | "public";
+  share_slug: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary

- **DB migration** (`0008_board_sharing.sql`): adds `visibility TEXT NOT NULL DEFAULT 'private'` and `share_slug TEXT` columns to `boards`, plus a unique index on `share_slug`
- **Shared types**: `Board` interface extended with `visibility` and `share_slug` fields
- **Backend** (`boardRepo.ts`): `updateBoard` accepts `visibility`; generates a `nanoid(10)` slug on first publish to public. New `getBoardBySlug` for public board lookup
- **Backend** (`routes.ts`): two unauthenticated public routes added before auth middleware:
  - `GET /api/share/:slug` — returns board + stripped tasks (no description/input/logs)
  - `GET /api/share/:slug/badge.svg` — shields.io-style SVG badge with task counts; `Cache-Control: public, max-age=300`
- **Frontend**: `FilterBar` now shows `BoardShareSettings` component on board pages — Private/Public toggle, Copy Link button, Copy Badge button (copies markdown)
- **Frontend**: New `/share/:slug` public route renders read-only kanban board with minimal chrome and "Powered by Agent Kanban" footer

## Test plan

- [ ] Toggle board from Private → Public: slug is generated, Copy Link and Copy Badge buttons appear
- [ ] Toggle back to Private: slug is preserved (re-enabling public restores same URL)
- [ ] Visit `/share/:slug` — board renders read-only with no auth requirement
- [ ] `/api/share/:slug/badge.svg` returns valid SVG with board name and task counts
- [ ] Copy Link copies `https://ak.tftt.cc/share/:slug`
- [ ] Copy Badge copies markdown with badge URL and link
- [ ] Non-existent or private board slug returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)