### PR TITLE
feat: daemon GPG signing + git identity injection (Plan B)

### DIFF
--- a/apps/web/functions/api/agentRepo.ts
+++ b/apps/web/functions/api/agentRepo.ts
@@ -52,6 +52,7 @@ export async function createAgent(db: D1, ownerId: string, input: CreateAgentInp
     skills: input.skills ?? null,
     public_key: publicKeyBase64,
     fingerprint,
+    gpg_subkey_id: null,
     builtin: builtin ? 1 : 0,
     created_at: now,
     updated_at: now,
@@ -72,7 +73,7 @@ export async function listAgents(db: D1, ownerId: string): Promise<AgentWithActi
   const result = await db
     .prepare(`
     SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.kind, a.handoff_to, a.runtime, a.model, a.skills,
-      a.public_key, a.fingerprint, a.builtin, a.created_at, a.updated_at,
+      a.public_key, a.fingerprint, a.gpg_subkey_id, a.builtin, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
       (SELECT MAX(tl.created_at) FROM task_actions tl WHERE tl.actor_id = a.id) as last_active_at,
       (SELECT COUNT(*) FROM tasks t WHERE t.assigned_to = a.id) as task_count,
@@ -94,7 +95,7 @@ export async function getAgent(db: D1, agentId: string, ownerId: string): Promis
   return db
     .prepare(`
     SELECT a.id, a.owner_id, a.name, a.bio, a.soul, a.role, a.kind, a.handoff_to, a.runtime, a.model, a.skills,
-      a.public_key, a.fingerprint, a.builtin, a.created_at, a.updated_at,
+      a.public_key, a.fingerprint, a.gpg_subkey_id, a.builtin, a.created_at, a.updated_at,
       CASE WHEN EXISTS (SELECT 1 FROM agent_sessions s WHERE s.agent_id = a.id AND s.status = 'active') THEN 'online' ELSE 'offline' END as status,
       (SELECT MAX(tl.created_at) FROM task_actions tl WHERE tl.actor_id = a.id) as last_active_at,
       (SELECT COUNT(*) FROM tasks t WHERE t.assigned_to = a.id) as task_count,
@@ -159,4 +160,8 @@ export async function getAgentLogs(db: D1, agentId: string): Promise<any[]> {
 export async function getAgentPrivateKey(db: D1, agentId: string): Promise<JsonWebKey | null> {
   const row = await db.prepare("SELECT private_key FROM agents WHERE id = ?").bind(agentId).first<{ private_key: string }>();
   return row ? JSON.parse(row.private_key) : null;
+}
+
+export async function setAgentGpgSubkeyId(db: D1, agentId: string, gpgSubkeyId: string): Promise<void> {
+  await db.prepare("UPDATE agents SET gpg_subkey_id = ? WHERE id = ?").bind(gpgSubkeyId, agentId).run();
 }

--- a/apps/web/functions/api/auth.ts
+++ b/apps/web/functions/api/auth.ts
@@ -64,6 +64,10 @@ const ROUTE_RULES: { method: string; pattern: RegExp; rule: RouteRule }[] = [
   // GPG keys — user only
   { method: "GET", pattern: /^\/api\/gpg\/public-key$/, rule: { allow: ["user"] } },
 
+  // GitHub integration — user only
+  { method: "POST", pattern: /^\/api\/github\/sync-gpg$/, rule: { allow: ["user"] } },
+  { method: "POST", pattern: /^\/api\/github\/sync-emails$/, rule: { allow: ["user"] } },
+
   // Admin — user identity only (Better Auth plugin enforces role internally)
   { method: "POST", pattern: /^\/api\/auth\/admin\//, rule: { allow: ["user"] } },
   { method: "GET", pattern: /^\/api\/auth\/admin\//, rule: { allow: ["user"] } },

--- a/apps/web/functions/api/betterAuth.ts
+++ b/apps/web/functions/api/betterAuth.ts
@@ -26,6 +26,7 @@ export function createAuth(env: Env) {
       github: {
         clientId: env.GITHUB_CLIENT_ID,
         clientSecret: env.GITHUB_CLIENT_SECRET,
+        scope: ["user", "write:gpg_key"],
       },
     },
     plugins: [

--- a/apps/web/functions/api/githubService.ts
+++ b/apps/web/functions/api/githubService.ts
@@ -1,0 +1,68 @@
+import type { D1 } from "./db";
+
+const GITHUB_API = "https://api.github.com";
+const USER_AGENT = "agent-kanban/1.0";
+
+interface GithubGpgKey {
+  id: number;
+  key_id: string;
+}
+
+export async function getGithubToken(db: D1, userId: string): Promise<string | null> {
+  const row = await db
+    .prepare("SELECT access_token FROM account WHERE user_id = ? AND provider_id = 'github'")
+    .bind(userId)
+    .first<{ access_token: string }>();
+  return row?.access_token ?? null;
+}
+
+export async function syncGpgKey(token: string, armoredPublicKey: string, fingerprint: string): Promise<void> {
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "User-Agent": USER_AGENT,
+    "Content-Type": "application/json",
+  };
+
+  const listRes = await fetch(`${GITHUB_API}/user/gpg_keys`, { headers });
+  if (!listRes.ok) throw new Error(`GitHub list GPG keys failed: ${listRes.status}`);
+
+  const keys = (await listRes.json()) as GithubGpgKey[];
+
+  // GitHub key_id is the last 16 hex chars of the fingerprint (uppercased)
+  const keyIdSuffix = fingerprint.toUpperCase().slice(-16);
+  const existing = keys.find((k) => k.key_id.toUpperCase() === keyIdSuffix);
+
+  if (existing) {
+    await fetch(`${GITHUB_API}/user/gpg_keys/${existing.id}`, {
+      method: "DELETE",
+      headers,
+    });
+  }
+
+  const createRes = await fetch(`${GITHUB_API}/user/gpg_keys`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ armored_public_key: armoredPublicKey }),
+  });
+  if (!createRes.ok) {
+    const body = await createRes.text();
+    throw new Error(`GitHub create GPG key failed: ${createRes.status} ${body}`);
+  }
+}
+
+export async function addAgentEmail(token: string, email: string): Promise<void> {
+  const res = await fetch(`${GITHUB_API}/user/emails`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "User-Agent": USER_AGENT,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ emails: [email] }),
+  });
+  // 422 = email already exists — treat as success
+  if (!res.ok && res.status !== 422) {
+    const body = await res.text();
+    throw new Error(`GitHub add email failed: ${res.status} ${body}`);
+  }
+}

