### PR TITLE
feat(auth): add adminClient plugin to auth client

### DIFF
--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,5 +1,6 @@
 import { agentAuthClient } from "@better-auth/agent-auth/client";
 import { apiKeyClient } from "@better-auth/api-key/client";
+import { adminClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/react";
 
 const TOKEN_KEY = "auth-token";
@@ -17,7 +18,7 @@ export function clearAuthToken() {
 }
 
 export const authClient = createAuthClient({
-  plugins: [agentAuthClient(), apiKeyClient()],
+  plugins: [agentAuthClient(), apiKeyClient(), adminClient()],
   fetchOptions: {
     auth: {
       type: "Bearer",


### PR DESCRIPTION
## Summary
- Import `adminClient` from `better-auth/client/plugins`
- Add `adminClient()` to the `plugins` array in `createAuthClient`
- Consumers can now call `authClient.admin.*` methods for user management (listUsers, banUser, unbanUser, setRole, removeUser, listUserSessions, revokeUserSession)

## Test plan
- [x] TypeScript type-check passes
- [x] Full build succeeds
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)