### PR TITLE
refactor(admin): redesign admin UI with shadcn components and design system

### DIFF
--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,103 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<"div"> & { size?: "default" | "sm" }) {
+  return (
+    <div
+      data-slot="card"
+      data-size={size}
+      className={cn(
+        "group/card flex flex-col gap-4 overflow-hidden rounded-xl bg-card py-4 text-sm text-card-foreground ring-1 ring-foreground/10 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "group/card-header @container/card-header grid auto-rows-min items-start gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto] [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn(
+        "font-heading text-base leading-snug font-medium group-data-[size=sm]/card:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn(
+        "flex items-center rounded-b-xl border-t bg-muted/50 p-4 group-data-[size=sm]/card:p-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/apps/web/src/routes/admin/AdminDashboardPage.tsx
+++ b/apps/web/src/routes/admin/AdminDashboardPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "../../components/ui/card";
 import { Skeleton } from "../../components/ui/skeleton";
 import { api } from "../../lib/api";
 
@@ -18,12 +19,12 @@ interface AdminStats {
   machines: { total: number; online: number };
 }
 
-const STATUS_COLORS: Record<string, string> = {
-  todo: "#71717A",
-  in_progress: "#22D3EE",
-  in_review: "#EAB308",
-  done: "#22C55E",
-  cancelled: "#3F3F46",
+const STATUS_BAR_CLASS: Record<string, string> = {
+  todo: "bg-zinc-500",
+  in_progress: "bg-accent",
+  in_review: "bg-warning",
+  done: "bg-success",
+  cancelled: "bg-zinc-700",
 };
 
 const STATUS_LABELS: Record<string, string> = {
@@ -36,23 +37,29 @@ const STATUS_LABELS: Record<string, string> = {
 
 function StatCard({ label, value, subtitle }: { label: string; value: number; subtitle: string }) {
   return (
-    <div className="bg-zinc-900 dark:bg-zinc-900 rounded-lg p-6 border border-zinc-800">
-      <p className="text-sm text-zinc-500 mb-1">{label}</p>
-      <p className="text-[32px] font-semibold text-zinc-100 leading-none" style={{ fontFamily: "Geist Mono, monospace" }}>
-        {value}
-      </p>
-      <p className="text-xs text-zinc-400 mt-2">{subtitle}</p>
-    </div>
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-xs font-medium text-content-tertiary uppercase tracking-wider">{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-4xl font-semibold font-mono text-content-primary leading-none">{value}</p>
+        {subtitle && <p className="text-xs text-content-tertiary mt-2">{subtitle}</p>}
+      </CardContent>
+    </Card>
   );
 }
 
 function StatCardSkeleton() {
   return (
-    <div className="bg-zinc-900 rounded-lg p-6 border border-zinc-800 space-y-3">
-      <Skeleton className="h-4 w-20 bg-zinc-800" />
-      <Skeleton className="h-9 w-16 bg-zinc-800" />
-      <Skeleton className="h-3 w-28 bg-zinc-800" />
-    </div>
+    <Card>
+      <CardHeader>
+        <Skeleton className="h-3 w-20" />
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Skeleton className="h-9 w-16" />
+        <Skeleton className="h-3 w-28" />
+      </CardContent>
+    </Card>
   );
 }
 
@@ -66,15 +73,13 @@ function TaskStatusBar({ byStatus }: { byStatus: TasksByStatus }) {
 
   return (
     <div className="mt-8">
-      <p className="text-sm font-medium text-zinc-400 mb-3">Task Status Breakdown</p>
+      <p className="text-xs font-medium text-content-tertiary uppercase tracking-wider mb-3">Task Status Breakdown</p>
       <div className="flex h-3 rounded-full overflow-hidden gap-0.5">
         {statuses.map((status) => {
           const count = byStatus[status] || 0;
           if (count === 0) return null;
           const pct = (count / total) * 100;
-          return (
-            <div key={status} style={{ width: `${pct}%`, backgroundColor: STATUS_COLORS[status] }} title={`${STATUS_LABELS[status]}: ${count}`} />
-          );
+          return <div key={status} className={STATUS_BAR_CLASS[status]} style={{ width: `${pct}%` }} title={`${STATUS_LABELS[status]}: ${count}`} />;
         })}
       </div>
       <div className="flex flex-wrap gap-4 mt-3">
@@ -82,9 +87,9 @@ function TaskStatusBar({ byStatus }: { byStatus: TasksByStatus }) {
           const count = byStatus[status] || 0;
           return (
             <div key={status} className="flex items-center gap-1.5">
-              <span className="inline-block w-2.5 h-2.5 rounded-sm" style={{ backgroundColor: STATUS_COLORS[status] }} />
-              <span className="text-xs text-zinc-500">{STATUS_LABELS[status]}</span>
-              <span className="text-xs font-mono text-zinc-400">{count}</span>
+              <span className={`inline-block w-2.5 h-2.5 rounded-sm ${STATUS_BAR_CLASS[status]}`} />
+              <span className="text-xs text-content-tertiary">{STATUS_LABELS[status]}</span>
+              <span className="text-xs font-mono text-content-secondary">{count}</span>
             </div>
           );
         })}
@@ -110,9 +115,7 @@ export function AdminDashboardPage() {
 
   return (
     <div className="px-8 py-10 max-w-5xl">
-      <h1 className="text-2xl font-semibold text-zinc-100 mb-8" style={{ letterSpacing: "-0.02em" }}>
-        Dashboard
-      </h1>
+      <h1 className="text-2xl font-semibold text-content-primary tracking-tight mb-8">Dashboard</h1>
 
       {loading ? (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
@@ -131,7 +134,7 @@ export function AdminDashboardPage() {
           <TaskStatusBar byStatus={tasksByStatus} />
         </>
       ) : (
-        <p className="text-zinc-500 text-sm">Failed to load stats.</p>
+        <p className="text-content-tertiary text-sm">Failed to load stats.</p>
       )}
     </div>
   );

--- a/apps/web/src/routes/admin/AdminLayout.tsx
+++ b/apps/web/src/routes/admin/AdminLayout.tsx
@@ -12,18 +12,21 @@ export function AdminLayout() {
   return (
     <div className="min-h-screen bg-surface-primary flex">
       {/* Sidebar */}
-      <aside className="w-56 shrink-0 fixed top-0 left-0 h-full flex flex-col" style={{ background: "#18181B", borderRight: "1px solid #27272A" }}>
-        <div className="px-4 py-4 border-b" style={{ borderColor: "#27272A" }}>
-          <button onClick={() => navigate("/")} className="flex items-center gap-1.5 text-xs text-zinc-400 hover:text-zinc-200 transition-colors">
+      <aside className="w-56 shrink-0 fixed top-0 left-0 h-full flex flex-col bg-surface-secondary border-r border-border">
+        <div className="px-4 py-4 border-b border-border">
+          <button
+            onClick={() => navigate("/")}
+            className="flex items-center gap-1.5 text-xs text-content-tertiary hover:text-content-primary transition-colors"
+          >
             <ChevronLeft size={14} />
             Back to Board
           </button>
         </div>
 
-        <div className="px-4 py-4 border-b" style={{ borderColor: "#27272A" }}>
+        <div className="px-4 py-4 border-b border-border">
           <div className="flex items-center gap-2">
-            <BarChart3 size={16} className="text-[#22D3EE]" />
-            <span className="text-sm font-semibold text-zinc-100 tracking-tight">Admin</span>
+            <BarChart3 size={16} className="text-accent" />
+            <span className="text-sm font-semibold text-content-primary tracking-tight">Admin</span>
           </div>
         </div>
 
@@ -34,17 +37,11 @@ export function AdminLayout() {
               to={to}
               end={end}
               className={({ isActive }) =>
-                `flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors relative ${
-                  isActive ? "text-[#22D3EE] bg-[#27272A]" : "text-zinc-400 hover:text-zinc-200 hover:bg-[#27272A]"
+                `flex items-center gap-2.5 px-3 py-2 rounded-md text-sm transition-colors border-l-2 ${
+                  isActive
+                    ? "text-accent bg-surface-tertiary border-l-accent"
+                    : "text-content-tertiary hover:text-content-primary hover:bg-surface-tertiary border-l-transparent"
                 }`
-              }
-              style={({ isActive }) =>
-                isActive
-                  ? {
-                      borderLeft: "2px solid #22D3EE",
-                      paddingLeft: "calc(0.75rem - 2px)",
-                    }
-                  : { borderLeft: "2px solid transparent", paddingLeft: "calc(0.75rem - 2px)" }
               }
             >
               <Icon size={15} />

--- a/apps/web/src/routes/admin/AdminUsersPage.tsx
+++ b/apps/web/src/routes/admin/AdminUsersPage.tsx
@@ -2,424 +2,18 @@ import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 import { formatRelative } from "../../components/TaskDetailFields";
 import { Avatar, AvatarFallback } from "../../components/ui/avatar";
 import { Button } from "../../components/ui/button";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog";
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../components/ui/dropdown-menu";
 import { Input } from "../../components/ui/input";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
-import { Skeleton } from "../../components/ui/skeleton";
-import { Textarea } from "../../components/ui/textarea";
-import { Tooltip, TooltipContent, TooltipTrigger } from "../../components/ui/tooltip";
 import { authClient, useSession } from "../../lib/auth-client";
+import { BanUserDialog } from "./BanUserDialog";
+import { DeleteUserDialog } from "./DeleteUserDialog";
+import { SessionsPanel } from "./SessionsPanel";
+import { SetRoleDialog } from "./SetRoleDialog";
+import { type DialogKind, type User } from "./types";
+import { RoleBadge, StatusBadge } from "./UserBadges";
+import { SkeletonRows, UserRowActions } from "./UserTableRows";
+import { ToastStack, useToasts } from "./useToasts";
 
 const PAGE_SIZE = 20;
-
-interface User {
-  id: string;
-  name: string;
-  email: string;
-  role: string;
-  banned?: boolean;
-  banReason?: string;
-  banExpires?: string | null;
-  createdAt: string;
-  image?: string;
-}
-
-interface Session {
-  id: string;
-  token: string;
-  ipAddress?: string;
-  userAgent?: string;
-  createdAt: string;
-  expiresAt: string;
-}
-
-interface Toast {
-  id: number;
-  type: "success" | "error";
-  message: string;
-}
-
-// --- Toast ---
-
-let toastSeq = 0;
-
-function useToasts() {
-  const [toasts, setToasts] = useState<Toast[]>([]);
-
-  const push = useCallback((type: Toast["type"], message: string) => {
-    const id = ++toastSeq;
-    setToasts((prev) => [...prev, { id, type, message }]);
-    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3500);
-  }, []);
-
-  return { toasts, push };
-}
-
-function ToastStack({ toasts }: { toasts: Toast[] }) {
-  if (toasts.length === 0) return null;
-  return (
-    <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2">
-      {toasts.map((t) => (
-        <div
-          key={t.id}
-          className={`px-4 py-2.5 rounded-lg text-sm font-medium shadow-lg ${
-            t.type === "success" ? "bg-[#22C55E] text-zinc-900" : "bg-[#EF4444] text-white"
-          }`}
-        >
-          {t.message}
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// --- Badges ---
-
-function RoleBadge({ role }: { role: string }) {
-  if (role === "admin") {
-    return (
-      <span className="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium uppercase tracking-wider bg-[rgba(34,211,238,0.1)] text-[#22D3EE]">
-        admin
-      </span>
-    );
-  }
-  return (
-    <span className="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium uppercase tracking-wider bg-zinc-800 text-zinc-400">
-      user
-    </span>
-  );
-}
-
-function StatusBadge({ user }: { user: User }) {
-  if (user.banned) {
-    const badge = (
-      <span className="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium uppercase tracking-wider bg-[rgba(239,68,68,0.1)] text-[#EF4444] cursor-default">
-        banned
-      </span>
-    );
-    if (user.banReason) {
-      return (
-        <Tooltip>
-          <TooltipTrigger render={<span />}>{badge}</TooltipTrigger>
-          <TooltipContent>{user.banReason}</TooltipContent>
-        </Tooltip>
-      );
-    }
-    return badge;
-  }
-  return (
-    <span className="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium uppercase tracking-wider bg-[rgba(34,197,94,0.1)] text-[#22C55E]">
-      active
-    </span>
-  );
-}
-
-// --- Dialogs ---
-
-function SetRoleDialog({ user, open, onClose, onSuccess }: { user: User; open: boolean; onClose: () => void; onSuccess: () => void }) {
-  const [role, setRole] = useState(user.role);
-  const [loading, setLoading] = useState(false);
-
-  async function handleSubmit() {
-    setLoading(true);
-    const { error } = await (authClient.admin as any).setRole({ userId: user.id, role });
-    setLoading(false);
-    if (!error) {
-      onSuccess();
-      onClose();
-    }
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={(o: boolean) => !o && onClose()}>
-      <DialogContent className="sm:max-w-xs" showCloseButton={false}>
-        <DialogHeader>
-          <DialogTitle>Set Role</DialogTitle>
-        </DialogHeader>
-        <p className="text-xs text-zinc-400">
-          User: <span className="font-mono text-zinc-200">{user.email}</span>
-        </p>
-        <Select value={role} onValueChange={(v) => v && setRole(v)}>
-          <SelectTrigger className="w-full">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="user">user</SelectItem>
-            <SelectItem value="admin">admin</SelectItem>
-          </SelectContent>
-        </Select>
-        <DialogFooter showCloseButton>
-          <Button size="sm" disabled={loading || role === user.role} onClick={handleSubmit}>
-            {loading ? "Saving…" : "Save"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-const BAN_EXPIRY_OPTIONS = [
-  { label: "1 hour", value: "3600" },
-  { label: "24 hours", value: "86400" },
-  { label: "7 days", value: "604800" },
-  { label: "30 days", value: "2592000" },
-  { label: "Permanent", value: "" },
-];
-
-function BanUserDialog({ user, open, onClose, onSuccess }: { user: User; open: boolean; onClose: () => void; onSuccess: () => void }) {
-  const [reason, setReason] = useState("");
-  const [expiry, setExpiry] = useState("");
-  const [loading, setLoading] = useState(false);
-
-  async function handleSubmit() {
-    setLoading(true);
-    const params: Record<string, unknown> = { userId: user.id, banReason: reason || undefined };
-    if (expiry) params.banExpiresIn = Number(expiry);
-    const { error } = await (authClient.admin as any).banUser(params);
-    setLoading(false);
-    if (!error) {
-      onSuccess();
-      onClose();
-    }
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={(o: boolean) => !o && onClose()}>
-      <DialogContent className="sm:max-w-sm" showCloseButton={false}>
-        <DialogHeader>
-          <DialogTitle>Ban User</DialogTitle>
-        </DialogHeader>
-        <p className="text-xs text-zinc-400">
-          User: <span className="font-mono text-zinc-200">{user.email}</span>
-        </p>
-        <div className="space-y-3">
-          <Textarea placeholder="Ban reason (optional)" value={reason} onChange={(e) => setReason(e.target.value)} className="min-h-[72px]" />
-          <Select value={expiry} onValueChange={(v) => setExpiry(v ?? "")}>
-            <SelectTrigger className="w-full">
-              <SelectValue placeholder="Duration" />
-            </SelectTrigger>
-            <SelectContent>
-              {BAN_EXPIRY_OPTIONS.map((opt) => (
-                <SelectItem key={opt.label} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <DialogFooter showCloseButton>
-          <Button size="sm" variant="destructive" disabled={loading} onClick={handleSubmit}>
-            {loading ? "Banning…" : "Ban User"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function DeleteUserDialog({ user, open, onClose, onSuccess }: { user: User; open: boolean; onClose: () => void; onSuccess: () => void }) {
-  const [loading, setLoading] = useState(false);
-
-  async function handleDelete() {
-    setLoading(true);
-    const { error } = await (authClient.admin as any).removeUser({ userId: user.id });
-    setLoading(false);
-    if (!error) {
-      onSuccess();
-      onClose();
-    }
-  }
-
-  return (
-    <Dialog open={open} onOpenChange={(o: boolean) => !o && onClose()}>
-      <DialogContent className="sm:max-w-xs" showCloseButton={false}>
-        <DialogHeader>
-          <DialogTitle>Delete User</DialogTitle>
-        </DialogHeader>
-        <p className="text-sm text-zinc-300">
-          Delete <span className="font-mono text-zinc-100">{user.email}</span>?
-        </p>
-        <p className="text-xs text-zinc-500">This action cannot be undone.</p>
-        <DialogFooter showCloseButton>
-          <Button size="sm" variant="destructive" disabled={loading} onClick={handleDelete}>
-            {loading ? "Deleting…" : "Delete"}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-// --- Sessions Panel ---
-
-function SessionsPanel({ user, onToast }: { user: User; onToast: (type: Toast["type"], msg: string) => void }) {
-  const [sessions, setSessions] = useState<Session[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [revoking, setRevoking] = useState<string | null>(null);
-
-  useEffect(() => {
-    (authClient.admin as any)
-      .listUserSessions({ userId: user.id })
-      .then(({ data, error }: any) => {
-        if (!error && data) setSessions(data.sessions ?? data ?? []);
-      })
-      .finally(() => setLoading(false));
-  }, [user.id]);
-
-  async function revokeSession(token: string) {
-    setRevoking(token);
-    const { error } = await (authClient.admin as any).revokeUserSession({ sessionToken: token });
-    setRevoking(null);
-    if (error) {
-      onToast("error", "Failed to revoke session");
-    } else {
-      onToast("success", "Session revoked");
-      setSessions((prev) => prev.filter((s) => s.token !== token));
-    }
-  }
-
-  async function revokeAll() {
-    setRevoking("all");
-    const { error } = await (authClient.admin as any).revokeUserSessions({ userId: user.id });
-    setRevoking(null);
-    if (error) {
-      onToast("error", "Failed to revoke sessions");
-    } else {
-      onToast("success", "All sessions revoked");
-      setSessions([]);
-    }
-  }
-
-  if (loading) {
-    return (
-      <div className="px-4 pb-3 space-y-2">
-        {[0, 1].map((i) => (
-          <Skeleton key={i} className="h-8 bg-zinc-800 rounded" />
-        ))}
-      </div>
-    );
-  }
-
-  if (sessions.length === 0) {
-    return <p className="px-4 pb-3 text-xs text-zinc-500">No active sessions.</p>;
-  }
-
-  return (
-    <div className="px-4 pb-3 space-y-2">
-      <div className="flex items-center justify-between mb-1">
-        <span className="text-xs text-zinc-500">
-          {sessions.length} active session{sessions.length !== 1 ? "s" : ""}
-        </span>
-        <button onClick={revokeAll} disabled={revoking === "all"} className="text-xs text-[#EF4444] hover:underline disabled:opacity-50">
-          {revoking === "all" ? "Revoking…" : "Revoke All"}
-        </button>
-      </div>
-      {sessions.map((s) => (
-        <div key={s.id} className="flex items-start justify-between gap-4 bg-zinc-900 rounded p-2.5">
-          <div className="min-w-0 space-y-0.5">
-            <p className="text-[11px] font-mono text-zinc-400 truncate">{s.token.slice(0, 16)}…</p>
-            {s.ipAddress && <p className="text-[10px] text-zinc-500">{s.ipAddress}</p>}
-            {s.userAgent && <p className="text-[10px] text-zinc-600 truncate max-w-xs">{s.userAgent}</p>}
-            <p className="text-[10px] font-mono text-zinc-600">
-              Created {formatRelative(s.createdAt)} · Expires {formatRelative(s.expiresAt)}
-            </p>
-          </div>
-          <button
-            onClick={() => revokeSession(s.token)}
-            disabled={revoking === s.token}
-            className="text-xs text-[#EF4444] hover:underline disabled:opacity-50 shrink-0 mt-0.5"
-          >
-            {revoking === s.token ? "…" : "Revoke"}
-          </button>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-// --- Row Actions Dropdown ---
-
-type DialogKind = "role" | "ban" | "delete";
-
-function UserRowActions({
-  user,
-  isSelf,
-  onAction,
-  onViewSessions,
-}: {
-  user: User;
-  isSelf: boolean;
-  onAction: (kind: DialogKind, user: User) => void;
-  onViewSessions: (userId: string) => void;
-}) {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        render={
-          <button className="p-1.5 rounded hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200 transition-colors">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
-              <circle cx="12" cy="5" r="2" />
-              <circle cx="12" cy="12" r="2" />
-              <circle cx="12" cy="19" r="2" />
-            </svg>
-          </button>
-        }
-      />
-      <DropdownMenuContent align="end" className="w-44">
-        <DropdownMenuItem onClick={() => onAction("role", user)}>Set Role</DropdownMenuItem>
-        {user.banned ? (
-          <DropdownMenuItem onClick={() => onAction("ban", user)}>Unban User</DropdownMenuItem>
-        ) : (
-          !isSelf && <DropdownMenuItem onClick={() => onAction("ban", user)}>Ban User</DropdownMenuItem>
-        )}
-        <DropdownMenuItem onClick={() => onViewSessions(user.id)}>View Sessions</DropdownMenuItem>
-        {!isSelf && (
-          <>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem className="text-[#EF4444] focus:text-[#EF4444]" onClick={() => onAction("delete", user)}>
-              Delete User
-            </DropdownMenuItem>
-          </>
-        )}
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-// --- Skeleton rows ---
-
-function SkeletonRows() {
-  return (
-    <>
-      {[0, 1, 2, 3, 4].map((i) => (
-        <tr key={i} className="border-b border-zinc-800">
-          <td className="px-4 py-3">
-            <div className="flex items-center gap-3">
-              <Skeleton className="w-7 h-7 rounded-full bg-zinc-800" />
-              <div className="space-y-1.5">
-                <Skeleton className="h-3 w-28 bg-zinc-800" />
-                <Skeleton className="h-2.5 w-40 bg-zinc-800" />
-              </div>
-            </div>
-          </td>
-          <td className="px-4 py-3">
-            <Skeleton className="h-4 w-14 bg-zinc-800 rounded" />
-          </td>
-          <td className="px-4 py-3">
-            <Skeleton className="h-4 w-14 bg-zinc-800 rounded" />
-          </td>
-          <td className="px-4 py-3">
-            <Skeleton className="h-3 w-16 bg-zinc-800" />
-          </td>
-          <td className="px-4 py-3" />
-        </tr>
-      ))}
-    </>
-  );
-}
-
-// --- Main Page ---
 
 export function AdminUsersPage() {
   const { data: session } = useSession();
@@ -435,7 +29,6 @@ export function AdminUsersPage() {
   const [expandedSessions, setExpandedSessions] = useState<string | null>(null);
 
   const { toasts, push: pushToast } = useToasts();
-
   const searchRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const fetchUsers = useCallback(async (offset: number, searchValue: string) => {
@@ -463,14 +56,6 @@ export function AdminUsersPage() {
     }, 300);
   }
 
-  function openDialog(kind: DialogKind, user: User) {
-    setActiveDialog({ kind, user });
-  }
-
-  function closeDialog() {
-    setActiveDialog(null);
-  }
-
   async function handleUnban(user: User) {
     const { error } = await (authClient.admin as any).unbanUser({ userId: user.id });
     if (error) {
@@ -486,11 +71,7 @@ export function AdminUsersPage() {
       handleUnban(user);
       return;
     }
-    openDialog(kind, user);
-  }
-
-  function handleViewSessions(userId: string) {
-    setExpandedSessions((prev) => (prev === userId ? null : userId));
+    setActiveDialog({ kind, user });
   }
 
   function onDialogSuccess() {
@@ -509,26 +90,22 @@ export function AdminUsersPage() {
   return (
     <div className="px-8 py-10 max-w-6xl">
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold text-zinc-100" style={{ letterSpacing: "-0.02em" }}>
-          Users
-        </h1>
-        <span className="text-xs font-mono text-zinc-500">{total} total</span>
+        <h1 className="text-2xl font-semibold text-content-primary tracking-tight">Users</h1>
+        <span className="text-xs font-mono text-content-tertiary">{total} total</span>
       </div>
 
-      {/* Search */}
       <div className="mb-4">
         <Input placeholder="Search by email…" onChange={(e) => handleSearchChange(e.target.value)} className="max-w-xs" />
       </div>
 
-      {/* Table */}
-      <div className="rounded-lg border border-zinc-800 overflow-hidden">
+      <div className="rounded-lg border border-border overflow-hidden">
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-zinc-800 bg-zinc-900">
-              <th className="px-4 py-3 text-left text-xs font-medium text-zinc-500 uppercase tracking-wider">User</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-zinc-500 uppercase tracking-wider">Role</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-zinc-500 uppercase tracking-wider">Status</th>
-              <th className="px-4 py-3 text-left text-xs font-medium text-zinc-500 uppercase tracking-wider">Created</th>
+            <tr className="border-b border-border bg-surface-secondary">
+              <th className="px-4 py-3 text-left text-xs font-medium text-content-tertiary uppercase tracking-wider">User</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-content-tertiary uppercase tracking-wider">Role</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-content-tertiary uppercase tracking-wider">Status</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-content-tertiary uppercase tracking-wider">Created</th>
               <th className="px-4 py-3 w-10" />
             </tr>
           </thead>
@@ -537,22 +114,24 @@ export function AdminUsersPage() {
               <SkeletonRows />
             ) : users.length === 0 ? (
               <tr>
-                <td colSpan={5} className="px-4 py-16 text-center text-zinc-500 text-sm">
+                <td colSpan={5} className="px-4 py-16 text-center text-content-tertiary text-sm">
                   No users found
                 </td>
               </tr>
             ) : (
               users.map((user) => (
                 <Fragment key={user.id}>
-                  <tr className="border-b border-zinc-800 bg-zinc-900 hover:bg-zinc-800 transition-colors">
+                  <tr className="border-b border-border bg-surface-secondary hover:bg-surface-tertiary transition-colors">
                     <td className="px-4 py-3">
                       <div className="flex items-center gap-3">
                         <Avatar size="sm">
-                          <AvatarFallback className="bg-zinc-800 text-zinc-300 text-xs">{(user.name || user.email)[0].toUpperCase()}</AvatarFallback>
+                          <AvatarFallback className="bg-surface-tertiary text-content-secondary text-xs">
+                            {(user.name || user.email)[0].toUpperCase()}
+                          </AvatarFallback>
                         </Avatar>
                         <div>
-                          <p className="text-zinc-100 text-sm font-medium leading-tight">{user.name || "—"}</p>
-                          <p className="font-mono text-xs text-zinc-400 leading-tight">{user.email}</p>
+                          <p className="text-content-primary text-sm font-medium leading-tight">{user.name || "—"}</p>
+                          <p className="font-mono text-xs text-content-tertiary leading-tight">{user.email}</p>
                         </div>
                       </div>
                     </td>
@@ -563,18 +142,23 @@ export function AdminUsersPage() {
                       <StatusBadge user={user} />
                     </td>
                     <td className="px-4 py-3">
-                      <span className="font-mono text-xs text-zinc-500">{formatRelative(user.createdAt)}</span>
+                      <span className="font-mono text-xs text-content-tertiary">{formatRelative(user.createdAt)}</span>
                     </td>
                     <td className="px-4 py-3 text-right">
-                      <UserRowActions user={user} isSelf={user.id === currentUserId} onAction={handleAction} onViewSessions={handleViewSessions} />
+                      <UserRowActions
+                        user={user}
+                        isSelf={user.id === currentUserId}
+                        onAction={handleAction}
+                        onViewSessions={(uid) => setExpandedSessions((prev) => (prev === uid ? null : uid))}
+                      />
                     </td>
                   </tr>
                   {expandedSessions === user.id && (
-                    <tr className="bg-zinc-950 border-b border-zinc-800">
+                    <tr className="bg-surface-primary border-b border-border">
                       <td colSpan={5}>
                         <div className="pt-2">
-                          <p className="px-4 pb-1 text-xs font-medium text-zinc-500 uppercase tracking-wider">Sessions</p>
-                          <SessionsPanel user={user} onToast={pushToast} />
+                          <p className="px-4 pb-1 text-xs font-medium text-content-tertiary uppercase tracking-wider">Sessions</p>
+                          <SessionsPanel userId={user.id} onToast={pushToast} />
                         </div>
                       </td>
                     </tr>
@@ -586,9 +170,8 @@ export function AdminUsersPage() {
         </table>
       </div>
 
-      {/* Pagination */}
       {total > 0 && (
-        <div className="mt-4 flex items-center justify-between text-xs text-zinc-500">
+        <div className="mt-4 flex items-center justify-between text-xs text-content-tertiary">
           <span>
             Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
           </span>
@@ -603,10 +186,15 @@ export function AdminUsersPage() {
         </div>
       )}
 
-      {/* Dialogs */}
-      {activeDialog?.kind === "role" && <SetRoleDialog user={activeDialog.user} open onClose={closeDialog} onSuccess={onDialogSuccess} />}
-      {activeDialog?.kind === "ban" && <BanUserDialog user={activeDialog.user} open onClose={closeDialog} onSuccess={onDialogSuccess} />}
-      {activeDialog?.kind === "delete" && <DeleteUserDialog user={activeDialog.user} open onClose={closeDialog} onSuccess={onDialogSuccess} />}
+      {activeDialog?.kind === "role" && (
+        <SetRoleDialog user={activeDialog.user} open onClose={() => setActiveDialog(null)} onSuccess={onDialogSuccess} />
+      )}
+      {activeDialog?.kind === "ban" && (
+        <BanUserDialog user={activeDialog.user} open onClose={() => setActiveDialog(null)} onSuccess={onDialogSuccess} />
+      )}
+      {activeDialog?.kind === "delete" && (
+        <DeleteUserDialog user={activeDialog.user} open onClose={() => setActiveDialog(null)} onSuccess={onDialogSuccess} />
+      )}
 
       <ToastStack toasts={toasts} />
     </div>

--- a/apps/web/src/routes/admin/BanUserDialog.tsx
+++ b/apps/web/src/routes/admin/BanUserDialog.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { Button } from "../../components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
+import { Textarea } from "../../components/ui/textarea";
+import { authClient } from "../../lib/auth-client";
+import { type User } from "./types";
+
+interface Props {
+  user: User;
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const BAN_EXPIRY_OPTIONS = [
+  { label: "1 hour", value: "3600" },
+  { label: "24 hours", value: "86400" },
+  { label: "7 days", value: "604800" },
+  { label: "30 days", value: "2592000" },
+  { label: "Permanent", value: "" },
+];
+
+export function BanUserDialog({ user, open, onClose, onSuccess }: Props) {
+  const [reason, setReason] = useState("");
+  const [expiry, setExpiry] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit() {
+    setLoading(true);
+    const params: Record<string, unknown> = { userId: user.id, banReason: reason || undefined };
+    if (expiry) params.banExpiresIn = Number(expiry);
+    const { error } = await (authClient.admin as any).banUser(params);
+    setLoading(false);
+    if (!error) {
+      onSuccess();
+      onClose();
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o: boolean) => !o && onClose()}>
+      <DialogContent className="sm:max-w-sm" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Ban User</DialogTitle>
+        </DialogHeader>
+        <p className="text-xs text-content-tertiary">
+          User: <span className="font-mono text-content-primary">{user.email}</span>
+        </p>
+        <div className="space-y-3">
+          <Textarea placeholder="Ban reason (optional)" value={reason} onChange={(e) => setReason(e.target.value)} className="min-h-[72px]" />
+          <Select value={expiry} onValueChange={(v) => setExpiry(v ?? "")}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Duration" />
+            </SelectTrigger>
+            <SelectContent>
+              {BAN_EXPIRY_OPTIONS.map((opt) => (
+                <SelectItem key={opt.label} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <DialogFooter showCloseButton>
+          <Button size="sm" variant="destructive" disabled={loading} onClick={handleSubmit}>
+            {loading ? "Banning…" : "Ban User"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/routes/admin/DeleteUserDialog.tsx
+++ b/apps/web/src/routes/admin/DeleteUserDialog.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { Button } from "../../components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog";
+import { authClient } from "../../lib/auth-client";
+import { type User } from "./types";
+
+interface Props {
+  user: User;
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function DeleteUserDialog({ user, open, onClose, onSuccess }: Props) {
+  const [loading, setLoading] = useState(false);
+
+  async function handleDelete() {
+    setLoading(true);
+    const { error } = await (authClient.admin as any).removeUser({ userId: user.id });
+    setLoading(false);
+    if (!error) {
+      onSuccess();
+      onClose();
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o: boolean) => !o && onClose()}>
+      <DialogContent className="sm:max-w-xs" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Delete User</DialogTitle>
+        </DialogHeader>
+        <p className="text-sm text-content-secondary">
+          Delete <span className="font-mono text-content-primary">{user.email}</span>?
+        </p>
+        <p className="text-xs text-content-tertiary">This action cannot be undone.</p>
+        <DialogFooter showCloseButton>
+          <Button size="sm" variant="destructive" disabled={loading} onClick={handleDelete}>
+            {loading ? "Deleting…" : "Delete"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/routes/admin/SessionsPanel.tsx
+++ b/apps/web/src/routes/admin/SessionsPanel.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from "react";
+import { formatRelative } from "../../components/TaskDetailFields";
+import { Skeleton } from "../../components/ui/skeleton";
+import { authClient } from "../../lib/auth-client";
+
+interface Session {
+  id: string;
+  token: string;
+  ipAddress?: string;
+  userAgent?: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+type ToastType = "success" | "error";
+
+interface Props {
+  userId: string;
+  onToast: (type: ToastType, msg: string) => void;
+}
+
+export function SessionsPanel({ userId, onToast }: Props) {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [revoking, setRevoking] = useState<string | null>(null);
+
+  useEffect(() => {
+    (authClient.admin as any)
+      .listUserSessions({ userId })
+      .then(({ data, error }: any) => {
+        if (!error && data) setSessions(data.sessions ?? data ?? []);
+      })
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  async function revokeSession(token: string) {
+    setRevoking(token);
+    const { error } = await (authClient.admin as any).revokeUserSession({ sessionToken: token });
+    setRevoking(null);
+    if (error) {
+      onToast("error", "Failed to revoke session");
+    } else {
+      onToast("success", "Session revoked");
+      setSessions((prev) => prev.filter((s) => s.token !== token));
+    }
+  }
+
+  async function revokeAll() {
+    setRevoking("all");
+    const { error } = await (authClient.admin as any).revokeUserSessions({ userId });
+    setRevoking(null);
+    if (error) {
+      onToast("error", "Failed to revoke sessions");
+    } else {
+      onToast("success", "All sessions revoked");
+      setSessions([]);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="px-4 pb-3 space-y-2">
+        {[0, 1].map((i) => (
+          <Skeleton key={i} className="h-8 rounded" />
+        ))}
+      </div>
+    );
+  }
+
+  if (sessions.length === 0) {
+    return <p className="px-4 pb-3 text-xs text-content-tertiary">No active sessions.</p>;
+  }
+
+  return (
+    <div className="px-4 pb-3 space-y-2">
+      <div className="flex items-center justify-between mb-1">
+        <span className="text-xs text-content-tertiary">
+          {sessions.length} active session{sessions.length !== 1 ? "s" : ""}
+        </span>
+        <button onClick={revokeAll} disabled={revoking === "all"} className="text-xs text-error hover:underline disabled:opacity-50">
+          {revoking === "all" ? "Revoking…" : "Revoke All"}
+        </button>
+      </div>
+      {sessions.map((s) => (
+        <div key={s.id} className="flex items-start justify-between gap-4 bg-surface-secondary rounded p-2.5">
+          <div className="min-w-0 space-y-0.5">
+            <p className="text-[11px] font-mono text-content-secondary truncate">{s.token.slice(0, 16)}…</p>
+            {s.ipAddress && <p className="text-[10px] text-content-tertiary">{s.ipAddress}</p>}
+            {s.userAgent && <p className="text-[10px] text-content-tertiary truncate max-w-xs">{s.userAgent}</p>}
+            <p className="text-[10px] font-mono text-content-tertiary">
+              Created {formatRelative(s.createdAt)} · Expires {formatRelative(s.expiresAt)}
+            </p>
+          </div>
+          <button
+            onClick={() => revokeSession(s.token)}
+            disabled={revoking === s.token}
+            className="text-xs text-error hover:underline disabled:opacity-50 shrink-0 mt-0.5"
+          >
+            {revoking === s.token ? "…" : "Revoke"}
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/routes/admin/SetRoleDialog.tsx
+++ b/apps/web/src/routes/admin/SetRoleDialog.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { Button } from "../../components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "../../components/ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select";
+import { authClient } from "../../lib/auth-client";
+import { type User } from "./types";
+
+interface Props {
+  user: User;
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export function SetRoleDialog({ user, open, onClose, onSuccess }: Props) {
+  const [role, setRole] = useState(user.role);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit() {
+    setLoading(true);
+    const { error } = await (authClient.admin as any).setRole({ userId: user.id, role });
+    setLoading(false);
+    if (!error) {
+      onSuccess();
+      onClose();
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(o: boolean) => !o && onClose()}>
+      <DialogContent className="sm:max-w-xs" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>Set Role</DialogTitle>
+        </DialogHeader>
+        <p className="text-xs text-content-tertiary">
+          User: <span className="font-mono text-content-primary">{user.email}</span>
+        </p>
+        <Select value={role} onValueChange={(v) => v && setRole(v)}>
+          <SelectTrigger className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="user">user</SelectItem>
+            <SelectItem value="admin">admin</SelectItem>
+          </SelectContent>
+        </Select>
+        <DialogFooter showCloseButton>
+          <Button size="sm" disabled={loading || role === user.role} onClick={handleSubmit}>
+            {loading ? "Saving…" : "Save"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/routes/admin/UserBadges.tsx
+++ b/apps/web/src/routes/admin/UserBadges.tsx
@@ -1,0 +1,41 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "../../components/ui/tooltip";
+import { type User } from "./types";
+
+export function RoleBadge({ role }: { role: string }) {
+  if (role === "admin") {
+    return (
+      <span className="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium uppercase tracking-wider bg-accent-soft text-accent">
+        admin
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium uppercase tracking-wider bg-surface-tertiary text-content-tertiary">
+      user
+    </span>
+  );
+}
+
+export function StatusBadge({ user }: { user: User }) {
+  if (user.banned) {
+    const badge = (
+      <span className="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium uppercase tracking-wider bg-error/10 text-error cursor-default">
+        banned
+      </span>
+    );
+    if (user.banReason) {
+      return (
+        <Tooltip>
+          <TooltipTrigger render={<span />}>{badge}</TooltipTrigger>
+          <TooltipContent>{user.banReason}</TooltipContent>
+        </Tooltip>
+      );
+    }
+    return badge;
+  }
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 rounded text-[11px] font-medium uppercase tracking-wider bg-success/10 text-success">
+      active
+    </span>
+  );
+}

--- a/apps/web/src/routes/admin/UserTableRows.tsx
+++ b/apps/web/src/routes/admin/UserTableRows.tsx
@@ -1,0 +1,78 @@
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "../../components/ui/dropdown-menu";
+import { Skeleton } from "../../components/ui/skeleton";
+import { type DialogKind, type User } from "./types";
+
+export function UserRowActions({
+  user,
+  isSelf,
+  onAction,
+  onViewSessions,
+}: {
+  user: User;
+  isSelf: boolean;
+  onAction: (kind: DialogKind, user: User) => void;
+  onViewSessions: (userId: string) => void;
+}) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button className="p-1.5 rounded hover:bg-surface-tertiary text-content-tertiary hover:text-content-primary transition-colors">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+              <circle cx="12" cy="5" r="2" />
+              <circle cx="12" cy="12" r="2" />
+              <circle cx="12" cy="19" r="2" />
+            </svg>
+          </button>
+        }
+      />
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuItem onClick={() => onAction("role", user)}>Set Role</DropdownMenuItem>
+        {user.banned ? (
+          <DropdownMenuItem onClick={() => onAction("ban", user)}>Unban User</DropdownMenuItem>
+        ) : (
+          !isSelf && <DropdownMenuItem onClick={() => onAction("ban", user)}>Ban User</DropdownMenuItem>
+        )}
+        <DropdownMenuItem onClick={() => onViewSessions(user.id)}>View Sessions</DropdownMenuItem>
+        {!isSelf && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="text-error focus:text-error" onClick={() => onAction("delete", user)}>
+              Delete User
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function SkeletonRows() {
+  return (
+    <>
+      {[0, 1, 2, 3, 4].map((i) => (
+        <tr key={i} className="border-b border-border">
+          <td className="px-4 py-3">
+            <div className="flex items-center gap-3">
+              <Skeleton className="w-7 h-7 rounded-full" />
+              <div className="space-y-1.5">
+                <Skeleton className="h-3 w-28" />
+                <Skeleton className="h-2.5 w-40" />
+              </div>
+            </div>
+          </td>
+          <td className="px-4 py-3">
+            <Skeleton className="h-4 w-14 rounded" />
+          </td>
+          <td className="px-4 py-3">
+            <Skeleton className="h-4 w-14 rounded" />
+          </td>
+          <td className="px-4 py-3">
+            <Skeleton className="h-3 w-16" />
+          </td>
+          <td className="px-4 py-3" />
+        </tr>
+      ))}
+    </>
+  );
+}

--- a/apps/web/src/routes/admin/types.ts
+++ b/apps/web/src/routes/admin/types.ts
@@ -1,0 +1,13 @@
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  banned?: boolean;
+  banReason?: string;
+  banExpires?: string | null;
+  createdAt: string;
+  image?: string;
+}
+
+export type DialogKind = "role" | "ban" | "delete";

--- a/apps/web/src/routes/admin/useToasts.tsx
+++ b/apps/web/src/routes/admin/useToasts.tsx
@@ -1,0 +1,39 @@
+import { useCallback, useState } from "react";
+
+export interface Toast {
+  id: number;
+  type: "success" | "error";
+  message: string;
+}
+
+let toastSeq = 0;
+
+export function useToasts() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const push = useCallback((type: Toast["type"], message: string) => {
+    const id = ++toastSeq;
+    setToasts((prev) => [...prev, { id, type, message }]);
+    setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3500);
+  }, []);
+
+  return { toasts, push };
+}
+
+export function ToastStack({ toasts }: { toasts: Toast[] }) {
+  if (toasts.length === 0) return null;
+  return (
+    <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2">
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          className={`px-4 py-2.5 rounded-lg text-sm font-medium shadow-lg ${
+            t.type === "success" ? "bg-success text-zinc-900" : "bg-error text-white"
+          }`}
+        >
+          {t.message}
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **AdminDashboardPage**: Replaced raw `<div>` stat cards with shadcn `Card`/`CardHeader`/`CardTitle`/`CardContent`. Removed `style={{ fontFamily }}` inline style — uses `font-mono` Tailwind class. All hardcoded hex colors replaced with design-token classes (`text-content-*`, `text-accent`, `bg-surface-*`).
- **AdminLayout**: Removed all `style={{ }}` inline attributes. Sidebar now uses `bg-surface-secondary`, `border-r border-border`, `text-accent`, `bg-surface-tertiary`, and proper Tailwind `border-l-2` for active nav indicator — works in both dark and light mode.
- **AdminUsersPage**: Replaced hardcoded hex values with semantic Tailwind classes. Split 614-line file into 8 focused files: `types.ts`, `BanUserDialog`, `DeleteUserDialog`, `SetRoleDialog`, `SessionsPanel`, `UserBadges`, `UserTableRows`, `useToasts` — main file now 211 lines.

## Test plan

- [ ] Build passes: `pnpm build` ✅
- [ ] TypeScript clean: `npx tsc --noEmit` ✅
- [ ] All 604 tests pass: `npx vitest run` ✅
- [ ] Admin dashboard stat cards use shadcn Card component
- [ ] Admin sidebar uses only Tailwind classes, no inline styles
- [ ] Admin pages look correct in dark mode (default)
- [ ] Admin pages look correct in light mode
- [ ] All dialog components (Ban, Role, Delete) inherit theme correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)