### PR TITLE
feat: update /api/ping to return status and timestamp

### DIFF
--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -77,7 +77,7 @@ api.on(["GET", "POST"], "/api/auth/**", async (c) => {
   }
 });
 
-api.get("/api/ping", (c) => c.json({ pong: true }));
+api.get("/api/ping", (c) => c.json({ status: "ok", timestamp: new Date().toISOString() }));
 
 // ─── Public Share Routes (no auth required) ───
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
+    pool: "forks",
+    fileParallelism: false,
     include: ["**/*.test.{ts,tsx}"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

- Updates `GET /api/ping` to return `{ status: 'ok', timestamp: '<ISO timestamp>' }` instead of `{ pong: true }`
- Fixes pre-existing parallel test execution failures by switching vitest to `pool: 'forks'` and `fileParallelism: false`, resolving Miniflare D1 resource contention

## Test plan

- [x] All 628 tests pass (`27 passed`)
- [x] TypeScript typecheck passes
- [x] Biome lint passes
- [x] Pre-commit hook passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)