### PR TITLE
feat: admin section with layout, route guard, and dashboard

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -7,6 +7,8 @@ import { AgentNewPage } from "./routes/AgentNewPage";
 import { AgentsPage } from "./routes/AgentsPage";
 import { AuthCallbackPage } from "./routes/AuthCallbackPage";
 import { AuthPage } from "./routes/AuthPage";
+import { AdminDashboardPage } from "./routes/admin/AdminDashboardPage";
+import { AdminLayout } from "./routes/admin/AdminLayout";
 import { BoardPage } from "./routes/BoardPage";
 import { BoardRedirect } from "./routes/BoardRedirect";
 import { LandingPage } from "./routes/LandingPage";
@@ -22,6 +24,15 @@ function ProtectedRoute({ children }: { children: React.ReactNode }) {
 
   if (isPending) return null;
   if (!session) return <Navigate to="/auth" replace />;
+  return <>{children}</>;
+}
+
+function AdminRoute({ children }: { children: React.ReactNode }) {
+  const { data: session, isPending } = useSession();
+
+  if (isPending) return null;
+  if (!session) return <Navigate to="/auth" replace />;
+  if ((session.user as any).role !== "admin") return <Navigate to="/" replace />;
   return <>{children}</>;
 }
 
@@ -130,6 +141,17 @@ export function App() {
             </ProtectedRoute>
           }
         />