--- a/apps/web/functions/api/gpgKeyRepo.ts
+++ b/apps/web/functions/api/gpgKeyRepo.ts
@@ -80,3 +80,11 @@ export async function getRootPublicKey(db: D1, ownerId: string): Promise<string 
     .first<Pick<GpgKey, "armored_public_key">>();
   return row?.armored_public_key ?? null;
 }
+
+export async function getArmoredPrivateKey(db: D1, ownerId: string): Promise<string | null> {
+  const row = await db
+    .prepare("SELECT armored_private_key FROM gpg_keys WHERE owner_id = ?")
+    .bind(ownerId)
+    .first<Pick<GpgKeyRow, "armored_private_key">>();
+  return row?.armored_private_key ?? null;
+}

--- a/apps/web/functions/api/gpgKeyRepo.ts
+++ b/apps/web/functions/api/gpgKeyRepo.ts
@@ -17,7 +17,7 @@ interface GpgKeyRow extends GpgKey {
 async function generateRootKey(ownerEmail: string): Promise<{ armoredPrivateKey: string; armoredPublicKey: string; fingerprint: string }> {
   const { privateKey, publicKey } = await openpgp.generateKey({
     type: "ecc",
-    curve: "ed25519",
+    curve: "ed25519Legacy",
     userIDs: [{ name: "Agent Kanban", email: ownerEmail }],
     format: "armored",
   });
@@ -55,7 +55,7 @@ export async function addSubkey(db: D1, ownerId: string): Promise<{ fingerprint:
   if (!row) return null;
 
   const privateKey = await openpgp.readPrivateKey({ armoredKey: row.armored_private_key });
-  const updatedKey = await privateKey.addSubkey({ type: "ecc", curve: "ed25519", sign: true });
+  const updatedKey = await privateKey.addSubkey({ type: "ecc", curve: "ed25519Legacy", sign: true });
   const armoredPrivate = updatedKey.armor();
   const armoredPublic = updatedKey.toPublic().armor();
 

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -7,7 +7,8 @@ import { authMiddleware } from "./auth";
 import { createAuth } from "./betterAuth";
 import { createBoard, deleteBoard, getBoard, getBoardByName, getBoardBySlug, listBoards, updateBoard } from "./boardRepo";
 import { createBoardSSEResponse, createPublicBoardSSEResponse } from "./boardSSE";
-import { getRootPublicKey } from "./gpgKeyRepo";
+import { addAgentEmail, getGithubToken, syncGpgKey } from "./githubService";
+import { addSubkey, getRootPublicKey } from "./gpgKeyRepo";
 import { createLogger } from "./logger";
 import { deleteMachine, getMachine, listMachines, updateMachine, upsertMachine } from "./machineRepo";
 import { createMessage, listMessages } from "./messageRepo";
@@ -295,7 +296,12 @@ api.post("/api/agents", async (c) => {
   if (body.role && RESERVED_ROLES.has(body.role)) {
     throw new HTTPException(403, { message: `Role "${body.role}" is reserved for built-in agents` });
   }
-  const agent = await createAgent(c.env.DB, c.get("ownerId"), body as CreateAgentInput);
+  const ownerId = c.get("ownerId");
+  const agent = await createAgent(c.env.DB, ownerId, body as CreateAgentInput);
+
+  // Add GPG subkey for this agent, then sync to GitHub (best-effort, silent on failure)
+  await syncAgentToGithub(c.env, ownerId, agent.id);
+
   return c.json(agent, 201);
 });
 
@@ -637,4 +643,55 @@ api.get("/api/gpg/public-key", async (c) => {
   return c.json({ armored_public_key: armoredPublicKey });
 });
 
+// ─── GitHub Integration ───
+
+api.post("/api/github/sync-gpg", async (c) => {
+  const ownerId = c.get("ownerId");
+  const token = await getGithubToken(c.env.DB, ownerId);
+  if (!token) throw new HTTPException(400, { message: "GitHub account not connected" });
+
+  const row = await c.env.DB.prepare("SELECT armored_public_key, fingerprint FROM gpg_keys WHERE owner_id = ?")
+    .bind(ownerId)
+    .first<{ armored_public_key: string; fingerprint: string }>();
+  if (!row) throw new HTTPException(404, { message: "GPG root key not found" });
+
+  await syncGpgKey(token, row.armored_public_key, row.fingerprint);
+  return c.json({ ok: true });
+});
+
+api.post("/api/github/sync-emails", async (c) => {
+  const ownerId = c.get("ownerId");
+  const token = await getGithubToken(c.env.DB, ownerId);
+  if (!token) throw new HTTPException(400, { message: "GitHub account not connected" });
+
+  const agents = await listAgents(c.env.DB, ownerId);
+  await Promise.all(agents.map((a) => addAgentEmail(token, agentEmail(a.id))));
+  return c.json({ ok: true });
+});
+
 export { api };
+
+// ─── Helpers ───
+
+function agentEmail(agentId: string): string {
+  return `${agentId}@mails.agent-kanban.dev`;
+}
+
+async function syncAgentToGithub(env: Env, ownerId: string, agentId: string): Promise<void> {
+  try {
+    await addSubkey(env.DB, ownerId);
+
+    const token = await getGithubToken(env.DB, ownerId);
+    if (!token) return;
+
+    const row = await env.DB.prepare("SELECT armored_public_key, fingerprint FROM gpg_keys WHERE owner_id = ?")
+      .bind(ownerId)
+      .first<{ armored_public_key: string; fingerprint: string }>();
+    if (!row) return;
+
+    await syncGpgKey(token, row.armored_public_key, row.fingerprint);
+    await addAgentEmail(token, agentEmail(agentId));
+  } catch (err: any) {
+    logger.warn(`github sync failed for agent ${agentId}: ${err.message}`);
+  }
+}

--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -1,14 +1,14 @@
 import { AGENT_RUNTIMES, type CreateAgentInput, isBoardType, parseScheduledAt, RESERVED_ROLES } from "@agent-kanban/shared";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
-import { createAgent, deleteAgent, getAgent, getAgentLogs, listAgents, updateAgent } from "./agentRepo";
+import { createAgent, deleteAgent, getAgent, getAgentLogs, listAgents, setAgentGpgSubkeyId, updateAgent } from "./agentRepo";
 import { closeSession, createSession, listSessions, reopenSession, updateSessionUsage } from "./agentSessionRepo";
 import { authMiddleware } from "./auth";
 import { createAuth } from "./betterAuth";
 import { createBoard, deleteBoard, getBoard, getBoardByName, getBoardBySlug, listBoards, updateBoard } from "./boardRepo";
 import { createBoardSSEResponse, createPublicBoardSSEResponse } from "./boardSSE";
 import { addAgentEmail, getGithubToken, syncGpgKey } from "./githubService";
-import { addSubkey, getRootPublicKey } from "./gpgKeyRepo";
+import { addSubkey, getArmoredPrivateKey, getRootPublicKey } from "./gpgKeyRepo";
 import { createLogger } from "./logger";
 import { deleteMachine, getMachine, listMachines, updateMachine, upsertMachine } from "./machineRepo";
 import { createMessage, listMessages } from "./messageRepo";
@@ -357,6 +357,20 @@ api.patch("/api/agents/:agentId/sessions/:sessionId/usage", async (c) => {
   return c.json({ ok: true });
 });
 
+api.get("/api/agents/:id/gpg-key", async (c) => {
+  // Only machines (daemon) may fetch private key material — agents must not.
+  if (c.get("identityType")?.startsWith("agent:")) {
+    throw new HTTPException(403, { message: "Forbidden" });
+  }
+  const row = await c.env.DB.prepare("SELECT gpg_subkey_id FROM agents WHERE id = ? AND owner_id = ?")
+    .bind(c.req.param("id"), c.get("ownerId"))
+    .first<{ gpg_subkey_id: string | null }>();
+  if (!row) throw new HTTPException(404, { message: "Agent not found" });
+  const armoredPrivateKey = await getArmoredPrivateKey(c.env.DB, c.get("ownerId"));
+  if (!armoredPrivateKey) throw new HTTPException(404, { message: "GPG key not found" });
+  return c.json({ armored_private_key: armoredPrivateKey, gpg_subkey_id: row.gpg_subkey_id });
+});
+
 // ─── Tasks ───
 
 api.post("/api/tasks", async (c) => {
@@ -678,9 +692,18 @@ function agentEmail(agentId: string): string {
 }
 
 async function syncAgentToGithub(env: Env, ownerId: string, agentId: string): Promise<void> {
+  // GPG subkey assignment — necessary for commit signing, separate from GitHub.
   try {
-    await addSubkey(env.DB, ownerId);
+    const subkey = await addSubkey(env.DB, ownerId);
+    if (subkey) {
+      await setAgentGpgSubkeyId(env.DB, agentId, subkey.keyId);
+    }
+  } catch (err: any) {
+    logger.warn(`GPG subkey setup failed for agent ${agentId}: ${err.message}`);
+  }
 
+  // GitHub sync — best-effort, optional.
+  try {
     const token = await getGithubToken(env.DB, ownerId);
     if (!token) return;
 

--- a/apps/web/migrations/0013_agent_gpg_subkey_id.sql
+++ b/apps/web/migrations/0013_agent_gpg_subkey_id.sql
@@ -1,0 +1,2 @@
+-- GPG subkey ID assigned to each agent for commit signing.
+ALTER TABLE agents ADD COLUMN gpg_subkey_id TEXT;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -104,4 +104,8 @@ export const api = {
   admin: {
     getStats: () => request<any>("GET", "/admin/stats"),
   },
+  github: {
+    syncGpg: () => request<{ ok: boolean }>("POST", "/github/sync-gpg"),
+    syncEmails: () => request<{ ok: boolean }>("POST", "/github/sync-emails"),
+  },
 };

--- a/apps/web/src/routes/AccountSettingsPage.tsx
+++ b/apps/web/src/routes/AccountSettingsPage.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Header } from "../components/Header";
 import { useBoards, useDeleteBoard, useUpdateBoard } from "../hooks/useBoard";
+import { api } from "../lib/api";
+import { authClient } from "../lib/auth-client";
 import { getTheme, setTheme, type Theme } from "../lib/theme";
 
 function BoardItem({ board }: { board: any }) {
@@ -116,6 +118,93 @@ function BoardItem({ board }: { board: any }) {
   );
 }
 
+function GitHubSection() {
+  const [accounts, setAccounts] = useState<Array<{ providerId: string }>>([]);
+  const [syncing, setSyncing] = useState<"gpg" | "emails" | null>(null);
+  const [syncMsg, setSyncMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    authClient.listAccounts().then((res: any) => {
+      if (res.data) setAccounts(res.data);
+    });
+  }, []);
+
+  const isConnected = accounts.some((a) => a.providerId === "github");
+
+  async function handleConnect() {
+    await authClient.signIn.social({ provider: "github", callbackURL: "/settings" });
+  }
+
+  async function handleSyncGpg() {
+    setSyncing("gpg");
+    setSyncMsg(null);
+    try {
+      await api.github.syncGpg();
+      setSyncMsg("GPG key synced to GitHub.");
+    } catch (err: any) {
+      setSyncMsg(`Error: ${err.message}`);
+    } finally {
+      setSyncing(null);
+    }
+  }
+
+  async function handleSyncEmails() {
+    setSyncing("emails");
+    setSyncMsg(null);
+    try {
+      await api.github.syncEmails();
+      setSyncMsg("Agent emails synced to GitHub.");
+    } catch (err: any) {
+      setSyncMsg(`Error: ${err.message}`);
+    } finally {
+      setSyncing(null);
+    }
+  }
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xs font-semibold text-content-tertiary uppercase tracking-wide">GitHub</h2>
+      <div className="border border-border rounded-lg p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-sm text-content-primary font-medium">GitHub Account</p>
+            <p className="text-xs text-content-tertiary mt-0.5">
+              {isConnected ? "Connected — GPG keys and agent emails can be synced." : "Not connected"}
+            </p>
+          </div>
+          {!isConnected && (
+            <button onClick={handleConnect} className="bg-accent text-[#09090B] font-medium text-xs px-3 py-1.5 rounded-md hover:opacity-90">
+              Connect GitHub
+            </button>
+          )}
+          {isConnected && <span className="text-xs text-green-500 font-medium">Connected</span>}
+        </div>
+
+        {isConnected && (
+          <div className="flex gap-2 pt-1">
+            <button
+              onClick={handleSyncGpg}
+              disabled={syncing !== null}
+              className="text-xs px-3 py-1.5 rounded-md border border-border text-content-secondary hover:border-accent hover:text-accent transition-colors disabled:opacity-50"
+            >
+              {syncing === "gpg" ? "Syncing…" : "Sync GPG Key"}
+            </button>
+            <button
+              onClick={handleSyncEmails}
+              disabled={syncing !== null}
+              className="text-xs px-3 py-1.5 rounded-md border border-border text-content-secondary hover:border-accent hover:text-accent transition-colors disabled:opacity-50"
+            >
+              {syncing === "emails" ? "Syncing…" : "Sync Emails"}
+            </button>
+          </div>
+        )}
+
+        {syncMsg && <p className={`text-xs ${syncMsg.startsWith("Error") ? "text-error" : "text-content-secondary"}`}>{syncMsg}</p>}
+      </div>
+    </section>
+  );
+}
+
 export function AccountSettingsPage() {
   const [currentTheme, setCurrentTheme] = useState<Theme>(getTheme());
   const { boards } = useBoards();
@@ -150,6 +239,9 @@ export function AccountSettingsPage() {
             ))}
           </div>
         </section>
+
+        {/* GitHub */}
+        <GitHubSection />
 
         {/* Boards */}
         <section className="space-y-3">

--- a/packages/cli/src/client.ts
+++ b/packages/cli/src/client.ts
@@ -96,6 +96,9 @@ export abstract class ApiClient {
   getAgent(agentId: string) {
     return this.request("GET", `/api/agents/${agentId}`);
   }
+  getAgentGpgKey(agentId: string) {
+    return this.request<{ armored_private_key: string; gpg_subkey_id: string | null }>("GET", `/api/agents/${agentId}/gpg-key`);
+  }
   updateAgent(agentId: string, body: Record<string, unknown>) {
     return this.request("PATCH", `/api/agents/${agentId}`, body);
   }

--- a/packages/cli/src/savedSessions.ts
+++ b/packages/cli/src/savedSessions.ts
@@ -14,13 +14,17 @@ export interface SavedSession {
   runtime: AgentRuntime;
   model?: string;
   status: SessionStatus;
+  gpgSubkeyId: string | null;
+  agentUsername: string;
+  agentName: string;
 }
 
 function readAll(): SavedSession[] {
   try {
     return JSON.parse(readFileSync(SAVED_SESSIONS_FILE, "utf-8"));
-  } catch {
-    return [];
+  } catch (err: any) {
+    if (err?.code === "ENOENT") return [];
+    throw err;
   }
 }
 

--- a/packages/cli/src/taskRunner.ts
+++ b/packages/cli/src/taskRunner.ts
@@ -1,4 +1,8 @@
+import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { BoardType } from "@agent-kanban/shared";
 import { AgentClient, ApiError, type MachineClient } from "./client.js";
 import { getCredentials } from "./config.js";
@@ -11,6 +15,16 @@ import { type AgentInfo, generateSystemPrompt, writePromptFile } from "./systemP
 import { createRepoWorkspace, createTempWorkspace, restoreWorkspace, type Workspace } from "./workspace.js";
 
 const logger = createLogger("runner");
+
+interface BuildEnvOpts {
+  agentId: string;
+  sessionId: string;
+  privateKeyJwk: JsonWebKey;
+  agentName: string;
+  agentUsername: string;
+  gpgSubkeyId: string | null;
+  gnupgHome: string | null;
+}
 
 export class TaskRunner {
   constructor(
@@ -38,7 +52,7 @@ export class TaskRunner {
 
     const abort = () => this.releaseAndClose(task.id, agentId, sessionId);
 
-    const agentDetails = (await this.client.getAgent(agentId)) as AgentInfo | null;
+    const agentDetails = (await this.client.getAgent(agentId)) as (AgentInfo & { gpg_subkey_id?: string | null }) | null;
     if (!agentDetails) {
       logger.error(`Agent ${agentId} not found, releasing task ${task.id}`);
       await abort();
@@ -55,12 +69,25 @@ export class TaskRunner {
       return false;
     }
 
+    // ---- GPG setup ----
+    const gpgSubkeyId = agentDetails.gpg_subkey_id ?? null;
+    let gnupgHome: string | null = null;
+    if (gpgSubkeyId) {
+      try {
+        const gpgData = await this.client.getAgentGpgKey(agentId);
+        gnupgHome = setupGnupgHome(gpgData.armored_private_key);
+      } catch (err: any) {
+        logger.warn(`GPG setup failed for agent ${agentId}: ${err.message} — proceeding without signing`);
+      }
+    }
+
     const providerName = normalizeRuntime(agentDetails.runtime);
     const provider = getProvider(providerName);
 
     const agentSkills = agentDetails.skills ?? [];
     if (!ensureSkills(workspace.cwd, agentSkills)) {
       logger.error(`Skill install failed for task ${task.id}, releasing task`);
+      cleanupGnupgHome(gnupgHome);
       workspace.cleanup();
       await abort();
       return false;
@@ -68,7 +95,15 @@ export class TaskRunner {
 
     const apiUrl = getCredentials().apiUrl;
     const agentClient = new AgentClient(apiUrl, agentId, sessionId, privateKey);
-    const agentEnv = this.buildAgentEnv(agentId, sessionId, privKeyJwk);
+    const agentEnv = this.buildAgentEnv({
+      agentId,
+      sessionId,
+      privateKeyJwk: privKeyJwk,
+      agentName: agentDetails.name,
+      agentUsername: agentId,
+      gpgSubkeyId,
+      gnupgHome,
+    });
     const systemPromptFile = writePromptFile(sessionId, generateSystemPrompt(agentDetails, boardType));
 
     const repos = await this.client.listRepositories();
@@ -95,6 +130,9 @@ export class TaskRunner {
       runtime: providerName,
       model: agentDetails.model ?? undefined,
       status: "active",
+      gpgSubkeyId,
+      agentUsername: agentId,
+      agentName: agentDetails.name,
     });
 
     await this.pm.spawnAgent({
@@ -106,7 +144,10 @@ export class TaskRunner {
       agentClient,
       agentEnv,
       systemPromptFile,
-      onCleanup: () => workspace.cleanup(),
+      onCleanup: () => {
+        workspace.cleanup();
+        cleanupGnupgHome(gnupgHome);
+      },
       model: agentDetails.model ?? undefined,
     });
 
@@ -155,10 +196,29 @@ export class TaskRunner {
       return false;
     }
 
+    // Re-fetch GPG key from API (not persisted to disk) and recreate GNUPGHOME.
+    let gnupgHome: string | null = null;
+    if (session.gpgSubkeyId) {
+      try {
+        const gpgData = await this.client.getAgentGpgKey(session.agentId);
+        gnupgHome = setupGnupgHome(gpgData.armored_private_key);
+      } catch (err: any) {
+        logger.warn(`GPG resume setup failed for task ${session.taskId}: ${err.message} — proceeding without signing`);
+      }
+    }
+
     const provider = getProvider(normalizeRuntime(session.runtime));
     const apiUrl = getCredentials().apiUrl;
     const agentClient = new AgentClient(apiUrl, session.agentId, session.sessionId, privateKey);
-    const agentEnv = this.buildAgentEnv(session.agentId, session.sessionId, session.privateKeyJwk);
+    const agentEnv = this.buildAgentEnv({
+      agentId: session.agentId,
+      sessionId: session.sessionId,
+      privateKeyJwk: session.privateKeyJwk,
+      agentName: session.agentName,
+      agentUsername: session.agentUsername,
+      gpgSubkeyId: session.gpgSubkeyId,
+      gnupgHome,
+    });
 
     logger.info(`Resuming task ${session.taskId} (session=${session.sessionId.slice(0, 8)})`);
 
@@ -172,11 +232,15 @@ export class TaskRunner {
         agentClient,
         agentEnv,
         resume: true,
-        onCleanup: () => workspace.cleanup(),
+        onCleanup: () => {
+          workspace.cleanup();
+          cleanupGnupgHome(gnupgHome);
+        },
         model: session.model,
       });
     } catch {
       logger.warn(`Failed to resume task ${session.taskId}, releasing`);
+      cleanupGnupgHome(gnupgHome);
       workspace.cleanup();
       removeSession(session.taskId);
       await this.client.releaseTask(session.taskId).catch(() => {});
@@ -192,12 +256,61 @@ export class TaskRunner {
     await this.client.closeSession(agentId, sessionId).catch(() => {});
   }
 
-  private buildAgentEnv(agentId: string, sessionId: string, privateKeyJwk: JsonWebKey): Record<string, string> {
-    return {
+  private buildAgentEnv(opts: BuildEnvOpts): Record<string, string> {
+    const { agentId, sessionId, privateKeyJwk, agentName, agentUsername, gpgSubkeyId, gnupgHome } = opts;
+    const email = `${agentUsername}@mails.agent-kanban.dev`;
+    const displayName = `${agentName} (agent-kanban)`;
+
+    const env: Record<string, string> = {
       AK_AGENT_ID: agentId,
       AK_SESSION_ID: sessionId,
       AK_AGENT_KEY: JSON.stringify(privateKeyJwk),
       AK_API_URL: getCredentials().apiUrl,
+      GIT_AUTHOR_NAME: displayName,
+      GIT_AUTHOR_EMAIL: email,
+      GIT_COMMITTER_NAME: displayName,
+      GIT_COMMITTER_EMAIL: email,
     };
+
+    if (gnupgHome && gpgSubkeyId) {
+      env.GNUPGHOME = gnupgHome;
+      env.GIT_CONFIG_COUNT = "3";
+      env.GIT_CONFIG_KEY_0 = "gpg.format";
+      env.GIT_CONFIG_VALUE_0 = "openpgp";
+      env.GIT_CONFIG_KEY_1 = "user.signingkey";
+      env.GIT_CONFIG_VALUE_1 = `${gpgSubkeyId}!`;
+      env.GIT_CONFIG_KEY_2 = "commit.gpgsign";
+      env.GIT_CONFIG_VALUE_2 = "true";
+    }
+
+    return env;
+  }
+}
+
+function setupGnupgHome(armoredPrivateKey: string): string {
+  const gnupgHome = mkdtempSync(join(tmpdir(), "ak-gpg-"));
+  const keyFile = join(gnupgHome, "key.asc");
+  writeFileSync(keyFile, armoredPrivateKey, { mode: 0o600 });
+  try {
+    execFileSync("gpg", ["--batch", "--import", keyFile], {
+      env: { ...process.env, GNUPGHOME: gnupgHome },
+      stdio: "pipe",
+    });
+  } finally {
+    try {
+      rmSync(keyFile);
+    } catch {
+      /* best-effort key file removal */
+    }
+  }
+  return gnupgHome;
+}
+
+function cleanupGnupgHome(gnupgHome: string | null): void {
+  if (!gnupgHome) return;
+  try {
+    rmSync(gnupgHome, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
   }
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -169,6 +169,7 @@ export interface Agent {
   skills: string[] | null;
   public_key: string;
   fingerprint: string;
+  gpg_subkey_id: string | null;
   builtin: number;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary

- Add `gpg_subkey_id` column to agents table (migration 0013) and store agent's GPG subkey ID on creation via `syncAgentToGithub`
- Add `GET /api/agents/:id/gpg-key` endpoint (machine-only) that returns the owner's armored private key and the agent's specific subkey ID
- Set up isolated `GNUPGHOME` per agent process (temp dir, import key, delete key file) before spawning
- Inject `GIT_AUTHOR_NAME/EMAIL` and `GIT_COMMITTER_NAME/EMAIL` for all agent spawns (Plan B: both use agent identity)
- Inject `GIT_CONFIG_*` vars enabling GPG commit signing with the agent's specific subkey
- Re-fetch GPG key from API on session resume (never persisted to disk) — addresses security concern
- Add `agentName`, `agentUsername`, `gpgSubkeyId` to `SavedSession` for resume flow
- Separate GPG subkey DB write from optional GitHub sync in `syncAgentToGithub`
- Fix `readAll` in `savedSessions.ts` to distinguish ENOENT from other file errors
- Identity guard on GPG key endpoint (agent JWTs are rejected)

## Test plan

- [ ] Build passes (`pnpm build`)
- [ ] Type check passes (`tsc --noEmit`)
- [ ] Existing tests pass (`npx vitest run`)
- [ ] Create a new agent and verify `gpg_subkey_id` is set in DB
- [ ] Daemon spawns agent with `GNUPGHOME`, `GIT_AUTHOR_*`, `GIT_COMMITTER_*`, `GIT_CONFIG_*` env vars
- [ ] Agent commits are GPG-signed and show correct author/committer identity
- [ ] Session resume re-fetches GPG key from API and re-creates `GNUPGHOME`
- [ ] Verify agent JWT cannot call `GET /api/agents/:id/gpg-key`