### PR TITLE
feat: GPG root key infrastructure per owner

### DIFF
--- a/apps/web/functions/api/auth.ts
+++ b/apps/web/functions/api/auth.ts
@@ -61,6 +61,9 @@ const ROUTE_RULES: { method: string; pattern: RegExp; rule: RouteRule }[] = [
   // Sessions — machine reopen
   { method: "POST", pattern: /^\/api\/agents\/[^/]+\/sessions\/[^/]+\/reopen$/, rule: { allow: ["machine"] } },
 
+  // GPG keys — user only
+  { method: "GET", pattern: /^\/api\/gpg\/public-key$/, rule: { allow: ["user"] } },
+
   // Admin — user identity only (Better Auth plugin enforces role internally)
   { method: "POST", pattern: /^\/api\/auth\/admin\//, rule: { allow: ["user"] } },
   { method: "GET", pattern: /^\/api\/auth\/admin\//, rule: { allow: ["user"] } },

--- a/apps/web/functions/api/gpgKeyRepo.ts
+++ b/apps/web/functions/api/gpgKeyRepo.ts
@@ -1,0 +1,81 @@
+import * as openpgp from "openpgp";
+import { type D1, newId } from "./db";
+
+export interface GpgKey {
+  id: string;
+  owner_id: string;
+  armored_public_key: string;
+  fingerprint: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface GpgKeyRow extends GpgKey {
+  armored_private_key: string;
+}
+
+async function generateRootKey(): Promise<{ armoredPrivateKey: string; armoredPublicKey: string; fingerprint: string }> {
+  const { privateKey, publicKey } = await openpgp.generateKey({
+    type: "curve25519",
+    userIDs: [{ name: "Agent Kanban Root", email: "root@mails.agent-kanban.dev" }],
+    format: "armored",
+  });
+  const parsed = await openpgp.readPrivateKey({ armoredKey: privateKey as string });
+  const fingerprint = parsed.getFingerprint();
+  return { armoredPrivateKey: privateKey as string, armoredPublicKey: publicKey as string, fingerprint };
+}
+
+export async function getOrCreateRootKey(db: D1, ownerId: string): Promise<GpgKey> {
+  const existing = await db
+    .prepare("SELECT id, owner_id, armored_public_key, fingerprint, created_at, updated_at FROM gpg_keys WHERE owner_id = ?")
+    .bind(ownerId)
+    .first<GpgKey>();
+  if (existing) return existing;
+
+  const { armoredPrivateKey, armoredPublicKey, fingerprint } = await generateRootKey();
+  const id = newId();
+  const now = new Date().toISOString();
+
+  await db
+    .prepare(
+      "INSERT INTO gpg_keys (id, owner_id, armored_private_key, armored_public_key, fingerprint, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(id, ownerId, armoredPrivateKey, armoredPublicKey, fingerprint, now, now)
+    .run();
+
+  return { id, owner_id: ownerId, armored_public_key: armoredPublicKey, fingerprint, created_at: now, updated_at: now };
+}
+
+export async function addSubkey(db: D1, ownerId: string): Promise<{ fingerprint: string; keyId: string } | null> {
+  const row = await db
+    .prepare("SELECT armored_private_key FROM gpg_keys WHERE owner_id = ?")
+    .bind(ownerId)
+    .first<Pick<GpgKeyRow, "armored_private_key">>();
+  if (!row) return null;
+
+  const privateKey = await openpgp.readPrivateKey({ armoredKey: row.armored_private_key });
+  const updatedKey = await privateKey.addSubkey({ type: "curve25519", sign: true });
+  const armoredPrivate = updatedKey.armor();
+  const armoredPublic = updatedKey.toPublic().armor();
+
+  const subkeys = updatedKey.getSubkeys();
+  const newSubkey = subkeys[subkeys.length - 1];
+  const subkeyFingerprint = newSubkey.getFingerprint();
+  const keyId = newSubkey.getKeyID().toHex();
+
+  const now = new Date().toISOString();
+  await db
+    .prepare("UPDATE gpg_keys SET armored_private_key = ?, armored_public_key = ?, updated_at = ? WHERE owner_id = ?")
+    .bind(armoredPrivate, armoredPublic, now, ownerId)
+    .run();
+
+  return { fingerprint: subkeyFingerprint, keyId };
+}
+
+export async function getRootPublicKey(db: D1, ownerId: string): Promise<string | null> {
+  const row = await db
+    .prepare("SELECT armored_public_key FROM gpg_keys WHERE owner_id = ?")
+    .bind(ownerId)
+    .first<Pick<GpgKey, "armored_public_key">>();
+  return row?.armored_public_key ?? null;
+}

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -7,6 +7,7 @@ import { authMiddleware } from "./auth";
 import { createAuth } from "./betterAuth";
 import { createBoard, deleteBoard, getBoard, getBoardByName, getBoardBySlug, listBoards, updateBoard } from "./boardRepo";
 import { createBoardSSEResponse, createPublicBoardSSEResponse } from "./boardSSE";
+import { getRootPublicKey } from "./gpgKeyRepo";
 import { createLogger } from "./logger";
 import { deleteMachine, getMachine, listMachines, updateMachine, upsertMachine } from "./machineRepo";
 import { createMessage, listMessages } from "./messageRepo";
@@ -626,6 +627,14 @@ api.delete("/api/repositories/:id", async (c) => {
   if (repo.owner_id !== ownerId) throw new HTTPException(403, { message: "Forbidden" });
   await deleteRepository(c.env.DB, c.req.param("id"));
   return c.json({ ok: true });
+});
+
+// ─── GPG Keys ───
+
+api.get("/api/gpg/public-key", async (c) => {
+  const armoredPublicKey = await getRootPublicKey(c.env.DB, c.get("ownerId"));
+  if (!armoredPublicKey) throw new HTTPException(404, { message: "GPG root key not found" });
+  return c.json({ armored_public_key: armoredPublicKey });
 });
 
 export { api };

--- a/apps/web/migrations/0012_gpg_keys.sql
+++ b/apps/web/migrations/0012_gpg_keys.sql
@@ -1,0 +1,11 @@
+-- GPG root key per owner — trust anchor for agent subkey signing.
+CREATE TABLE gpg_keys (
+  id                  TEXT PRIMARY KEY,
+  owner_id            TEXT NOT NULL REFERENCES "user"(id) ON DELETE CASCADE,
+  armored_private_key TEXT NOT NULL,
+  armored_public_key  TEXT NOT NULL,
+  fingerprint         TEXT NOT NULL,
+  created_at          TEXT NOT NULL,
+  updated_at          TEXT NOT NULL,
+  UNIQUE (owner_id)
+);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "kysely-d1": "^0.4.0",
     "lucide-react": "^0.577.0",
     "nanoid": "^5.0.0",
+    "openpgp": "^6.3.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@agent-kanban/shared": "workspace:*",
-    "framer-motion": "^12.38.0"
+    "framer-motion": "^12.38.0",
+    "openpgp": "^6.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       framer-motion:
         specifier: ^12.38.0
         version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      openpgp:
+        specifier: ^6.3.0
+        version: 6.3.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.8
@@ -142,6 +145,9 @@ importers:
       nanoid:
         specifier: ^5.0.0
         version: 5.1.7
+      openpgp:
+        specifier: ^6.3.0
+        version: 6.3.0
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -4068,6 +4074,10 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
+
+  openpgp@6.3.0:
+    resolution: {integrity: sha512-pLzCU8IgyKXPSO11eeharQkQ4GzOKNWhXq79pQarIRZEMt1/ssyr+MIuWBv1mNoenJLg04gvPx+fi4gcKZ4bag==}
+    engines: {node: '>= 18.0.0'}
 
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
@@ -8936,6 +8946,8 @@ snapshots:
       is-docker: 2.2.1
       is-wsl: 2.2.0
 
+  openpgp@6.3.0: {}
+
   ora@8.2.0:
     dependencies:
       chalk: 5.6.2
@@ -9647,7 +9659,7 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  terser-webpack-plugin@5.4.0(esbuild@0.25.0)(webpack@5.105.0):
+  terser-webpack-plugin@5.4.0(esbuild@0.25.0)(webpack@5.105.0(esbuild@0.27.3)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -10021,7 +10033,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.4.0(esbuild@0.25.0)(webpack@5.105.0)
+      terser-webpack-plugin: 5.4.0(esbuild@0.25.0)(webpack@5.105.0(esbuild@0.27.3))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Add `gpg_keys` DB table (migration `0012_gpg_keys.sql`) with one root key per owner
- Add `gpgKeyRepo.ts` with `getOrCreateRootKey`, `addSubkey`, and `getRootPublicKey` functions
- Add `GET /api/gpg/public-key` endpoint (user-only) returning the owner's armored public key

## Test plan
- [ ] Build and type-check pass with no errors
- [ ] Migration creates `gpg_keys` table with UNIQUE `owner_id` constraint
- [ ] `getOrCreateRootKey` auto-generates ECC/curve25519 root key on first call, returns existing on subsequent calls
- [ ] `addSubkey` appends a new curve25519 signing subkey and updates both armored columns
- [ ] `GET /api/gpg/public-key` returns 404 when no key exists, 200 with armored public key when it does
- [ ] Endpoint is accessible only to `user` identity type

🤖 Generated with [Claude Code](https://claude.com/claude-code)