### PR TITLE
feat: integrate Better Auth admin plugin + DB migration

### DIFF
--- a/apps/web/functions/api/auth.ts
+++ b/apps/web/functions/api/auth.ts
@@ -63,6 +63,10 @@ const ROUTE_RULES: { method: string; pattern: RegExp; rule: RouteRule }[] = [
 
   // Sessions — machine reopen
   { method: "POST", pattern: /^\/api\/agents\/[^/]+\/sessions\/[^/]+\/reopen$/, rule: { allow: ["machine"] } },
+
+  // Admin — user identity only (Better Auth plugin enforces role internally)
+  { method: "POST", pattern: /^\/api\/auth\/admin\//, rule: { allow: ["user"] } },
+  { method: "GET", pattern: /^\/api\/auth\/admin\//, rule: { allow: ["user"] } },
 ];
 
 function matchRouteRule(method: string, path: string): RouteRule | null {

--- a/apps/web/functions/api/betterAuth.ts
+++ b/apps/web/functions/api/betterAuth.ts
@@ -1,7 +1,7 @@
 import { agentAuth } from "@better-auth/agent-auth";
 import { apiKey } from "@better-auth/api-key";
 import { betterAuth } from "better-auth";
-import { bearer } from "better-auth/plugins";
+import { admin, bearer } from "better-auth/plugins";
 import { Kysely } from "kysely";
 import { D1Dialect } from "kysely-d1";
 import type { Env } from "./types";
@@ -30,6 +30,13 @@ export function createAuth(env: Env) {
     },
     plugins: [
       bearer(),
+      // Admin plugin enables /api/auth/admin/* endpoints (list-users, ban-user, set-role, etc.)
+      // First admin must be set manually via D1 console:
+      //   UPDATE user SET role = 'admin' WHERE email = '...'
+      admin({
+        defaultRole: "user",
+        adminRoles: ["admin"],
+      }),
       apiKey({
         defaultPrefix: "ak_",
         enableMetadata: true,

--- a/apps/web/migrations/0009_admin_fields.sql
+++ b/apps/web/migrations/0009_admin_fields.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "user" ADD COLUMN "role" TEXT DEFAULT 'user';
+ALTER TABLE "user" ADD COLUMN "banned" INTEGER DEFAULT 0;
+ALTER TABLE "user" ADD COLUMN "banReason" TEXT;
+ALTER TABLE "user" ADD COLUMN "banExpires" TEXT;

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -23,6 +23,8 @@ export async function applyMigrations(db: D1Database) {
     "0005_agent_runtime_required.sql",
     "0006_add_device_id.sql",
     "0007_task_seq.sql",
+    "0008_board_sharing.sql",
+    "0009_admin_fields.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");


### PR DESCRIPTION
## Summary

- Adds `admin()` plugin to `betterAuth.ts` from `better-auth/plugins` with `defaultRole: "user"` and `adminRoles: ["admin"]`
- Creates `apps/web/migrations/0009_admin_fields.sql` with `role`, `banned`, `banReason`, `banExpires` columns on the `user` table
- Adds route rules in `auth.ts` ROUTE_RULES to restrict `GET/POST /api/auth/admin/*` to `user` identity type only
- Updates test helper `applyMigrations` to include migrations 0008 and 0009
- Documents manual first-admin setup via D1 console in a code comment

## Test plan

- [x] All 567 unit/integration tests pass
- [x] TypeScript type check passes (biome + tsc --noEmit)
- [x] `routes.test.ts` passes end-to-end (previously failing due to missing `role` column)
- [ ] Apply migration to staging D1: `wrangler d1 migrations apply <DB>`
- [ ] Verify `/api/auth/admin/list-users` accessible only with user session, not API key or agent JWT
- [ ] Promote first admin via D1 console: `UPDATE user SET role = 'admin' WHERE email = '...'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)