### PR TITLE
fix(agents): include kind in updateAgent updatable fields

### DIFF
--- a/apps/web/functions/api/agentRepo.ts
+++ b/apps/web/functions/api/agentRepo.ts
@@ -164,7 +164,7 @@ export async function getAgent(db: D1, agentId: string, ownerId: string): Promis
 export async function updateAgent(
   db: D1,
   agentId: string,
-  updates: Partial<Pick<Agent, "name" | "bio" | "soul" | "role" | "handoff_to" | "runtime" | "model" | "skills">>,
+  updates: Partial<Pick<Agent, "name" | "bio" | "soul" | "role" | "kind" | "handoff_to" | "runtime" | "model" | "skills">>,
 ): Promise<Agent | null> {
   const agent = await db.prepare("SELECT * FROM agents WHERE id = ?").bind(agentId).first<Agent>();
   if (!agent) return null;
@@ -174,7 +174,7 @@ export async function updateAgent(
   const binds: unknown[] = [now];
 
   const jsonFields = new Set(["skills", "handoff_to"]);
-  const fields = ["name", "bio", "soul", "role", "handoff_to", "runtime", "model", "skills"] as const;
+  const fields = ["name", "bio", "soul", "role", "kind", "handoff_to", "runtime", "model", "skills"] as const;
   for (const field of fields) {
     if (field in updates && (updates as any)[field] !== undefined) {
       sets.push(`${field} = ?`);

--- a/tests/agent-kind-handoff-skills.test.ts
+++ b/tests/agent-kind-handoff-skills.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment node
+// Verify --kind, --handoff-to, --skills flags for create and update agent (v1.8.1)
+
+import type { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createTestAgent, setupMiniflare } from "./helpers/db";
+
+let db: D1Database;
+let mf: Miniflare;
+
+beforeAll(async () => {
+  ({ mf, db } = await setupMiniflare());
+});
+
+afterAll(async () => {
+  await mf.dispose();
+});
+
+describe("create agent: --kind flag", () => {
+  it("creates an agent with kind=leader", async () => {
+    const agent = await createTestAgent(db, "owner-kind", {
+      username: "test-leader",
+      name: "Test Leader",
+      runtime: "claude",
+      role: "lead",
+      kind: "leader",
+    });
+
+    expect(agent.kind).toBe("leader");
+  });
+
+  it("creates an agent with kind=worker (default)", async () => {
+    const agent = await createTestAgent(db, "owner-kind", {
+      username: "test-worker",
+      name: "Test Worker",
+      runtime: "claude",
+    });
+
+    expect(agent.kind).toBe("worker");
+  });
+
+  it("kind=leader persists through getAgent", async () => {
+    const { getAgent } = await import("../apps/web/functions/api/agentRepo");
+    const created = await createTestAgent(db, "owner-kind2", {
+      username: "test-leader-persist",
+      name: "Test Leader Persist",
+      runtime: "claude",
+      kind: "leader",
+    });
+
+    const fetched = await getAgent(db, created.id, "owner-kind2");
+    expect(fetched).toBeTruthy();
+    expect(fetched!.kind).toBe("leader");
+  });
+
+  it("kind=leader appears in listAgents", async () => {
+    const { listAgents } = await import("../apps/web/functions/api/agentRepo");
+    const created = await createTestAgent(db, "owner-kind3", {
+      username: "test-leader-list",
+      name: "Test Leader List",
+      runtime: "claude",
+      kind: "leader",
+    });
+
+    const agents = await listAgents(db, "owner-kind3");
+    const found = agents.find((a) => a.id === created.id);
+    expect(found).toBeTruthy();
+    expect(found!.kind).toBe("leader");
+  });
+});
+
+describe("create agent: --handoff-to flag", () => {
+  it("creates an agent with handoff_to populated", async () => {
+    const agent = await createTestAgent(db, "owner-handoff", {
+      username: "test-handoff",
+      name: "Test Handoff",
+      runtime: "claude",
+      role: "dev",
+      handoff_to: ["leader-agent-id"],
+    });
+
+    expect(Array.isArray(agent.handoff_to)).toBe(true);
+    expect(agent.handoff_to).toEqual(["leader-agent-id"]);
+  });
+
+  it("handoff_to with multiple ids is stored as array", async () => {
+    const agent = await createTestAgent(db, "owner-handoff", {
+      username: "test-handoff-multi",
+      name: "Test Handoff Multi",
+      runtime: "claude",
+      handoff_to: ["agent-1", "agent-2"],
+    });
+
+    expect(agent.handoff_to).toHaveLength(2);
+    expect(agent.handoff_to).toEqual(["agent-1", "agent-2"]);
+  });
+});
+
+describe("create agent: --skills flag", () => {
+  it("creates an agent with skills array populated", async () => {
+    const agent = await createTestAgent(db, "owner-skills", {
+      username: "test-skills",
+      name: "Test Skills",
+      runtime: "claude",
+      role: "dev",
+      skills: ["agent-kanban"],
+    });
+
+    expect(Array.isArray(agent.skills)).toBe(true);
+    expect(agent.skills).toEqual(["agent-kanban"]);
+  });
+
+  it("multiple skills are stored as array", async () => {
+    const agent = await createTestAgent(db, "owner-skills", {
+      username: "test-skills-multi",
+      name: "Test Skills Multi",
+      runtime: "claude",
+      skills: ["agent-kanban", "trailofbits/skills@differential-review"],
+    });
+
+    expect(agent.skills).toHaveLength(2);
+    expect(agent.skills).toContain("agent-kanban");
+    expect(agent.skills).toContain("trailofbits/skills@differential-review");
+  });
+});
+
+describe("update agent: --kind, --handoff-to, --skills flags", () => {
+  let agentId: string;
+
+  beforeAll(async () => {
+    const agent = await createTestAgent(db, "owner-update", {
+      username: "test-update-target",
+      name: "Test Update Target",
+      runtime: "claude",
+    });
+    agentId = agent.id;
+  });
+
+  it("updates kind from worker to leader", async () => {
+    const { updateAgent } = await import("../apps/web/functions/api/agentRepo");
+    const updated = await updateAgent(db, agentId, { kind: "leader" });
+
+    expect(updated).toBeTruthy();
+    expect(updated!.kind).toBe("leader");
+  });
+
+  it("kind update persists through getAgent", async () => {
+    const { getAgent } = await import("../apps/web/functions/api/agentRepo");
+    const fetched = await getAgent(db, agentId, "owner-update");
+
+    expect(fetched!.kind).toBe("leader");
+  });
+
+  it("updates handoff_to via updateAgent", async () => {
+    const { updateAgent } = await import("../apps/web/functions/api/agentRepo");
+    const updated = await updateAgent(db, agentId, { handoff_to: ["some-leader-id"] });
+
+    expect(updated).toBeTruthy();
+    expect(updated!.handoff_to).toEqual(["some-leader-id"]);
+  });
+
+  it("updates skills via updateAgent", async () => {
+    const { updateAgent } = await import("../apps/web/functions/api/agentRepo");
+    const updated = await updateAgent(db, agentId, { skills: ["agent-kanban"] });
+
+    expect(updated).toBeTruthy();
+    expect(updated!.skills).toEqual(["agent-kanban"]);
+  });
+
+  it("updates kind back to worker", async () => {
+    const { updateAgent } = await import("../apps/web/functions/api/agentRepo");
+    const updated = await updateAgent(db, agentId, { kind: "worker" });
+
+    expect(updated!.kind).toBe("worker");
+  });
+
+  it("all three fields persist together", async () => {
+    const { updateAgent, getAgent } = await import("../apps/web/functions/api/agentRepo");
+    await updateAgent(db, agentId, {
+      kind: "leader",
+      handoff_to: ["final-leader"],
+      skills: ["agent-kanban", "browse"],
+    });
+
+    const fetched = await getAgent(db, agentId, "owner-update");
+    expect(fetched!.kind).toBe("leader");
+    expect(fetched!.handoff_to).toEqual(["final-leader"]);
+    expect(fetched!.skills).toEqual(["agent-kanban", "browse"]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug found**: `updateAgent()` in `agentRepo.ts` was missing `kind` from its updatable fields list and `Pick` type — `ak update agent --kind` silently had no effect
- **Fix**: Add `kind` to both the TypeScript type and the runtime fields array in `updateAgent()`
- **Tests added**: `tests/agent-kind-handoff-skills.test.ts` with 14 tests covering all three flags for create and update

## Verification Results

### `--kind` flag (create)
- ✅ `kind=leader` is stored and returned correctly
- ✅ `kind=worker` is the default when omitted
- ✅ Persists through `getAgent` and `listAgents`

### `--handoff-to` flag (create)
- ✅ Single ID stored as array
- ✅ Multiple comma-separated IDs stored correctly

### `--skills` flag (create)
- ✅ Single skill stored as array
- ✅ Multiple skills stored correctly

### `ak update agent` flags
- ✅ `--kind`: now works (was broken — fix applied)
- ✅ `--handoff-to`: works
- ✅ `--skills`: works
- ✅ All three together persist correctly

### Auth note
`POST /api/agents` requires `user`, `machine`, or `agent:leader` identity — worker agents correctly receive 403, which is by design.

## Test plan
- [x] 14 new unit tests pass (`tests/agent-kind-handoff-skills.test.ts`)
- [x] Full test suite: 658 tests pass across 29 files
- [x] Build + type check: clean