### PR TITLE
fix(share): include scheduled_at and repository_name in public task fields

### DIFF
--- a/apps/web/functions/api/routes.ts
+++ b/apps/web/functions/api/routes.ts
@@ -102,8 +102,10 @@ api.get("/api/share/:slug", async (c) => {
     status: t.status,
     priority: t.priority,
     labels: t.labels,
+    repository_name: t.repository_name,
     agent_name: t.agent_name,
     agent_public_key: t.agent_public_key,
+    scheduled_at: t.scheduled_at,
     created_at: t.created_at,
     updated_at: t.updated_at,
   }));


### PR DESCRIPTION
## Summary

- **Bug found**: `/api/share/:slug` explicitly mapped task fields to build the public response but omitted `scheduled_at` and `repository_name`
- **Effect**: The scheduled time indicator (`🕐 MM-DD HH:mm`) never appeared on task cards on public share pages; the repository name badge was also missing
- **Fix**: Added `scheduled_at` and `repository_name` to the `publicTasks` field mapping — both fields are already returned by `getBoardBySlug` (via `SELECT t.* LEFT JOIN repositories`), so no query changes were needed

## Findings from Verification

### ✅ Working correctly (authenticated board)
- Task card shows `🕐 MM-DD HH:mm` when `scheduled_at` is in the future
- Task card hides the indicator when `scheduled_at` is in the past (correct behavior — no longer pending)
- Task detail panel shows "Scheduled" field: future → formatted date, past → relative time (e.g. "5m")

### 🐛 Bug (share page, now fixed)
- `scheduled_at` was not included in the public task API response → indicator never appeared
- `repository_name` was also missing → repo badge never appeared

## Test Plan
- [x] Verified share API response now includes `scheduled_at` via code review
- [x] 72 route tests pass (`tests/routes.test.ts`)
- [x] 24 scheduled_at tests pass (`tests/task-scheduled-at.test.ts`)
- [ ] Visual verification on staging: create a task with `--scheduled-at` 30 minutes in the future, open the public share page, confirm `🕐 03-28 22:18` appears on the task card