### PR TITLE
Add username field to Agent entity

### DIFF
--- a/apps/web/functions/api/agentRepo.ts
+++ b/apps/web/functions/api/agentRepo.ts
@@ -1,10 +1,40 @@
 import type { Agent, AgentWithActivity, CreateAgentInput } from "@agent-kanban/shared";
-import { type AgentRuntime, BUILTIN_TEMPLATES, computeFingerprint, computeKeyId, generateKeypair } from "@agent-kanban/shared";
+import {
+  type AgentRuntime,
+  BUILTIN_TEMPLATES,
+  computeFingerprint,
+  computeKeyId,
+  deriveUsername,
+  generateKeypair,
+  isValidUsername,
+} from "@agent-kanban/shared";
+import { HTTPException } from "hono/http-exception";
 import { type D1, parseJsonFields } from "./db";
 
-const parseAgent = <T extends Agent>(row: T) => parseJsonFields(row, ["skills", "handoff_to"]);
+const AGENT_EMAIL_DOMAIN = "mails.agent-kanban.dev";
+
+function agentEmail(username: string): string {
+  return `${username}@${AGENT_EMAIL_DOMAIN}`;
+}
+
+function parseAgentWithActivity(row: AgentWithActivity): AgentWithActivity {
+  const parsed = parseJsonFields(row, ["skills", "handoff_to"]);
+  return { ...parsed, email: agentEmail(parsed.username) };
+}
 
 export async function createAgent(db: D1, ownerId: string, input: CreateAgentInput, builtin = false): Promise<Agent> {
+  const username = input.username ?? deriveUsername(input.name);
+  if (!isValidUsername(username)) {
+    throw new HTTPException(400, {
+      message: `Invalid username "${username}". Must be 3–39 lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens.`,
+    });
+  }
+
+  const existing = await db.prepare("SELECT id FROM agents WHERE owner_id = ? AND username = ?").bind(ownerId, username).first();
+  if (existing) {
+    throw new HTTPException(409, { message: `Username "${username}" is already taken.` });
+  }
+
   const { publicKeyBase64, privateKeyJwk } = await generateKeypair();
   const fingerprint = await computeFingerprint(publicKeyBase64);
   const id = computeKeyId(fingerprint);
@@ -12,36 +42,45 @@ export async function createAgent(db: D1, ownerId: string, input: CreateAgentInp
   const skillsJson = input.skills ? JSON.stringify(input.skills) : null;
   const handoffJson = input.handoff_to ? JSON.stringify(input.handoff_to) : null;
 
-  await db
-    .prepare(`
-    INSERT INTO agents (id, owner_id, name, bio, soul, role, kind, handoff_to, runtime, model, skills, public_key, private_key, fingerprint, builtin, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `)
-    .bind(
-      id,
-      ownerId,
-      input.name,
-      input.bio ?? null,
-      input.soul ?? null,
-      input.role ?? null,
-      input.kind ?? "worker",
-      handoffJson,
-      input.runtime,
-      input.model ?? null,
-      skillsJson,
-      publicKeyBase64,
-      JSON.stringify(privateKeyJwk),
-      fingerprint,
-      builtin ? 1 : 0,
-      now,
-      now,
-    )
-    .run();
+  try {
+    await db
+      .prepare(`
+      INSERT INTO agents (id, owner_id, name, username, bio, soul, role, kind, handoff_to, runtime, model, skills, public_key, private_key, fingerprint, builtin, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+      .bind(
+        id,
+        ownerId,
+        input.name,
+        username,
+        input.bio ?? null,
+        input.soul ?? null,
+        input.role ?? null,
+        input.kind ?? "worker",
+        handoffJson,
+        input.runtime,
+        input.model ?? null,
+        skillsJson,
+        publicKeyBase64,
+        JSON.stringify(privateKeyJwk),
+        fingerprint,
+        builtin ? 1 : 0,
+        now,
+        now,
+      )
+      .run();
+  } catch (err: any) {
+    if (err?.message?.includes("UNIQUE constraint failed")) {
+      throw new HTTPException(409, { message: `Username "${username}" is already taken.` });
+    }
+    throw err;
+  }
 
   return {
     id,
     owner_id: ownerId,
     name: input.name,
+    username,
     bio: input.bio ?? null,
     soul: input.soul ?? null,
     role: input.role ?? null,
@@ -71,7 +110,7 @@ export async function seedBuiltinAgents(db: D1, ownerId: string): Promise<void> 
 export async function listAgents(db: D1, ownerId: string): Promise<AgentWithActivity[]> {
   const result = await db
     .prepare(`
-    SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.kind, a.handoff_to, a.runtime, a.model, a.skills,
+    SELECT a.id, a.owner_id, a.name, a.username, a.bio, a.soul, a.role, a.kind, a.handoff_to, a.runtime, a.model, a.skills,
       a.public_key, a.fingerprint, a.builtin, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
       (SELECT MAX(tl.created_at) FROM task_actions tl WHERE tl.actor_id = a.id) as last_active_at,
@@ -87,13 +126,13 @@ export async function listAgents(db: D1, ownerId: string): Promise<AgentWithActi
   `)
     .bind(ownerId)
     .all<AgentWithActivity>();
-  return result.results.map(parseAgent);
+  return result.results.map(parseAgentWithActivity);
 }
 
 export async function getAgent(db: D1, agentId: string, ownerId: string): Promise<AgentWithActivity | null> {
   return db
     .prepare(`
-    SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.kind, a.handoff_to, a.runtime, a.model, a.skills,
+    SELECT a.id, a.owner_id, a.name, a.username, a.bio, a.soul, a.role, a.kind, a.handoff_to, a.runtime, a.model, a.skills,
       a.public_key, a.fingerprint, a.builtin, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
       (SELECT MAX(tl.created_at) FROM task_actions tl WHERE tl.actor_id = a.id) as last_active_at,
@@ -108,7 +147,7 @@ export async function getAgent(db: D1, agentId: string, ownerId: string): Promis
   `)
     .bind(agentId, ownerId)
     .first<AgentWithActivity>()
-    .then((r) => (r ? parseAgent(r) : null));
+    .then((r) => (r ? parseAgentWithActivity(r) : null));
 }
 
 export async function updateAgent(
@@ -138,7 +177,7 @@ export async function updateAgent(
     .prepare(`UPDATE agents SET ${sets.join(", ")} WHERE id = ?`)
     .bind(...binds)
     .run();
-  return parseAgent({ ...agent, ...updates, updated_at: now });
+  return parseJsonFields({ ...agent, ...updates, updated_at: now }, ["skills", "handoff_to"]);
 }
 
 export async function deleteAgent(db: D1, agentId: string): Promise<boolean> {

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -277,6 +277,7 @@ api.get("/api/agents/:id", async (c) => {
 api.post("/api/agents", async (c) => {
   const body = await c.req.json<{
     name: string;
+    username?: string;
     bio?: string;
     soul?: string;
     role?: string;

--- a/apps/web/migrations/0012_agent_username.sql
+++ b/apps/web/migrations/0012_agent_username.sql
@@ -1,0 +1,14 @@
+-- Add username field to agents table for external-facing identity.
+-- Used for email (username@mails.agent-kanban.dev) and git commit identity.
+-- Username is unique per owner (two different tenants may have agents with the same username).
+ALTER TABLE agents ADD COLUMN username TEXT;
+
+-- Backfill: lowercase name, spaces→hyphens.
+UPDATE agents SET username = lower(replace(name, ' ', '-'))
+WHERE username IS NULL;
+
+-- Safety net: any row whose name produced a NULL or invalid username gets a stable fallback.
+UPDATE agents SET username = 'agent-' || substr(id, 1, 8)
+WHERE username IS NULL OR username = '';
+
+CREATE UNIQUE INDEX idx_agents_owner_username ON agents (owner_id, username) WHERE username IS NOT NULL;

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,4 +1,4 @@
-import { fetchTemplate, isBoardType, parseScheduledAt } from "@agent-kanban/shared";
+import { deriveUsername, fetchTemplate, isBoardType, parseScheduledAt } from "@agent-kanban/shared";
 import type { Command } from "commander";
 import { type ApiClient, createClient } from "../client.js";
 import { getFormat, output } from "../output.js";
@@ -101,8 +101,10 @@ async function createAgent(opts: Record<string, string>) {
       console.error("Template has no runtime. Pass --runtime explicitly.");
       process.exit(1);
     }
+    const name = opts.name || template.name;
     body = {
-      name: opts.name || template.name,
+      name,
+      username: opts.username || deriveUsername(name),
       bio: opts.bio || template.bio,
       soul: opts.soul || template.soul,
       role: opts.role || template.role,
@@ -118,7 +120,7 @@ async function createAgent(opts: Record<string, string>) {
       process.exit(1);
     }
     const runtime = opts.runtime || detectRuntime();
-    body = { name: opts.name, runtime };
+    body = { name: opts.name, username: opts.username || deriveUsername(opts.name), runtime };
     if (opts.bio) body.bio = opts.bio;
     if (opts.soul) body.soul = opts.soul;
     if (opts.role) body.role = opts.role;
@@ -183,6 +185,7 @@ export function registerCreateCommand(program: Command) {
     .option("--scheduled-at <time>", "ISO 8601 time to schedule task (task)")
     // agent flags
     .option("--template <slug>", "Agent template slug (agent)")
+    .option("--username <username>", "Agent username for email/git identity; auto-derived from --name if omitted (agent)")
     .option("--bio <bio>", "Agent bio (agent)")
     .option("--soul <soul>", "Agent soul — persistent behavior instructions (agent)")
     .option("--role <role>", "Agent role (agent)")

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -155,10 +155,32 @@ export function normalizeRuntime(runtime: string): AgentRuntime {
   return RUNTIME_ALIASES[runtime] ?? (runtime as AgentRuntime);
 }
 
+// ─── Agent Username ───
+
+const USERNAME_RE = /^[a-z0-9][a-z0-9-]{1,37}[a-z0-9]$/;
+
+/** Returns true if the username matches GitHub-style rules: lowercase alphanumeric + hyphens, 3–39 chars, no leading/trailing/consecutive hyphens. */
+export function isValidUsername(username: string): boolean {
+  return USERNAME_RE.test(username) && !username.includes("--");
+}
+
+/** Derives a valid username from a human-readable name. */
+export function deriveUsername(name: string): string {
+  const sanitized = name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 39);
+  if (!sanitized) return "agent";
+  if (sanitized.length < 3) return sanitized.padEnd(3, "0");
+  return sanitized;
+}
+
 export interface Agent {
   id: string;
   owner_id: string;
   name: string;
+  username: string;
   bio: string | null;
   soul: string | null;
   role: string | null;
@@ -183,6 +205,7 @@ export interface AgentWithActivity extends Agent {
   cache_read_tokens: number;
   cache_creation_tokens: number;
   cost_micro_usd: number;
+  email: string;
 }
 
 // ─── Agent Session ───
@@ -268,6 +291,7 @@ export interface CompleteTaskInput {
 
 export interface CreateAgentInput {
   name: string;
+  username?: string;
   bio?: string;
   soul?: string;
   role?: string;

--- a/tests/agent-auth.test.ts
+++ b/tests/agent-auth.test.ts
@@ -28,6 +28,7 @@ async function applyMigrations(db: D1Database) {
     "0007_task_seq.sql",
     "0010_board_type.sql",
     "0011_task_scheduled_at.sql",
+    "0012_agent_username.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");

--- a/tests/agent-json-fields.test.ts
+++ b/tests/agent-json-fields.test.ts
@@ -21,6 +21,7 @@ async function applyMigrations(db: D1Database) {
     "0007_task_seq.sql",
     "0010_board_type.sql",
     "0011_task_scheduled_at.sql",
+    "0012_agent_username.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");

--- a/tests/agent-redesign.test.ts
+++ b/tests/agent-redesign.test.ts
@@ -40,6 +40,7 @@ async function applyMigrations(db: D1Database) {
     "0007_task_seq.sql",
     "0010_board_type.sql",
     "0011_task_scheduled_at.sql",
+    "0012_agent_username.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");

--- a/tests/builtin-agents.test.ts
+++ b/tests/builtin-agents.test.ts
@@ -30,6 +30,7 @@ async function applyMigrations(db: D1Database) {
     "0007_task_seq.sql",
     "0010_board_type.sql",
     "0011_task_scheduled_at.sql",
+    "0012_agent_username.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");

--- a/tests/cli-agent-jwt.test.ts
+++ b/tests/cli-agent-jwt.test.ts
@@ -34,6 +34,7 @@ async function applyMigrations(db: D1Database) {
     "0007_task_seq.sql",
     "0010_board_type.sql",
     "0011_task_scheduled_at.sql",
+    "0012_agent_username.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");

--- a/tests/helpers/db.ts
+++ b/tests/helpers/db.ts
@@ -27,6 +27,7 @@ export async function applyMigrations(db: D1Database) {
     "0009_admin_fields.sql",
     "0010_board_type.sql",
     "0011_task_scheduled_at.sql",
+    "0012_agent_username.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");

--- a/tests/machine-agent-flow.test.ts
+++ b/tests/machine-agent-flow.test.ts
@@ -35,6 +35,7 @@ async function applyMigrations(db: D1Database) {
     "0007_task_seq.sql",
     "0010_board_type.sql",
     "0011_task_scheduled_at.sql",
+    "0012_agent_username.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");

--- a/tests/machine-usage.test.ts
+++ b/tests/machine-usage.test.ts
@@ -22,6 +22,7 @@ async function applyMigrations(db: D1Database) {
     "0007_task_seq.sql",
     "0010_board_type.sql",
     "0011_task_scheduled_at.sql",
+    "0012_agent_username.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");

--- a/tests/task-dependencies.test.ts
+++ b/tests/task-dependencies.test.ts
@@ -29,6 +29,7 @@ async function applyMigrations(db: D1Database) {
     "0007_task_seq.sql",
     "0010_board_type.sql",
     "0011_task_scheduled_at.sql",
+    "0012_agent_username.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");

--- a/tests/task-json-fields.test.ts
+++ b/tests/task-json-fields.test.ts
@@ -21,6 +21,7 @@ async function applyMigrations(db: D1Database) {
     "0007_task_seq.sql",
     "0010_board_type.sql",
     "0011_task_scheduled_at.sql",
+    "0012_agent_username.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");

--- a/tests/task-state-machine.test.ts
+++ b/tests/task-state-machine.test.ts
@@ -32,6 +32,7 @@ async function applyMigrations(db: D1Database) {
     "0007_task_seq.sql",
     "0010_board_type.sql",
     "0011_task_scheduled_at.sql",
+    "0012_agent_username.sql",
   ];
   for (const file of files) {
     const sql = readFileSync(join(MIGRATIONS_DIR, file), "utf-8");


### PR DESCRIPTION
## Summary

- **DB migration** (`0012_agent_username.sql`): adds `username TEXT` column to `agents` table, backfills existing rows via `lower(replace(name, ' ', '-'))` with a safety-net fallback, enforces per-owner uniqueness via partial index `(owner_id, username)`
- **Shared types**: `username: string` added to `Agent`; `email: string` (computed) added to `AgentWithActivity`; `isValidUsername` and `deriveUsername` helpers exported for reuse across CLI and server
- **agentRepo**: `createAgent` validates format, checks per-owner uniqueness (with UNIQUE constraint catch as 409 fallback), inserts `username`; `listAgents`/`getAgent` select `username` and compute `email` as `${username}@mails.agent-kanban.dev`
- **API**: `POST /api/agents` accepts optional `username` — auto-derived from `name` if absent
- **CLI**: `ak create agent --username <name>` flag added; auto-derives from `--name` if omitted
- **Tests**: new migration added to all test migration lists

## Test plan

- [ ] All 628 existing tests pass (`npx vitest run`)
- [ ] `pnpm build && pnpm tsc --noEmit` clean
- [ ] `ak create agent --name "My Agent"` creates agent with username `my-agent`
- [ ] `ak create agent --name "My Agent" --username custom-name` uses the explicit username
- [ ] Duplicate username for same owner returns 409
- [ ] Same username for different owners is allowed
- [ ] `GET /api/agents` returns `username` and computed `email` on each agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)