### PR TITLE
refactor(cli): split update into resource-specific subcommands

### DIFF
--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,7 +1,6 @@
 import type { Command } from "commander";
 import { type ApiClient, createClient } from "../client.js";
 import { getFormat, output } from "../output.js";
-import { normalizeResource } from "./resources.js";
 
 async function resolveRepoId(client: ApiClient, repoRef: string): Promise<string> {
   if (!repoRef.includes("://") && !repoRef.startsWith("git@")) return repoRef;
@@ -30,21 +29,70 @@ async function resolveBoardId(client: ApiClient, nameOrId: string): Promise<stri
 }
 
 export function registerUpdateCommand(program: Command) {
-  program
-    .command("update <resource> <id>")
-    .description("Update a resource (board, task, agent)")
-    .option("--format <format>", "Output format (json, text)")
-    // Board options
+  const updateCmd = program.command("update").description("Update a resource");
+
+  updateCmd
+    .command("board <id>")
+    .description("Update a board")
     .option("--name <name>", "New name")
     .option("--description <desc>", "New description")
-    // Task options
-    .option("--title <title>", "New title (task)")
-    .option("--priority <priority>", "New priority (task: low, medium, high, urgent)")
-    .option("--labels <labels>", "Comma-separated labels (task)")
-    .option("--input <json>", "JSON input payload (task)")
-    .option("--depends-on <ids>", "Comma-separated task IDs (task)")
-    .option("--repo <repo>", "Repository ID or URL (task)")
-    // Agent options
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (id: string, opts) => {
+      const client = await createClient();
+      const boardId = await resolveBoardId(client, id);
+      const body: Record<string, unknown> = {};
+      if (opts.name) body.name = opts.name;
+      if (opts.description) body.description = opts.description;
+      if (Object.keys(body).length === 0) {
+        console.error("Nothing to update. Provide --name or --description.");
+        process.exit(1);
+      }
+      const board = await client.updateBoard(boardId, body);
+      const fmt = getFormat(opts.format);
+      output(board, fmt, (b) => `Updated board ${b.id}: ${b.name}`);
+    });
+
+  updateCmd
+    .command("task <id>")
+    .description("Update a task")
+    .option("--title <title>", "New title")
+    .option("--description <desc>", "New description")
+    .option("--priority <priority>", "New priority: low, medium, high, urgent")
+    .option("--labels <labels>", "Comma-separated labels")
+    .option("--input <json>", "JSON input payload")
+    .option("--depends-on <ids>", "Comma-separated task IDs")
+    .option("--repo <repo>", "Repository ID or URL")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (id: string, opts) => {
+      const client = await createClient();
+      const body: Record<string, unknown> = {};
+      if (opts.title) body.title = opts.title;
+      if (opts.description) body.description = opts.description;
+      if (opts.priority) body.priority = opts.priority;
+      if (opts.labels) body.labels = opts.labels.split(",").map((l: string) => l.trim());
+      if (opts.dependsOn) body.depends_on = opts.dependsOn.split(",").map((d: string) => d.trim());
+      if (opts.repo) body.repository_id = await resolveRepoId(client, opts.repo);
+      if (opts.input) {
+        try {
+          body.input = JSON.parse(opts.input);
+        } catch {
+          console.error("Invalid JSON for --input");
+          process.exit(1);
+        }
+      }
+      if (Object.keys(body).length === 0) {
+        console.error("Nothing to update. Provide at least one option.");
+        process.exit(1);
+      }
+      const task = await client.updateTask(id, body);
+      const fmt = getFormat(opts.format);
+      output(task, fmt, (t) => `Updated task ${t.id}: ${t.title}`);
+    });
+
+  updateCmd
+    .command("agent <id>")
+    .description("Update an agent")
+    .option("--name <name>", "Agent display name")
     .option("--bio <bio>", "Agent bio")
     .option("--soul <soul>", "Agent soul — persistent behavior instructions")
     .option("--role <role>", "Agent role")
