### PR TITLE
fix(api): return status and timestamp from /ping

### DIFF
--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -77,7 +77,7 @@ api.on(["GET", "POST"], "/api/auth/**", async (c) => {
   }
 });
 
-api.get("/api/ping", (c) => c.json({ pong: true }));
+api.get("/api/ping", (c) => c.json({ status: "ok", timestamp: new Date().toISOString() }));
 
 // ─── Public Share Routes (no auth required) ───
 


### PR DESCRIPTION
## Summary
- Updated `GET /api/ping` to return `{ status: "ok", timestamp: "<ISO>" }` instead of `{ pong: true }`

## Test plan
- [x] Build passes
- [x] All 628 existing tests pass
- [x] Pre-commit hooks (biome, typecheck, test) pass