### PR TITLE
feat(cli): ak apply -f — declarative YAML/JSON create/update

### DIFF
--- a/packages/cli/src/apply/kinds.ts
+++ b/packages/cli/src/apply/kinds.ts
@@ -1,0 +1,71 @@
+import type { ApiClient } from "../client.js";
+import { output } from "../output.js";
+
+function isUrl(value: string): boolean {
+  return value.includes("://") || value.startsWith("git@");
+}
+
+async function resolveRepoField(client: ApiClient, spec: Record<string, unknown>): Promise<void> {
+  const repo = spec.repo as string | undefined;
+  if (!repo) return;
+  delete spec.repo;
+  if (isUrl(repo)) {
+    const repos = await client.listRepositories({ url: repo });
+    if (repos.length === 0) {
+      console.error(`Repository not found for URL: ${repo}`);
+      process.exit(1);
+    }
+    spec.repository_id = repos[0].id;
+  } else {
+    spec.repository_id = repo;
+  }
+}
+
+export async function applyResource(client: ApiClient, kind: string, spec: Record<string, unknown>, fmt: "json" | "text"): Promise<void> {
+  const id = spec.id as string | undefined;
+
+  switch (kind.toLowerCase()) {
+    case "task": {
+      await resolveRepoField(client, spec);
+      if (id) {
+        const { id: _, ...body } = spec;
+        const task = (await client.updateTask(id, body)) as any;
+        output(task, fmt, (t) => `Updated task ${t.id}: ${t.title}`);
+      } else {
+        const task = (await client.createTask(spec)) as any;
+        output(task, fmt, (t) => `Created task ${t.id}: ${t.title}`);
+      }
+      break;
+    }
+    case "board": {
+      if (id) {
+        const { id: _, ...body } = spec;
+        const board = (await client.updateBoard(id, body)) as any;
+        output(board, fmt, (b) => `Updated board ${b.id}: ${b.name}`);
+      } else {
+        const board = (await client.createBoard(spec as any)) as any;
+        output(board, fmt, (b) => `Created board ${b.id}: ${b.name}`);
+      }
+      break;
+    }
+    case "agent": {
+      if (id) {
+        const { id: _, ...body } = spec;
+        const agent = (await client.updateAgent(id, body)) as any;
+        output(agent, fmt, (a) => `Updated agent ${a.id}: ${a.name}`);
+      } else {
+        const agent = (await client.createAgent(spec as any)) as any;
+        output(agent, fmt, (a) => `Created agent ${a.id}: ${a.name} (${a.role || "no role"})`);
+      }
+      break;
+    }
+    case "repo": {
+      const repo = (await client.createRepository(spec as any)) as any;
+      output(repo, fmt, (r) => `Added repository ${r.id}: ${r.name}`);
+      break;
+    }
+    default:
+      console.error(`Unknown kind: ${kind}. Supported: Task, Board, Agent, Repo`);
+      process.exit(1);
+  }
+}

--- a/packages/cli/src/apply/parser.ts
+++ b/packages/cli/src/apply/parser.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { parseAllDocuments } from "yaml";
+
+export interface ResourceDoc {
+  kind: string;
+  spec: Record<string, unknown>;
+}
+
+const CAMEL_TO_SNAKE: Record<string, string> = {
+  boardId: "board_id",
+  assignTo: "assigned_to",
+  dependsOn: "depends_on",
+  createdFrom: "created_from",
+  scheduledAt: "scheduled_at",
+  repositoryId: "repository_id",
+  handoffTo: "handoff_to",
+  prUrl: "pr_url",
+};
+
+function convertSpec(raw: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    const mapped = CAMEL_TO_SNAKE[key] ?? key;
+    result[mapped] = value;
+  }
+  return result;
+}
+
+function readInput(file: string): string {
+  if (file === "-") return readFileSync("/dev/stdin", "utf-8");
+  return readFileSync(file, "utf-8");
+}
+
+export function parseResourceDocs(file: string): ResourceDoc[] {
+  const content = readInput(file);
+  const trimmed = content.trimStart();
+
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    const parsed = JSON.parse(content) as unknown;
+    const docs = Array.isArray(parsed) ? parsed : [parsed];
+    return docs.map((d: any) => ({
+      kind: d.kind as string,
+      spec: convertSpec(d.spec as Record<string, unknown>),
+    }));
+  }
+
+  const documents = parseAllDocuments(content);
+  return documents.map((doc) => {
+    const data = doc.toJS() as { kind: string; spec: Record<string, unknown> };
+    return {
+      kind: data.kind,
+      spec: convertSpec(data.spec),
+    };
+  });
+}