@@ -53,71 +101,25 @@ export function registerUpdateCommand(program: Command) {
     .option("--kind <kind>", "Agent kind: worker, leader")
     .option("--handoff-to <ids>", "Comma-separated agent IDs for handoff")
     .option("--skills <skills>", "Comma-separated skill slugs")
-    .action(async (resource: string, id: string, opts) => {
-      const name = normalizeResource(resource);
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (id: string, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
-
-      switch (name) {
-        case "board": {
-          const boardId = await resolveBoardId(client, id);
-          const body: Record<string, unknown> = {};
-          if (opts.name) body.name = opts.name;
-          if (opts.description) body.description = opts.description;
-          if (Object.keys(body).length === 0) {
-            console.error("Nothing to update. Provide --name or --description.");
-            process.exit(1);
-          }
-          const board = await client.updateBoard(boardId, body);
-          output(board, fmt, (b) => `Updated board ${b.id}: ${b.name}`);
-          break;
-        }
-        case "task": {
-          const body: Record<string, unknown> = {};
-          if (opts.title) body.title = opts.title;
-          if (opts.description) body.description = opts.description;
-          if (opts.priority) body.priority = opts.priority;
-          if (opts.labels) body.labels = opts.labels.split(",").map((l: string) => l.trim());
-          if (opts.dependsOn) body.depends_on = opts.dependsOn.split(",").map((d: string) => d.trim());
-          if (opts.repo) body.repository_id = await resolveRepoId(client, opts.repo);
-          if (opts.input) {
-            try {
-              body.input = JSON.parse(opts.input);
-            } catch {
-              console.error("Invalid JSON for --input");
-              process.exit(1);
-            }
-          }
-          if (Object.keys(body).length === 0) {
-            console.error("Nothing to update. Provide at least one option.");
-            process.exit(1);
-          }
-          const task = await client.updateTask(id, body);
-          output(task, fmt, (t) => `Updated task ${t.id}: ${t.title}`);
-          break;
-        }
-        case "agent": {
-          const body: Record<string, unknown> = {};
-          if (opts.name) body.name = opts.name;
-          if (opts.bio) body.bio = opts.bio;
-          if (opts.soul) body.soul = opts.soul;
-          if (opts.role) body.role = opts.role;
-          if (opts.runtime) body.runtime = opts.runtime;
-          if (opts.model) body.model = opts.model;
-          if (opts.kind) body.kind = opts.kind;
-          if (opts.handoffTo) body.handoff_to = opts.handoffTo.split(",").map((s: string) => s.trim());
-          if (opts.skills) body.skills = opts.skills.split(",").map((s: string) => s.trim());
-          if (Object.keys(body).length === 0) {
-            console.error("Nothing to update. Provide at least one option (--name, --bio, --role, --runtime, --model, --kind, --skills).");
-            process.exit(1);
-          }
-          const agent = await client.updateAgent(id, body);
-          output(agent, fmt, (a) => `Updated agent ${a.id}: ${a.name}`);
-          break;
-        }
-        default:
-          console.error(`Update is not supported for resource: ${name}`);
-          process.exit(1);
+      const body: Record<string, unknown> = {};
+      if (opts.name) body.name = opts.name;
+      if (opts.bio) body.bio = opts.bio;
+      if (opts.soul) body.soul = opts.soul;
+      if (opts.role) body.role = opts.role;
+      if (opts.runtime) body.runtime = opts.runtime;
+      if (opts.model) body.model = opts.model;
+      if (opts.kind) body.kind = opts.kind;
+      if (opts.handoffTo) body.handoff_to = opts.handoffTo.split(",").map((s: string) => s.trim());
+      if (opts.skills) body.skills = opts.skills.split(",").map((s: string) => s.trim());
+      if (Object.keys(body).length === 0) {
+        console.error("Nothing to update. Provide at least one option (--name, --bio, --role, --runtime, --model, --kind, --skills).");
+        process.exit(1);
       }
+      const agent = await client.updateAgent(id, body);
+      const fmt = getFormat(opts.format);
+      output(agent, fmt, (a) => `Updated agent ${a.id}: ${a.name}`);
     });
 }


### PR DESCRIPTION
## Summary

- Replaces the flat `ak update <resource> <id>` command with Commander.js nested subcommands: `ak update board <id>`, `ak update task <id>`, `ak update agent <id>`
- Each subcommand exposes only its own resource-specific flags — no more shared flat option list
- Removes `normalizeResource` dependency from update.ts; retains `resolveRepoId` and `resolveBoardId` helpers
- Matches the exact pattern established by the `ak create` refactor

## Test plan

- [ ] `ak update board <id> --name "New Name"` updates board name
- [ ] `ak update task <id> --title "New Title" --priority high` updates task fields
- [ ] `ak update agent <id> --bio "..." --role "..."` updates agent fields
- [ ] Running `ak update --help` shows `board`, `task`, `agent` subcommands
- [ ] Running `ak update board --help` shows only `--name` and `--description`
- [ ] Running `ak update task --help` shows only task-relevant flags
- [ ] Running `ak update agent --help` shows only agent-relevant flags
- [ ] Missing required fields show an appropriate error message