### PR TITLE
fix(api): return status and timestamp from /api/ping

### DIFF
--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -77,7 +77,7 @@ api.on(["GET", "POST"], "/api/auth/**", async (c) => {
   }
 });
 
-api.get("/api/ping", (c) => c.json({ pong: true }));
+api.get("/api/ping", (c) => c.json({ status: "ok", timestamp: new Date().toISOString() }));
 
 // ─── Public Share Routes (no auth required) ───
 


### PR DESCRIPTION
## Summary
- Update `GET /api/ping` to return `{ status: 'ok', timestamp: '<ISO>' }` instead of `{ pong: true }`
- Standard health check response shape for monitoring and uptime checks

## Test plan
- [ ] `GET /api/ping` returns `{ status: "ok", timestamp: "..." }` with valid ISO-8601 timestamp
- [ ] Existing tests pass (verified via pre-commit hooks)