### PR TITLE
refactor: split create into resource-specific subcommands

### DIFF
--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -3,7 +3,6 @@ import type { Command } from "commander";
 import { type ApiClient, createClient } from "../client.js";
 import { getFormat, output } from "../output.js";
 import { getAvailableProviders } from "../providers/registry.js";
-import { normalizeResource } from "./resources.js";
 
 function detectRuntime(): string {
   const available = getAvailableProviders();
@@ -28,194 +27,157 @@ async function resolveRepoId(client: ApiClient, repoRef: string): Promise<string
   return repos[0].id;
 }
 
-async function createBoard(opts: Record<string, string>) {
-  if (!opts.name) {
-    console.error("--name is required for board creation");
-    process.exit(1);
-  }
-  if (!opts.type) {
-    console.error("--type is required (dev or ops)");
-    process.exit(1);
-  }
-  if (!isBoardType(opts.type)) {
-    console.error(`Unknown type "${opts.type}" — must be dev or ops`);
-    process.exit(1);
-  }
-  const client = await createClient();
-  const type = opts.type;
-  const board = await client.createBoard({ name: opts.name, type, description: opts.description });
-  const fmt = getFormat(opts.format);
-  output(board, fmt, (b) => `Created board ${b.id}: ${b.name}`);
-}
-
-async function createTask(opts: Record<string, string>) {
-  if (!opts.board) {
-    console.error("--board is required for task creation");
-    process.exit(1);
-  }
-  if (!opts.title) {
-    console.error("--title is required for task creation");
-    process.exit(1);
-  }
-  const client = await createClient();
-
-  const body: Record<string, unknown> = { title: opts.title, board_id: opts.board };
-  if (opts.description) body.description = opts.description;
-  if (opts.repo) body.repository_id = await resolveRepoId(client, opts.repo);
-  if (opts.priority) body.priority = opts.priority;
-  if (opts.labels) body.labels = opts.labels.split(",").map((l: string) => l.trim());
-  if (opts.assignTo) body.assigned_to = opts.assignTo;
-  if (opts.parent) body.created_from = opts.parent;
-  if (opts.dependsOn) body.depends_on = opts.dependsOn.split(",").map((id: string) => id.trim());
-  if (opts.scheduledAt) {
-    const normalized = parseScheduledAt(opts.scheduledAt);
-    if (!normalized) {
-      console.error("--scheduled-at must be ISO 8601 with timezone (e.g. 2026-03-28T09:00:00Z)");
-      process.exit(1);
-    }
-    body.scheduled_at = normalized;
-  }
-  if (opts.input) {
-    try {
-      body.input = JSON.parse(opts.input);
-    } catch {
-      console.error("Invalid JSON for --input");
-      process.exit(1);
-    }
-  }
-
-  const task = await client.createTask(body);
-  const fmt = getFormat(opts.format);
-  output(task, fmt, (t) => `Created task ${t.id}: ${t.title}`);
-}
-
-async function createAgent(opts: Record<string, string>) {
-  const client = await createClient();
-
-  let body: Record<string, unknown>;
-
-  if (opts.template) {
-    const template = await fetchTemplate(opts.template);
-    const runtime = opts.runtime || template.runtime;
-    if (!runtime) {
-      console.error("Template has no runtime. Pass --runtime explicitly.");
-      process.exit(1);
-    }
-    const username = opts.username || template.username;
-    if (!username) {
-      console.error("--username is required (template has no default username)");
-      process.exit(1);
-    }
-    body = {
-      name: opts.name || template.name || username,
-      username,
-      bio: opts.bio || template.bio,
-      soul: opts.soul || template.soul,
-      role: opts.role || template.role,
-      kind: opts.kind,
-      handoff_to: opts.handoffTo ? opts.handoffTo.split(",").map((s: string) => s.trim()) : template.handoff_to,
-      runtime,
-      model: opts.model || template.model,
-      skills: opts.skills ? opts.skills.split(",").map((s: string) => s.trim()) : template.skills,
-    };
-  } else {
-    if (!opts.username) {
-      console.error("--username is required");
-      process.exit(1);
-    }
-    const runtime = opts.runtime || detectRuntime();
-    body = { name: opts.name || opts.username, username: opts.username, runtime };
-    if (opts.bio) body.bio = opts.bio;
-    if (opts.soul) body.soul = opts.soul;
-    if (opts.role) body.role = opts.role;
-    if (opts.kind) body.kind = opts.kind;
-    if (opts.handoffTo) body.handoff_to = opts.handoffTo.split(",").map((s: string) => s.trim());
-    if (opts.model) body.model = opts.model;
-    if (opts.skills) body.skills = opts.skills.split(",").map((s: string) => s.trim());
-  }
-
-  const agent = await client.createAgent(body as any);
-  const fmt = getFormat(opts.format);
-  output(agent, fmt, (a) => `Created agent ${a.id}: ${a.name} (${a.role || "no role"})`);
-}
-
-async function createRepo(opts: Record<string, string>) {
-  if (!opts.name) {
-    console.error("--name is required for repo creation");
-    process.exit(1);
-  }
-  if (!opts.url) {
-    console.error("--url is required for repo creation");
-    process.exit(1);
-  }
-  const client = await createClient();
-  const repo = await client.createRepository({ name: opts.name, url: opts.url });
-  const fmt = getFormat(opts.format);
-  output(repo, fmt, (r) => `Added repository ${r.id}: ${r.name}`);
-}
-
-async function createNote(taskId: string, message: string) {
-  if (!taskId) {
-    console.error("--task is required for note creation");
-    process.exit(1);
-  }
-  if (!message) {
-    console.error("<message> is required for note creation");
-    process.exit(1);
-  }
-  const client = await createClient();
-  await client.addNote(taskId, message);
-  console.log("Log entry added.");
-}
-
 export function registerCreateCommand(program: Command) {
-  program
-    .command("create <resource> [message]")
-    .description("Create a resource (board, task, agent, repo, note)")
-    .option("--name <name>", "Resource name (board, agent, repo)")
-    .option("--description <desc>", "Description (board, task)")
-    .option("--type <type>", "Board type: dev, ops (board)")
-    .option("--format <format>", "Output format (json, text)")
-    // task flags
-    .option("--board <id>", "Board ID (task)")
-    .option("--title <title>", "Task title")
-    .option("--repo <repo>", "Repository ID or URL (task)")
-    .option("--priority <priority>", "Priority: low, medium, high, urgent (task)")
-    .option("--labels <labels>", "Comma-separated labels (task)")
-    .option("--input <json>", "JSON input payload (task)")
-    .option("--assign-to <id>", "Agent ID to assign (task)")
-    .option("--parent <id>", "Parent task ID (task)")
-    .option("--depends-on <ids>", "Comma-separated dependency task IDs (task)")
-    .option("--scheduled-at <time>", "ISO 8601 time to schedule task (task)")
-    // agent flags
-    .option("--username <username>", "Agent username (agent)")
-    .option("--template <slug>", "Agent template slug (agent)")
-    .option("--bio <bio>", "Agent bio (agent)")
-    .option("--soul <soul>", "Agent soul — persistent behavior instructions (agent)")
-    .option("--role <role>", "Agent role (agent)")
-    .option("--runtime <runtime>", "Agent runtime (agent)")
-    .option("--model <model>", "Model to use (agent)")
-    .option("--kind <kind>", "Agent kind: worker, leader (agent)")
-    .option("--handoff-to <ids>", "Comma-separated agent IDs for handoff (agent)")
-    .option("--skills <skills>", "Comma-separated skill slugs (agent)")
-    // repo flags
-    .option("--url <url>", "Clone URL (repo)")
-    // note flags
-    .option("--task <id>", "Task ID (note)")
-    .action(async (resource: string, message: string | undefined, opts) => {
-      const name = normalizeResource(resource);
+  const createCmd = program.command("create").description("Create a resource");
 
-      switch (name) {
-        case "board":
-          return createBoard(opts);
-        case "task":
-          return createTask(opts);
-        case "agent":
-          return createAgent(opts);
-        case "repo":
-          return createRepo(opts);
-        case "note":
-          return createNote(opts.task, message || "");
+  createCmd
+    .command("board")
+    .description("Create a board")
+    .requiredOption("--name <name>", "Board name")
+    .requiredOption("--type <type>", "Board type: dev, ops")
+    .option("--description <desc>", "Board description")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (opts) => {
+      if (!isBoardType(opts.type)) {
+        console.error(`Unknown type "${opts.type}" — must be dev or ops`);
+        process.exit(1);
       }
+      const client = await createClient();
+      const board = await client.createBoard({ name: opts.name, type: opts.type, description: opts.description });
+      const fmt = getFormat(opts.format);
+      output(board, fmt, (b) => `Created board ${b.id}: ${b.name}`);
+    });
+
+  createCmd
+    .command("task")
+    .description("Create a task")
+    .requiredOption("--board <id>", "Board ID")
+    .requiredOption("--title <title>", "Task title")
+    .option("--description <desc>", "Task description")
+    .option("--repo <repo>", "Repository ID or URL")
+    .option("--priority <priority>", "Priority: low, medium, high, urgent")
+    .option("--labels <labels>", "Comma-separated labels")
+    .option("--input <json>", "JSON input payload")
+    .option("--assign-to <id>", "Agent ID to assign")
+    .option("--parent <id>", "Parent task ID")
+    .option("--depends-on <ids>", "Comma-separated dependency task IDs")
+    .option("--scheduled-at <time>", "ISO 8601 time to schedule task")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (opts) => {
+      const client = await createClient();
+      const body: Record<string, unknown> = { title: opts.title, board_id: opts.board };
+      if (opts.description) body.description = opts.description;
+      if (opts.repo) body.repository_id = await resolveRepoId(client, opts.repo);
+      if (opts.priority) body.priority = opts.priority;
+      if (opts.labels) body.labels = opts.labels.split(",").map((l: string) => l.trim());
+      if (opts.assignTo) body.assigned_to = opts.assignTo;
+      if (opts.parent) body.created_from = opts.parent;
+      if (opts.dependsOn) body.depends_on = opts.dependsOn.split(",").map((id: string) => id.trim());
+      if (opts.scheduledAt) {
+        const normalized = parseScheduledAt(opts.scheduledAt);
+        if (!normalized) {
+          console.error("--scheduled-at must be ISO 8601 with timezone (e.g. 2026-03-28T09:00:00Z)");
+          process.exit(1);
+        }
+        body.scheduled_at = normalized;
+      }
+      if (opts.input) {
+        try {
+          body.input = JSON.parse(opts.input);
+        } catch {
+          console.error("Invalid JSON for --input");
+          process.exit(1);
+        }
+      }
+      const task = await client.createTask(body);
+      const fmt = getFormat(opts.format);
+      output(task, fmt, (t) => `Created task ${t.id}: ${t.title}`);
+    });
+
+  createCmd
+    .command("agent")
+    .description("Create an agent")
+    .option("--name <name>", "Agent display name")
+    .option("--username <username>", "Agent username")
+    .option("--template <slug>", "Agent template slug")
+    .option("--bio <bio>", "Agent bio")
+    .option("--soul <soul>", "Agent soul — persistent behavior instructions")
+    .option("--role <role>", "Agent role")
+    .option("--runtime <runtime>", "Agent runtime")
+    .option("--model <model>", "Model to use")
+    .option("--kind <kind>", "Agent kind: worker, leader")
+    .option("--handoff-to <ids>", "Comma-separated agent IDs for handoff")
+    .option("--skills <skills>", "Comma-separated skill slugs")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (opts) => {
+      const client = await createClient();
+      let body: Record<string, unknown>;
+
+      if (opts.template) {
+        const template = await fetchTemplate(opts.template);
+        const runtime = opts.runtime || template.runtime;
+        if (!runtime) {
+          console.error("Template has no runtime. Pass --runtime explicitly.");
+          process.exit(1);
+        }
+        const username = opts.username || template.username;
+        if (!username) {
+          console.error("--username is required (template has no default username)");
+          process.exit(1);
+        }
+        body = {
+          name: opts.name || template.name || username,
+          username,
+          bio: opts.bio || template.bio,
+          soul: opts.soul || template.soul,
+          role: opts.role || template.role,
+          kind: opts.kind,
+          handoff_to: opts.handoffTo ? opts.handoffTo.split(",").map((s: string) => s.trim()) : template.handoff_to,
+          runtime,
+          model: opts.model || template.model,
+          skills: opts.skills ? opts.skills.split(",").map((s: string) => s.trim()) : template.skills,
+        };
+      } else {
+        if (!opts.username) {
+          console.error("--username is required");
+          process.exit(1);
+        }
+        const runtime = opts.runtime || detectRuntime();
+        body = { name: opts.name || opts.username, username: opts.username, runtime };
+        if (opts.bio) body.bio = opts.bio;
+        if (opts.soul) body.soul = opts.soul;
+        if (opts.role) body.role = opts.role;
+        if (opts.kind) body.kind = opts.kind;
+        if (opts.handoffTo) body.handoff_to = opts.handoffTo.split(",").map((s: string) => s.trim());
+        if (opts.model) body.model = opts.model;
+        if (opts.skills) body.skills = opts.skills.split(",").map((s: string) => s.trim());
+      }
+
+      const agent = await client.createAgent(body as any);
+      const fmt = getFormat(opts.format);
+      output(agent, fmt, (a) => `Created agent ${a.id}: ${a.name} (${a.role || "no role"})`);
+    });
+
+  createCmd
+    .command("repo")
+    .description("Create a repository")
+    .requiredOption("--name <name>", "Repository name")
+    .requiredOption("--url <url>", "Clone URL")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (opts) => {
+      const client = await createClient();
+      const repo = await client.createRepository({ name: opts.name, url: opts.url });
+      const fmt = getFormat(opts.format);
+      output(repo, fmt, (r) => `Added repository ${r.id}: ${r.name}`);
+    });
+
+  createCmd
+    .command("note <message>")
+    .description("Add a log note to a task")
+    .requiredOption("--task <id>", "Task ID")
+    .action(async (message, opts) => {
+      const client = await createClient();
+      await client.addNote(opts.task, message);
+      console.log("Log entry added.");
     });
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,11 @@ const helpSections: [string, [string, string][]][] = [
     [
       ["get <resource> [id]", "Get a resource or list resources"],
       ["create <resource>", "Create a resource (board, task, agent, repo, note)"],
+      ["  create board", "Create a board (--name, --type)"],
+      ["  create task", "Create a task (--board, --title, ...)"],
+      ["  create agent", "Create an agent (--username, --template, ...)"],
+      ["  create repo", "Create a repository (--name, --url)"],
+      ["  create note <msg>", "Add a log note to a task (--task)"],
       ["update <resource> <id>", "Update a resource (board, task, agent)"],
       ["delete <resource> <id>", "Delete a resource (board, task, agent, repo)"],
     ],


### PR DESCRIPTION
## Summary
- Replaces single `ak create <resource>` command (30 mixed flags) with nested subcommands: `board`, `task`, `agent`, `repo`, `note`
- Each subcommand shows only its own flags in `--help`, reducing cognitive load for agents and humans
- Uses Commander.js `.requiredOption()` for built-in validation (replaces manual checks for board `--name`/`--type`, task `--board`/`--title`, repo `--name`/`--url`, note `--task`)

## Breaking change
`ak create --title X task` (flags before resource name) no longer works. `ak create task --title X` continues to work.

## Test plan
- [x] `ak create --help` shows subcommand list
- [x] `ak create task --help` shows only task flags
- [x] `ak create board --help` shows only board flags  
- [x] `ak create agent --help` shows only agent flags
- [x] Pre-commit hooks pass (biome, typecheck, vitest)