### PR TITLE
feat: update /api/ping to return status and timestamp

### DIFF
--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -77,7 +77,7 @@ api.on(["GET", "POST"], "/api/auth/**", async (c) => {
   }
 });
 
-api.get("/api/ping", (c) => c.json({ pong: true }));
+api.get("/api/ping", (c) => c.json({ status: "ok", timestamp: new Date().toISOString() }));
 
 // ─── Public Share Routes (no auth required) ───
 


### PR DESCRIPTION
## Summary
- Updated `GET /api/ping` to return `{ status: 'ok', timestamp: '<current ISO timestamp>' }` instead of `{ pong: true }`

## Test plan
- [ ] Hit `GET /api/ping` and verify the response shape is `{ status: 'ok', timestamp: '...' }` with a valid ISO 8601 timestamp