### PR TITLE
feat(admin): add GET /api/admin/stats system overview endpoint

### DIFF
--- a/apps/web/functions/api/auth.ts
+++ b/apps/web/functions/api/auth.ts
@@ -67,6 +67,9 @@ const ROUTE_RULES: { method: string; pattern: RegExp; rule: RouteRule }[] = [
   // Admin — user identity only (Better Auth plugin enforces role internally)
   { method: "POST", pattern: /^\/api\/auth\/admin\//, rule: { allow: ["user"] } },
   { method: "GET", pattern: /^\/api\/auth\/admin\//, rule: { allow: ["user"] } },
+
+  // Admin stats — user identity only (role check in handler)
+  { method: "GET", pattern: /^\/api\/admin\/stats$/, rule: { allow: ["user"] } },
 ];
 
 function matchRouteRule(method: string, path: string): RouteRule | null {

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -12,6 +12,7 @@ import { deleteMachine, getMachine, listMachines, updateMachine, upsertMachine }
 import { createMessage, listMessages } from "./messageRepo";
 import { createRepository, deleteRepository, getRepository, listRepositories } from "./repositoryRepo";
 import { createSSEResponse } from "./sse";
+import { getSystemStats } from "./statsRepo";
 import {
   addTaskAction,
   assignTask,
@@ -561,6 +562,16 @@ api.delete("/api/boards/:id", async (c) => {
   const deleted = await deleteBoard(c.env.DB, c.req.param("id"));
   if (!deleted) throw new HTTPException(404, { message: "Board not found" });
   return c.json({ ok: true });
+});
+
+// ─── Admin ───
+
+api.get("/api/admin/stats", async (c) => {
+  if ((c.get("user") as any)?.role !== "admin") {
+    return c.json({ error: { code: "FORBIDDEN", message: "Admin role required" } }, 403);
+  }
+  const stats = await getSystemStats(c.env.DB);
+  return c.json(stats);
 });
 
 // ─── Repositories ───

--- a/apps/web/functions/api/statsRepo.ts
+++ b/apps/web/functions/api/statsRepo.ts
@@ -1,0 +1,52 @@
+import type { D1 } from "./db";
+
+export interface SystemStats {
+  users: { total: number; recent: number };
+  agents: { total: number; online: number };
+  tasks: { todo: number; in_progress: number; in_review: number; done: number; cancelled: number };
+  boards: { total: number };
+  machines: { total: number; online: number };
+}
+
+type CountRow = { "COUNT(*)": number };
+type TaskStatusRow = { status: string; count: number };
+
+export async function getSystemStats(db: D1): Promise<SystemStats> {
+  const [usersTotal, usersRecent, agentsTotal, agentsOnline, tasksByStatus, boardsTotal, machinesTotal, machinesOnline] = await db.batch([
+    db.prepare("SELECT COUNT(*) FROM user"),
+    db.prepare("SELECT COUNT(*) FROM user WHERE createdAt > datetime('now', '-7 days')"),
+    db.prepare("SELECT COUNT(*) FROM agents"),
+    db.prepare(
+      "SELECT COUNT(*) FROM agents WHERE EXISTS (SELECT 1 FROM agent_sessions WHERE agent_sessions.agent_id = agents.id AND agent_sessions.status = 'active')",
+    ),
+    db.prepare("SELECT status, COUNT(*) as count FROM tasks GROUP BY status"),
+    db.prepare("SELECT COUNT(*) FROM boards"),
+    db.prepare("SELECT COUNT(*) FROM machines"),
+    db.prepare("SELECT COUNT(*) FROM machines WHERE status = 'online'"),
+  ]);
+
+  const taskCounts = { todo: 0, in_progress: 0, in_review: 0, done: 0, cancelled: 0 };
+  for (const row of tasksByStatus.results as TaskStatusRow[]) {
+    const s = row.status as keyof typeof taskCounts;
+    if (s in taskCounts) taskCounts[s] = row.count;
+  }
+
+  return {
+    users: {
+      total: (usersTotal.results[0] as CountRow)["COUNT(*)"],
+      recent: (usersRecent.results[0] as CountRow)["COUNT(*)"],
+    },
+    agents: {
+      total: (agentsTotal.results[0] as CountRow)["COUNT(*)"],
+      online: (agentsOnline.results[0] as CountRow)["COUNT(*)"],
+    },
+    tasks: taskCounts,
+    boards: {
+      total: (boardsTotal.results[0] as CountRow)["COUNT(*)"],
+    },
+    machines: {
+      total: (machinesTotal.results[0] as CountRow)["COUNT(*)"],
+      online: (machinesOnline.results[0] as CountRow)["COUNT(*)"],
+    },
+  };
+}

--- a/tests/admin-stats.test.ts
+++ b/tests/admin-stats.test.ts
@@ -1,0 +1,305 @@
+// @vitest-environment node
+
+import { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getSystemStats } from "../apps/web/functions/api/statsRepo";
+import { createTestEnv, seedUser, setupMiniflare } from "./helpers/db";
+
+const env = createTestEnv();
+let mf: Miniflare;
+
+async function apiRequest(method: string, path: string, body?: Record<string, unknown>, token?: string) {
+  const { api } = await import("../apps/web/functions/api/routes");
+  const headers: Record<string, string> = { "Content-Type": "application/json", Host: "localhost:8788", "x-forwarded-proto": "http" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const init: RequestInit = { method, headers };
+  if (body && method !== "GET") init.body = JSON.stringify(body);
+  return api.request(path, init, env);
+}
+
+beforeAll(async () => {
+  ({ mf, db: env.DB } = await setupMiniflare());
+});
+
+afterAll(async () => {
+  await mf.dispose();
+});
+
+// ─── getSystemStats unit tests ───
+
+describe("getSystemStats", () => {
+  it("returns the correct shape with all expected top-level fields", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(stats).toHaveProperty("users");
+    expect(stats).toHaveProperty("agents");
+    expect(stats).toHaveProperty("tasks");
+    expect(stats).toHaveProperty("boards");
+    expect(stats).toHaveProperty("machines");
+  });
+
+  it("returns users.total as a number", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(typeof stats.users.total).toBe("number");
+  });
+
+  it("returns users.recent as a number", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(typeof stats.users.recent).toBe("number");
+  });
+
+  it("returns agents.total as a number", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(typeof stats.agents.total).toBe("number");
+  });
+
+  it("returns agents.online as a number", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(typeof stats.agents.online).toBe("number");
+  });
+
+  it("returns tasks with all five status fields", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(typeof stats.tasks.todo).toBe("number");
+    expect(typeof stats.tasks.in_progress).toBe("number");
+    expect(typeof stats.tasks.in_review).toBe("number");
+    expect(typeof stats.tasks.done).toBe("number");
+    expect(typeof stats.tasks.cancelled).toBe("number");
+  });
+
+  it("returns boards.total as a number", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(typeof stats.boards.total).toBe("number");
+  });
+
+  it("returns machines.total as a number", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(typeof stats.machines.total).toBe("number");
+  });
+
+  it("returns machines.online as a number", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(typeof stats.machines.online).toBe("number");
+  });
+
+  it("returns zero task counts on an empty database", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(stats.tasks.todo).toBe(0);
+    expect(stats.tasks.in_progress).toBe(0);
+    expect(stats.tasks.in_review).toBe(0);
+    expect(stats.tasks.done).toBe(0);
+    expect(stats.tasks.cancelled).toBe(0);
+  });
+
+  it("returns zero board count on an empty database", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(stats.boards.total).toBe(0);
+  });
+
+  it("returns zero machine counts on an empty database", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(stats.machines.total).toBe(0);
+    expect(stats.machines.online).toBe(0);
+  });
+
+  it("returns zero agent counts on an empty database", async () => {
+    const stats = await getSystemStats(env.DB);
+    expect(stats.agents.total).toBe(0);
+    expect(stats.agents.online).toBe(0);
+  });
+
+  it("reflects seeded users in users.total", async () => {
+    const before = await getSystemStats(env.DB);
+    await seedUser(env.DB, "stats-seed-user-1", "stats-seed-1@test.com");
+    const after = await getSystemStats(env.DB);
+    expect(after.users.total).toBeGreaterThan(before.users.total);
+  });
+
+  it("reflects a recently created user in users.recent", async () => {
+    const before = await getSystemStats(env.DB);
+    await seedUser(env.DB, "stats-seed-user-2", "stats-seed-2@test.com");
+    const after = await getSystemStats(env.DB);
+    expect(after.users.recent).toBeGreaterThan(before.users.recent);
+  });
+
+  it("reflects seeded boards in boards.total", async () => {
+    const before = await getSystemStats(env.DB);
+    const userId = "stats-board-owner";
+    await seedUser(env.DB, userId, "stats-board-owner@test.com");
+    const { createBoard } = await import("../apps/web/functions/api/boardRepo");
+    await createBoard(env.DB, userId, "Stats Test Board");
+    const after = await getSystemStats(env.DB);
+    expect(after.boards.total).toBeGreaterThan(before.boards.total);
+  });
+
+  it("reflects task status counts after seeding tasks", async () => {
+    const userId = "stats-task-owner";
+    await seedUser(env.DB, userId, "stats-task-owner@test.com");
+    const { createBoard } = await import("../apps/web/functions/api/boardRepo");
+    const board = await createBoard(env.DB, userId, "Stats Task Board");
+    const { createTask } = await import("../apps/web/functions/api/taskRepo");
+    await createTask(env.DB, userId, { title: "Stats Todo Task", board_id: board.id });
+
+    const stats = await getSystemStats(env.DB);
+    expect(stats.tasks.todo).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reflects done task count after updating task to done", async () => {
+    const userId = "stats-done-owner";
+    await seedUser(env.DB, userId, "stats-done-owner@test.com");
+    const { createBoard } = await import("../apps/web/functions/api/boardRepo");
+    const board = await createBoard(env.DB, userId, "Stats Done Board");
+    const { createTask } = await import("../apps/web/functions/api/taskRepo");
+    const task = await createTask(env.DB, userId, { title: "Stats Done Task", board_id: board.id });
+    await env.DB.prepare("UPDATE tasks SET status = 'done' WHERE id = ?").bind(task.id).run();
+
+    const stats = await getSystemStats(env.DB);
+    expect(stats.tasks.done).toBeGreaterThanOrEqual(1);
+  });
+
+  it("reflects seeded agents in agents.total", async () => {
+    const before = await getSystemStats(env.DB);
+    const userId = "stats-agent-owner";
+    await seedUser(env.DB, userId, "stats-agent-owner@test.com");
+    const { createAgent } = await import("../apps/web/functions/api/agentRepo");
+    await createAgent(env.DB, userId, { name: "Stats Agent", runtime: "claude" });
+    const after = await getSystemStats(env.DB);
+    expect(after.agents.total).toBeGreaterThan(before.agents.total);
+  });
+});
+
+// ─── GET /api/admin/stats route tests ───
+
+describe("GET /api/admin/stats", () => {
+  let adminToken: string;
+  let regularToken: string;
+  let machineApiKey: string;
+
+  beforeAll(async () => {
+    const { createAuth } = await import("../apps/web/functions/api/betterAuth");
+    const auth = createAuth(env);
+
+    // Create admin user via signup then elevate role
+    const adminResult = await auth.api.signUpEmail({
+      body: { name: "Admin Stats User", email: "admin-stats@test.com", password: "admin-password-123" },
+    });
+    if (!adminResult.token) throw new Error("admin signUpEmail did not return a token");
+    await env.DB.prepare("UPDATE user SET role = 'admin' WHERE email = ?").bind("admin-stats@test.com").run();
+    adminToken = adminResult.token;
+
+    // Create regular (non-admin) user via signup
+    const regularResult = await auth.api.signUpEmail({
+      body: { name: "Regular Stats User", email: "regular-stats@test.com", password: "regular-password-123" },
+    });
+    if (!regularResult.token) throw new Error("regular signUpEmail did not return a token");
+    regularToken = regularResult.token;
+
+    // Create a machine API key for testing machine identity blocking
+    const machineKeyResult = await auth.api.createApiKey({ body: { userId: "machine-owner-for-stats" } });
+    machineApiKey = machineKeyResult.key;
+  });
+
+  it("returns 401 when no token is provided", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a regular (non-admin) user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, regularToken);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns FORBIDDEN error code for a non-admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, regularToken);
+    const body = (await res.json()) as any;
+    expect(body.error).toBeDefined();
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 403 for machine identity (API key auth)", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, machineApiKey);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 200 for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    expect(res.status).toBe(200);
+  });
+
+  it("returns users field in stats for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(body).toHaveProperty("users");
+  });
+
+  it("returns agents field in stats for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(body).toHaveProperty("agents");
+  });
+
+  it("returns tasks field in stats for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(body).toHaveProperty("tasks");
+  });
+
+  it("returns boards field in stats for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(body).toHaveProperty("boards");
+  });
+
+  it("returns machines field in stats for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(body).toHaveProperty("machines");
+  });
+
+  it("returns numeric users.total for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(typeof body.users.total).toBe("number");
+  });
+
+  it("returns numeric users.recent for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(typeof body.users.recent).toBe("number");
+  });
+
+  it("returns numeric agents.total for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(typeof body.agents.total).toBe("number");
+  });
+
+  it("returns numeric agents.online for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(typeof body.agents.online).toBe("number");
+  });
+
+  it("returns numeric tasks.todo for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(typeof body.tasks.todo).toBe("number");
+  });
+
+  it("returns numeric boards.total for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(typeof body.boards.total).toBe("number");
+  });
+
+  it("returns numeric machines.total for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(typeof body.machines.total).toBe("number");
+  });
+
+  it("returns numeric machines.online for an admin user", async () => {
+    const res = await apiRequest("GET", "/api/admin/stats", undefined, adminToken);
+    const body = (await res.json()) as any;
+    expect(typeof body.machines.online).toBe("number");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `apps/web/functions/api/statsRepo.ts` with `getSystemStats()` that runs 8 COUNT queries in parallel via `db.batch()`
- Adds `GET /api/admin/stats` route in `routes.ts` with admin-role enforcement (`403` for non-admin users)
- Adds auth rule in `auth.ts` restricting the endpoint to `user` identity type
- Fixes a subtle bug: `agents` table has no `status` column; online status is derived from `agent_sessions` via an EXISTS subquery
- Adds 37 integration tests in `tests/admin-stats.test.ts` covering auth, shape, and data correctness

## Test plan
- [ ] `GET /api/admin/stats` returns 401 with no token
- [ ] `GET /api/admin/stats` returns 403 for regular (non-admin) user
- [ ] `GET /api/admin/stats` returns 403 for machine API key
- [ ] `GET /api/admin/stats` returns 200 with correct stats shape for admin user
- [ ] All 604 tests pass: `npx vitest run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)