### PR TITLE
feat: GitHub OAuth integration for GPG key and agent email sync

### DIFF
--- a/apps/web/functions/api/auth.ts
+++ b/apps/web/functions/api/auth.ts
@@ -64,6 +64,10 @@ const ROUTE_RULES: { method: string; pattern: RegExp; rule: RouteRule }[] = [
   // GPG keys — user only
   { method: "GET", pattern: /^\/api\/gpg\/public-key$/, rule: { allow: ["user"] } },
 
+  // GitHub integration — user only
+  { method: "POST", pattern: /^\/api\/github\/sync-gpg$/, rule: { allow: ["user"] } },
+  { method: "POST", pattern: /^\/api\/github\/sync-emails$/, rule: { allow: ["user"] } },
+
   // Admin — user identity only (Better Auth plugin enforces role internally)
   { method: "POST", pattern: /^\/api\/auth\/admin\//, rule: { allow: ["user"] } },
   { method: "GET", pattern: /^\/api\/auth\/admin\//, rule: { allow: ["user"] } },

--- a/apps/web/functions/api/betterAuth.ts
+++ b/apps/web/functions/api/betterAuth.ts
@@ -26,6 +26,7 @@ export function createAuth(env: Env) {
       github: {
         clientId: env.GITHUB_CLIENT_ID,
         clientSecret: env.GITHUB_CLIENT_SECRET,
+        scope: ["user", "write:gpg_key"],
       },
     },
     plugins: [

--- a/apps/web/functions/api/githubService.ts
+++ b/apps/web/functions/api/githubService.ts
@@ -1,0 +1,68 @@
+import type { D1 } from "./db";
+
+const GITHUB_API = "https://api.github.com";
+const USER_AGENT = "agent-kanban/1.0";
+
+interface GithubGpgKey {
+  id: number;
+  key_id: string;
+}
+
+export async function getGithubToken(db: D1, userId: string): Promise<string | null> {
+  const row = await db
+    .prepare("SELECT access_token FROM account WHERE user_id = ? AND provider_id = 'github'")
+    .bind(userId)
+    .first<{ access_token: string }>();
+  return row?.access_token ?? null;
+}
+
+export async function syncGpgKey(token: string, armoredPublicKey: string, fingerprint: string): Promise<void> {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "User-Agent": USER_AGENT,
+    "Content-Type": "application/json",
+  };
+
+  const listRes = await fetch(`${GITHUB_API}/user/gpg_keys`, { headers });
+  if (!listRes.ok) throw new Error(`GitHub list GPG keys failed: ${listRes.status}`);
+
+  const keys = (await listRes.json()) as GithubGpgKey[];
+
+  // GitHub key_id is the last 16 hex chars of the fingerprint (uppercased)
+  const keyIdSuffix = fingerprint.toUpperCase().slice(-16);
+  const existing = keys.find((k) => k.key_id.toUpperCase() === keyIdSuffix);
+
+  if (existing) {
+    await fetch(`${GITHUB_API}/user/gpg_keys/${existing.id}`, {
+      method: "DELETE",
+      headers,
+    });
+  }
+
+  const createRes = await fetch(`${GITHUB_API}/user/gpg_keys`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ armored_public_key: armoredPublicKey }),
+  });
+  if (!createRes.ok) {
+    const body = await createRes.text();
+    throw new Error(`GitHub create GPG key failed: ${createRes.status} ${body}`);
+  }
+}
+
+export async function addAgentEmail(token: string, email: string): Promise<void> {
+  const res = await fetch(`${GITHUB_API}/user/emails`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "User-Agent": USER_AGENT,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ emails: [email] }),
+  });
+  // 422 = email already exists — treat as success
+  if (!res.ok && res.status !== 422) {
+    const body = await res.text();
+    throw new Error(`GitHub add email failed: ${res.status} ${body}`);
+  }
+}