--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -1,0 +1,29 @@
+import type { Command } from "commander";
+import { applyResource } from "../apply/kinds.js";
+import { parseResourceDocs } from "../apply/parser.js";
+import { createClient } from "../client.js";
+import { getFormat } from "../output.js";
+
+export function registerApplyCommand(program: Command) {
+  program
+    .command("apply")
+    .description("Apply a YAML/JSON resource spec from file or stdin")
+    .requiredOption("-f <file>", "File to apply (use - for stdin)")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (opts) => {
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+      const docs = parseResourceDocs(opts.f);
+      for (const doc of docs) {
+        if (!doc.kind) {
+          console.error("Missing 'kind' field in document");
+          process.exit(1);
+        }
+        if (!doc.spec || typeof doc.spec !== "object") {
+          console.error(`Missing or invalid 'spec' field in document (kind: ${doc.kind})`);
+          process.exit(1);
+        }
+        await applyResource(client, doc.kind, doc.spec, fmt);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { Command } from "commander";
 import { createClient } from "./client.js";
+import { registerApplyCommand } from "./commands/apply.js";
 import { registerCreateCommand } from "./commands/create.js";
 import { registerDeleteCommand } from "./commands/delete.js";
 import { registerGetCommand } from "./commands/get.js";
@@ -26,6 +27,7 @@ const helpSections: [string, [string, string][]][] = [
       ["create <resource>", "Create a resource (board, task, agent, repo, note)"],
       ["update <resource> <id>", "Update a resource (board, task, agent)"],
       ["delete <resource> <id>", "Delete a resource (board, task, agent, repo)"],
+      ["apply -f <file>", "Apply a YAML/JSON resource spec (create or update)"],
     ],
   ],
   [
@@ -200,6 +202,7 @@ registerGetCommand(program);
 registerCreateCommand(program);
 registerUpdateCommand(program);
 registerDeleteCommand(program);
+registerApplyCommand(program);
 
 // ─── Identity ───
 


### PR DESCRIPTION
## Summary
- Adds `ak apply -f <file>` (and `ak apply -f -` for stdin) to create or update resources from YAML/JSON specs
- Supports multi-document YAML (`---` separator) for batch operations
- Converts camelCase spec fields to snake_case automatically before sending to the API
- Routes by `kind` (Task, Board, Agent, Repo): no `id` → POST create, `id` present → PATCH update
- Resolves `repo` shorthand: URL → lookup repository_id, plain string → use as repository_id directly

## New files
- `packages/cli/src/apply/parser.ts` — reads file/stdin, parses YAML/JSON, applies camelCase→snake_case mapping
- `packages/cli/src/apply/kinds.ts` — kind→API method dispatch
- `packages/cli/src/commands/apply.ts` — commander command registration
- `packages/cli/src/index.ts` — registers apply command + adds to help output

## Test plan
- [ ] `ak apply -f task.yaml` creates a task with camelCase field names correctly mapped
- [ ] `ak apply -f task.yaml` with `id` in spec updates the task via PATCH
- [ ] Multi-doc YAML (separated by `---`) creates multiple resources in sequence
- [ ] `echo '...' | ak apply -f -` works from stdin
- [ ] `repo: <url>` resolves to `repository_id` via URL lookup
- [ ] `repo: <id>` passes through as `repository_id` directly
- [ ] `ak apply -f unknown.yaml` with unknown kind exits with clear error message
- [ ] `-o json` / `--format json` outputs JSON result
- [ ] All 734 existing tests pass (verified in pre-commit hook)