+        <Route
+          path="/admin"
+          element={
+            <AdminRoute>
+              <AdminLayout />
+            </AdminRoute>
+          }
+        >
+          <Route index element={<AdminDashboardPage />} />
+          <Route path="users" element={<div className="px-8 py-10 text-zinc-400 text-sm">Users — coming soon</div>} />
+        </Route>
       </Routes>
     </BrowserRouter>
   );

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -50,7 +50,8 @@ function ThemeIcon({ theme }: { theme: Theme }) {
 
 export function Header() {
   const { data: session } = useSession();
-  const user = session?.user as { name?: string; email?: string; image?: string } | undefined;
+  const user = session?.user as { name?: string; email?: string; image?: string; role?: string } | undefined;
+  const isAdmin = user?.role === "admin";
   const { boards, refresh: refreshBoards } = useBoards();
   const { boardId } = useParams<{ boardId: string }>();
 
@@ -171,6 +172,24 @@ export function Header() {
                 </svg>
                 Repositories
               </DropdownMenuItem>
+
+              {isAdmin && (
+                <DropdownMenuItem onClick={() => navigate("/admin")}>
+                  <svg
+                    width="14"
+                    height="14"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+                  </svg>
+                  Admin
+                </DropdownMenuItem>
+              )}
 
               <DropdownMenuSeparator />
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -101,4 +101,7 @@ export const api = {
     create: (input: { name: string; url: string }) => request<any>("POST", "/repositories", input),
     delete: (id: string) => request<void>("DELETE", `/repositories/${id}`),
   },
+  admin: {
+    getStats: () => request<any>("GET", "/admin/stats"),
+  },
 };

--- a/apps/web/src/routes/admin/AdminDashboardPage.tsx
+++ b/apps/web/src/routes/admin/AdminDashboardPage.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useState } from "react";
+import { Skeleton } from "../../components/ui/skeleton";
+import { api } from "../../lib/api";
+
+interface TasksByStatus {
+  todo: number;
+  in_progress: number;
+  in_review: number;
+  done: number;
+  cancelled: number;
+}
+
+interface AdminStats {
+  users: { total: number; new_this_week: number };
+  agents: { total: number; online: number };
+  tasks: { total: number; by_status: TasksByStatus };
+  boards: { total: number };
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  todo: "#71717A",
+  in_progress: "#22D3EE",
+  in_review: "#EAB308",
+  done: "#22C55E",
+  cancelled: "#3F3F46",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  todo: "Todo",
+  in_progress: "In Progress",
+  in_review: "In Review",
+  done: "Done",
+  cancelled: "Cancelled",
+};
+
+function StatCard({ label, value, subtitle }: { label: string; value: number; subtitle: string }) {
+  return (
+    <div className="bg-zinc-900 dark:bg-zinc-900 rounded-lg p-6 border border-zinc-800">
+      <p className="text-sm text-zinc-500 mb-1">{label}</p>
+      <p className="text-[32px] font-semibold text-zinc-100 leading-none" style={{ fontFamily: "Geist Mono, monospace" }}>
+        {value}
+      </p>
+      <p className="text-xs text-zinc-400 mt-2">{subtitle}</p>
+    </div>
+  );
+}
+
+function StatCardSkeleton() {
+  return (
+    <div className="bg-zinc-900 rounded-lg p-6 border border-zinc-800 space-y-3">
+      <Skeleton className="h-4 w-20 bg-zinc-800" />
+      <Skeleton className="h-9 w-16 bg-zinc-800" />
+      <Skeleton className="h-3 w-28 bg-zinc-800" />
+    </div>
+  );
+}
+
+type StatusKey = keyof TasksByStatus;
+
+function TaskStatusBar({ byStatus }: { byStatus: TasksByStatus }) {
+  const statuses: StatusKey[] = ["todo", "in_progress", "in_review", "done", "cancelled"];
+  const total = statuses.reduce((sum, s) => sum + (byStatus[s] || 0), 0);
+
+  if (total === 0) return null;
+
+  return (
+    <div className="mt-8">
+      <p className="text-sm font-medium text-zinc-400 mb-3">Task Status Breakdown</p>
+      <div className="flex h-3 rounded-full overflow-hidden gap-0.5">
+        {statuses.map((status) => {
+          const count = byStatus[status] || 0;
+          if (count === 0) return null;
+          const pct = (count / total) * 100;
+          return (
+            <div key={status} style={{ width: `${pct}%`, backgroundColor: STATUS_COLORS[status] }} title={`${STATUS_LABELS[status]}: ${count}`} />
+          );
+        })}
+      </div>
+      <div className="flex flex-wrap gap-4 mt-3">
+        {statuses.map((status) => {
+          const count = byStatus[status] || 0;
+          return (
+            <div key={status} className="flex items-center gap-1.5">
+              <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: STATUS_COLORS[status] }} />
+              <span className="text-xs text-zinc-500">{STATUS_LABELS[status]}</span>
+              <span className="text-xs font-mono text-zinc-400">{count}</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function AdminDashboardPage() {
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api.admin
+      .getStats()
+      .then(setStats)
+      .finally(() => setLoading(false));
+  }, []);
+
+  const tasksByStatus: TasksByStatus = stats?.tasks.by_status ?? { todo: 0, in_progress: 0, in_review: 0, done: 0, cancelled: 0 };
+  const activeTaskCount = (tasksByStatus.in_progress || 0) + (tasksByStatus.in_review || 0);
+
+  return (
+    <div className="px-8 py-10 max-w-5xl">
+      <h1 className="text-2xl font-semibold text-zinc-100 mb-8" style={{ letterSpacing: "-0.02em" }}>
+        Dashboard
+      </h1>
+
+      {loading ? (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {[0, 1, 2, 3].map((i) => (
+            <StatCardSkeleton key={i} />
+          ))}
+        </div>
+      ) : stats ? (
+        <>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <StatCard label="Users" value={stats.users.total} subtitle={`${stats.users.new_this_week} new this week`} />
+            <StatCard label="Agents" value={stats.agents.total} subtitle={`${stats.agents.online} online`} />
+            <StatCard label="Tasks" value={stats.tasks.total} subtitle={`${activeTaskCount} active`} />
+            <StatCard label="Boards" value={stats.boards.total} subtitle="" />
+          </div>
+          <TaskStatusBar byStatus={tasksByStatus} />
+        </>
+      ) : (
+        <p className="text-zinc-500 text-sm">Failed to load stats.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/admin/AdminLayout.tsx
+++ b/apps/web/src/routes/admin/AdminLayout.tsx
@@ -1,0 +1,63 @@
+import { BarChart3, ChevronLeft, LayoutDashboard, Users } from "lucide-react";
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
+
+const navItems = [
+  { to: "/admin", label: "Dashboard", icon: LayoutDashboard, end: true },
+  { to: "/admin/users", label: "Users", icon: Users },
+];
+
+export function AdminLayout() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="min-h-screen bg-surface-primary flex">
+      {/* Sidebar */}
+      <aside className="w-56 shrink-0 fixed top-0 left-0 h-full flex flex-col" style={{ background: "#18181B", borderRight: "1px solid #27272A" }}>
+        <div className="px-4 py-4 border-b" style={{ borderColor: "#27272A" }}>
+          <button onClick={() => navigate("/")} className="flex items-center gap-1.5 text-xs text-zinc-400 hover:text-zinc-200 transition-colors">
+            <ChevronLeft size={14} />
+            Back to Board
+          </button>
+        </div>
+
+        <div className="px-4 py-4 border-b" style={{ borderColor: "#27272A" }}>
+          <div className="flex items-center gap-2">
+            <BarChart3 size={16} className="text-[#22D3EE]" />
+            <span className="text-sm font-semibold text-zinc-100 tracking-tight">Admin</span>
+          </div>
+        </div>
+
+        <nav className="flex-1 px-2 py-3 space-y-0.5">
+          {navItems.map(({ to, label, icon: Icon, end }) => (
+            <NavLink
+              key={to}
+              to={to}
+              end={end}
+              className={({ isActive }) =>
+                `flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors relative ${
+                  isActive ? "text-[#22D3EE] bg-[#27272A]" : "text-zinc-400 hover:text-zinc-200 hover:bg-[#27272A]"
+                }`
+              }
+              style={({ isActive }) =>
+                isActive
+                  ? {
+                      borderLeft: "2px solid #22D3EE",
+                      paddingLeft: "calc(0.75rem - 2px)",
+                    }
+                  : { borderLeft: "2px solid transparent", paddingLeft: "calc(0.75rem - 2px)" }
+              }
+            >
+              <Icon size={15} />
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+
+      {/* Main content */}
+      <main className="flex-1 ml-56 min-h-screen">
+        <Outlet />
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **AdminRoute** guard component checks `session.user.role === "admin"`, redirects to `/` if not admin (follows `ProtectedRoute` pattern)
- **AdminLayout** (`/admin/*`) — fixed left sidebar (w-56, `#18181B` bg, `#22D3EE` cyan active accent with left border, NavLink active detection)
- **AdminDashboardPage** — fetches `GET /api/admin/stats`, displays 4 stat cards (Users/Agents/Tasks/Boards) in a 2×2→4-col responsive grid + horizontal stacked task status bar
- **Header.tsx** — "Admin" menu item (Shield icon) in user dropdown, visible only when `session.user.role === "admin"`
- **api.ts** — adds `api.admin.getStats()` following existing `request()` pattern

## Design Compliance
- Dark sidebar `#18181B`, hover/active bg `#27272A`, cyan `#22D3EE` active border accent
- Stat cards: `bg-zinc-900`, `rounded-lg`, `p-6`, Geist Mono 600 32px numbers, `text-zinc-500` labels
- Skeleton shimmer on loading state
- Geist/Geist Mono fonts, industrial/utilitarian aesthetic per DESIGN.md

## Test plan
- [ ] Visit `/admin` as admin user → sees dashboard with stat cards
- [ ] Visit `/admin` as non-admin user → redirected to `/`
- [ ] Visit `/admin` unauthenticated → redirected to `/auth`
- [ ] Admin user sees "Admin" item in header dropdown; non-admin does not
- [ ] Dashboard loading state shows skeleton shimmer cards
- [ ] Task status bar renders proportionally for each status

🤖 Generated with [Claude Code](https://claude.com/claude-code)