### PR TITLE
tests: add username/email coverage for Agent entity

### DIFF
--- a/tests/agent-json-fields.test.ts
+++ b/tests/agent-json-fields.test.ts
@@ -90,6 +90,15 @@ describe("agent JSON field parsing (skills, handoff_to)", () => {
     expect(agent.handoff_to).toEqual(["quality-goalkeeper", "enduser"]);
   });
 
+  it("listAgents returns email derived from username", async () => {
+    const { listAgents } = await import("../apps/web/functions/api/agentRepo");
+    const agents = await listAgents(db, ownerId);
+    const agent = agents.find((a) => a.id === agentId)!;
+
+    expect(agent.username).toBe("test-agent");
+    expect(agent.email).toBe("test-agent@mails.agent-kanban.dev");
+  });
+
   it("getAgent returns parsed arrays", async () => {
     const { getAgent } = await import("../apps/web/functions/api/agentRepo");
     const agent = await getAgent(db, agentId, ownerId);
@@ -98,6 +107,15 @@ describe("agent JSON field parsing (skills, handoff_to)", () => {
     expect(Array.isArray(agent!.skills)).toBe(true);
     expect(agent!.skills).toEqual(["trailofbits/skills@differential-review", "obra/superpowers@verification-before-completion"]);
     expect(Array.isArray(agent!.handoff_to)).toBe(true);
+  });
+
+  it("getAgent returns email derived from username", async () => {
+    const { getAgent } = await import("../apps/web/functions/api/agentRepo");
+    const agent = await getAgent(db, agentId, ownerId);
+
+    expect(agent).toBeTruthy();
+    expect(agent!.username).toBe("test-agent");
+    expect(agent!.email).toBe("test-agent@mails.agent-kanban.dev");
   });
 
   it("updateAgent accepts arrays and returns parsed arrays", async () => {

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -322,6 +322,46 @@ describe("routes", () => {
     expect(res.status).toBe(400);
   });
 
+  it("POST /api/agents rejects invalid username format", async () => {
+    const res = await apiRequest("POST", "/api/agents", { username: "My Invalid Agent!", runtime: "claude" }, apiKey);
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/agents rejects duplicate username", async () => {
+    // First create succeeds
+    const r1 = await apiRequest("POST", "/api/agents", { username: "dupe-agent", runtime: "claude" }, apiKey);
+    expect(r1.status).toBe(201);
+    // Same username second time → conflict
+    const r2 = await apiRequest("POST", "/api/agents", { username: "dupe-agent", runtime: "claude" }, apiKey);
+    expect(r2.status).toBe(409);
+  });
+
+  it("POST /api/agents returns username in response", async () => {
+    const res = await apiRequest("POST", "/api/agents", { username: "username-check-agent", runtime: "claude" }, apiKey);
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as any;
+    expect(body.username).toBe("username-check-agent");
+  });
+
+  it("GET /api/agents returns email derived from username", async () => {
+    const res = await apiRequest("GET", "/api/agents", undefined, apiKey);
+    expect(res.status).toBe(200);
+    const agents = (await res.json()) as any[];
+    for (const agent of agents) {
+      if (agent.username) {
+        expect(agent.email).toBe(`${agent.username}@mails.agent-kanban.dev`);
+      }
+    }
+  });
+
+  it("GET /api/agents/:id returns email derived from username", async () => {
+    const res = await apiRequest("GET", `/api/agents/${agentId}`, undefined, apiKey);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.username).toBeTruthy();
+    expect(body.email).toBe(`${body.username}@mails.agent-kanban.dev`);
+  });
+
   it("POST /api/agents rejects reserved role", async () => {
     const res = await apiRequest(
       "POST",

--- a/tests/shared.test.ts
+++ b/tests/shared.test.ts
@@ -1,5 +1,68 @@
-import { AGENT_STATUSES, PRIORITIES, STALE_TIMEOUT_MS, TASK_ACTIONS } from "@agent-kanban/shared";
+import { AGENT_STATUSES, deriveUsername, isValidUsername, PRIORITIES, STALE_TIMEOUT_MS, TASK_ACTIONS } from "@agent-kanban/shared";
 import { describe, expect, it } from "vitest";
+
+describe("isValidUsername", () => {
+  it("accepts lowercase alphanumeric", () => {
+    expect(isValidUsername("alice")).toBe(true);
+  });
+
+  it("accepts single character", () => {
+    expect(isValidUsername("a")).toBe(true);
+  });
+
+  it("accepts hyphens in the middle", () => {
+    expect(isValidUsername("my-agent")).toBe(true);
+    expect(isValidUsername("my-cool-agent")).toBe(true);
+  });
+
+  it("rejects leading hyphen", () => {
+    expect(isValidUsername("-agent")).toBe(false);
+  });
+
+  it("rejects trailing hyphen", () => {
+    expect(isValidUsername("agent-")).toBe(false);
+  });
+
+  it("rejects spaces", () => {
+    expect(isValidUsername("my agent")).toBe(false);
+  });
+
+  it("rejects uppercase letters", () => {
+    expect(isValidUsername("MyAgent")).toBe(false);
+  });
+
+  it("rejects special characters", () => {
+    expect(isValidUsername("agent@email")).toBe(false);
+    expect(isValidUsername("agent.bot")).toBe(false);
+  });
+
+  it("rejects empty string", () => {
+    expect(isValidUsername("")).toBe(false);
+  });
+});
+
+describe("deriveUsername", () => {
+  it("lowercases and replaces spaces with hyphens", () => {
+    expect(deriveUsername("My Agent")).toBe("my-agent");
+  });
+
+  it("strips non-alphanumeric characters", () => {
+    expect(deriveUsername("Agent #1!")).toBe("agent-1");
+  });
+
+  it("strips leading and trailing hyphens", () => {
+    expect(deriveUsername(" Agent ")).toBe("agent");
+  });
+
+  it("falls back to 'agent' for empty result", () => {
+    expect(deriveUsername("!!!")).toBe("agent");
+  });
+
+  it("truncates to 40 characters", () => {
+    const long = "a".repeat(50);
+    expect(deriveUsername(long).length).toBeLessThanOrEqual(40);
+  });
+});
 
 describe("shared constants", () => {
   it("TASK_ACTIONS includes all v2 actions", () => {


### PR DESCRIPTION
## Summary

The `username` field on Agent was already fully implemented on `main` (migration `0013_agent_identity.sql`, shared types, agentRepo, CLI flag). This PR fills the remaining gap: **test coverage**.

- **`tests/shared.test.ts`** — unit tests for `isValidUsername` (valid/invalid patterns) and `deriveUsername` (space→hyphen, special-char stripping, fallback, truncation)
- **`tests/routes.test.ts`** — route-level tests:
  - Invalid username format → 400
  - Duplicate username → 409 conflict
  - `POST /api/agents` returns `username` in response body
  - `GET /api/agents` returns `email` = `${username}@mails.agent-kanban.dev`
  - `GET /api/agents/:id` returns matching `email`
- **`tests/agent-json-fields.test.ts`** — repo-level tests:
  - `listAgents` returns correct `email` for each agent
  - `getAgent` returns correct `email`

## Test plan

- [x] `pnpm test` — 665 tests pass (up from 644)
- [x] `pnpm build` — clean
- [x] `pnpm tsc --noEmit` — no type errors