--- a/apps/web/functions/api/gpgKeyRepo.ts
+++ b/apps/web/functions/api/gpgKeyRepo.ts
@@ -17,7 +17,7 @@ interface GpgKeyRow extends GpgKey {
 async function generateRootKey(ownerEmail: string): Promise<{ armoredPrivateKey: string; armoredPublicKey: string; fingerprint: string }> {
   const { privateKey, publicKey } = await openpgp.generateKey({
     type: "ecc",
-    curve: "ed25519",
+    curve: "ed25519Legacy",
     userIDs: [{ name: "Agent Kanban", email: ownerEmail }],
     format: "armored",
   });
@@ -55,7 +55,7 @@ export async function addSubkey(db: D1, ownerId: string): Promise<{ fingerprint:
   if (!row) return null;
 
   const privateKey = await openpgp.readPrivateKey({ armoredKey: row.armored_private_key });
-  const updatedKey = await privateKey.addSubkey({ type: "ecc", curve: "ed25519", sign: true });
+  const updatedKey = await privateKey.addSubkey({ type: "ecc", curve: "ed25519Legacy", sign: true });
   const armoredPrivate = updatedKey.armor();
   const armoredPublic = updatedKey.toPublic().armor();
 

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -7,7 +7,8 @@ import { authMiddleware } from "./auth";
 import { createAuth } from "./betterAuth";
 import { createBoard, deleteBoard, getBoard, getBoardByName, getBoardBySlug, listBoards, updateBoard } from "./boardRepo";
 import { createBoardSSEResponse, createPublicBoardSSEResponse } from "./boardSSE";
-import { getRootPublicKey } from "./gpgKeyRepo";
+import { addAgentEmail, getGithubToken, syncGpgKey } from "./githubService";
+import { addSubkey, getRootPublicKey } from "./gpgKeyRepo";
 import { createLogger } from "./logger";
 import { deleteMachine, getMachine, listMachines, updateMachine, upsertMachine } from "./machineRepo";
 import { createMessage, listMessages } from "./messageRepo";
@@ -295,7 +296,12 @@ api.post("/api/agents", async (c) => {
   if (body.role && RESERVED_ROLES.has(body.role)) {
     throw new HTTPException(403, { message: `Role "${body.role}" is reserved for built-in agents` });
   }
-  const agent = await createAgent(c.env.DB, c.get("ownerId"), body as CreateAgentInput);
+  const ownerId = c.get("ownerId");
+  const agent = await createAgent(c.env.DB, ownerId, body as CreateAgentInput);
+
+  // Add GPG subkey for this agent, then sync to GitHub (best-effort, silent on failure)
+  await syncAgentToGithub(c.env, ownerId, agent.id);
+
   return c.json(agent, 201);
 });
 
@@ -637,4 +643,55 @@ api.get("/api/gpg/public-key", async (c) => {
   return c.json({ armored_public_key: armoredPublicKey });
 });
 
+// ─── GitHub Integration ───
+
+api.post("/api/github/sync-gpg", async (c) => {
+  const ownerId = c.get("ownerId");
+  const token = await getGithubToken(c.env.DB, ownerId);
+  if (!token) throw new HTTPException(400, { message: "GitHub account not connected" });
+
+  const row = await c.env.DB.prepare("SELECT armored_public_key, fingerprint FROM gpg_keys WHERE owner_id = ?")
+    .bind(ownerId)
+    .first<{ armored_public_key: string; fingerprint: string }>();
+  if (!row) throw new HTTPException(404, { message: "GPG root key not found" });
+
+  await syncGpgKey(token, row.armored_public_key, row.fingerprint);
+  return c.json({ ok: true });
+});
+
+api.post("/api/github/sync-emails", async (c) => {
+  const ownerId = c.get("ownerId");
+  const token = await getGithubToken(c.env.DB, ownerId);
+  if (!token) throw new HTTPException(400, { message: "GitHub account not connected" });
+
+  const agents = await listAgents(c.env.DB, ownerId);
+  await Promise.all(agents.map((a) => addAgentEmail(token, agentEmail(a.id))));
+  return c.json({ ok: true });
+});
+
 export { api };
+
+// ─── Helpers ───
+
+function agentEmail(agentId: string): string {
+  return `${agentId}@mails.agent-kanban.dev`;
+}
+
+async function syncAgentToGithub(env: Env, ownerId: string, agentId: string): Promise<void> {
+  try {
+    await addSubkey(env.DB, ownerId);
+
+    const token = await getGithubToken(env.DB, ownerId);
+    if (!token) return;
+
+    const row = await env.DB.prepare("SELECT armored_public_key, fingerprint FROM gpg_keys WHERE owner_id = ?")
+      .bind(ownerId)
+      .first<{ armored_public_key: string; fingerprint: string }>();
+    if (!row) return;
+
+    await syncGpgKey(token, row.armored_public_key, row.fingerprint);
+    await addAgentEmail(token, agentEmail(agentId));
+  } catch (err: any) {
+    logger.warn(`github sync failed for agent ${agentId}: ${err.message}`);
+  }
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -104,4 +104,8 @@ export const api = {
   admin: {
     getStats: () => request<any>("GET", "/admin/stats"),
   },
+  github: {
+    syncGpg: () => request<{ ok: boolean }>("POST", "/github/sync-gpg"),
+    syncEmails: () => request<{ ok: boolean }>("POST", "/github/sync-emails"),
+  },
 };

--- a/apps/web/src/routes/AccountSettingsPage.tsx
+++ b/apps/web/src/routes/AccountSettingsPage.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Header } from "../components/Header";
 import { useBoards, useDeleteBoard, useUpdateBoard } from "../hooks/useBoard";
+import { api } from "../lib/api";
+import { authClient } from "../lib/auth-client";
 import { getTheme, setTheme, type Theme } from "../lib/theme";
 
 function BoardItem({ board }: { board: any }) {
@@ -116,6 +118,93 @@ function BoardItem({ board }: { board: any }) {
   );
 }
 
+function GitHubSection() {
+  const [accounts, setAccounts] = useState<Array<{ providerId: string }>>([]);
+  const [syncing, setSyncing] = useState<"gpg" | "emails" | null>(null);
+  const [syncMsg, setSyncMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    authClient.listAccounts().then((res: any) => {
+      if (res.data) setAccounts(res.data);
+    });
+  }, []);
+
+  const isConnected = accounts.some((a) => a.providerId === "github");
+
+  async function handleConnect() {
+    await authClient.signIn.social({ provider: "github", callbackURL: "/settings" });
+  }
+
+  async function handleSyncGpg() {
+    setSyncing("gpg");
+    setSyncMsg(null);
+    try {
+      await api.github.syncGpg();
+      setSyncMsg("GPG key synced to GitHub.");
+    } catch (err: any) {
+      setSyncMsg(`Error: ${err.message}`);
+    } finally {
+      setSyncing(null);
+    }
+  }
+
+  async function handleSyncEmails() {
+    setSyncing("emails");
+    setSyncMsg(null);
+    try {
+      await api.github.syncEmails();
+      setSyncMsg("Agent emails synced to GitHub.");
+    } catch (err: any) {
+      setSyncMsg(`Error: ${err.message}`);
+    } finally {
+      setSyncing(null);
+    }
+  }
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xs font-semibold text-content-tertiary uppercase tracking-wide">GitHub</h2>
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-content-primary font-medium">GitHub Account</p>
+            <p className="text-xs text-content-tertiary mt-0.5">
+              {isConnected ? "Connected — GPG keys and agent emails can be synced." : "Not connected"}
+            </p>
+          </div>
+          {!isConnected && (
+            <button onClick={handleConnect} className="bg-accent text-[#09090B] font-medium text-xs px-3 py-1.5 rounded-md hover:opacity-90">
+              Connect GitHub
+            </button>
+          )}
+          {isConnected && <span className="text-xs text-green-500 font-medium">Connected</span>}
+        </div>
+
+        {isConnected && (
+          <div className="flex gap-2 pt-1">
+            <button
+              onClick={handleSyncGpg}
+              disabled={syncing !== null}
+              className="text-xs px-3 py-1.5 rounded-md border border-border text-content-secondary hover:border-accent hover:text-accent transition-colors disabled:opacity-50"
+            >
+              {syncing === "gpg" ? "Syncing…" : "Sync GPG Key"}
+            </button>
+            <button
+              onClick={handleSyncEmails}
+              disabled={syncing !== null}
+              className="text-xs px-3 py-1.5 rounded-md border border-border text-content-secondary hover:border-accent hover:text-accent transition-colors disabled:opacity-50"
+            >
+              {syncing === "emails" ? "Syncing…" : "Sync Emails"}
+            </button>
+          </div>
+        )}
+
+        {syncMsg && <p className={`text-xs ${syncMsg.startsWith("Error") ? "text-error" : "text-content-secondary"}`}>{syncMsg}</p>}
+      </div>
+    </section>
+  );
+}
+
 export function AccountSettingsPage() {
   const [currentTheme, setCurrentTheme] = useState<Theme>(getTheme());
   const { boards } = useBoards();
@@ -150,6 +239,9 @@ export function AccountSettingsPage() {
             ))}
           </div>
         </section>
+
+        {/* GitHub */}
+        <GitHubSection />
 
         {/* Boards */}
         <section className="space-y-3">


### PR DESCRIPTION
## Summary
- Add GitHub OAuth social provider with user + write:gpg_key scopes
- Create githubService.ts with GPG key sync and agent email registration  
- Integrate GPG subkey creation + GitHub sync on agent creation (best-effort, silent on failure)
- Add POST /api/github/sync-gpg and POST /api/github/sync-emails endpoints (user-only)
- Add GitHub connection UI in Settings page with Connect, Sync GPG Key, and Sync Emails buttons

## Test plan
- [ ] Connect GitHub in Settings page — should redirect to GitHub OAuth and return Connected
- [ ] Create a new agent — should silently add GPG subkey and sync to GitHub if connected
- [ ] Sync GPG Key button — should upload root public key to GitHub
- [ ] Sync Emails button — should add all agent emails to GitHub account
- [ ] Revoke GitHub access — agent creation and sync should fail silently, not break anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)