### PR TITLE
refactor(cli): split get/delete into subcommands + add describe command

### DIFF
--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -1,42 +1,51 @@
 import type { Command } from "commander";
 import { createClient } from "../client.js";
 import { getFormat, output } from "../output.js";
-import { normalizeResource } from "./resources.js";
 
 export function registerDeleteCommand(program: Command) {
-  program
-    .command("delete <resource> <id>")
-    .description("Delete a resource (board, task, agent, repo)")
+  const deleteCmd = program.command("delete").description("Delete a resource (board, task, agent, repo)");
+
+  deleteCmd
+    .command("board <id>")
+    .description("Delete a board")
     .option("--format <format>", "Output format (json, text)")
-    .action(async (resource: string, id: string, opts) => {
-      const name = normalizeResource(resource);
+    .action(async (id: string, opts) => {
       const client = await createClient();
       const fmt = getFormat(opts.format);
+      const board = await client.deleteBoard(id);
+      output(board, fmt, () => `Deleted board ${id}`);
+    });
 
-      switch (name) {
-        case "board": {
-          const board = await client.deleteBoard(id);
-          output(board, fmt, () => `Deleted board ${id}`);
-          break;
-        }
-        case "task": {
-          const task = await client.deleteTask(id);
-          output(task, fmt, () => `Deleted task ${id}`);
-          break;
-        }
-        case "agent": {
-          const agent = await client.deleteAgent(id);
-          output(agent, fmt, () => `Deleted agent ${id}`);
-          break;
-        }
-        case "repo": {
-          const repo = await client.deleteRepository(id);
-          output(repo, fmt, () => `Deleted repository ${id}`);
-          break;
-        }
-        default:
-          console.error(`Delete is not supported for resource: ${name}`);
-          process.exit(1);
-      }
+  deleteCmd
+    .command("task <id>")
+    .description("Delete a task")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (id: string, opts) => {
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+      const task = await client.deleteTask(id);
+      output(task, fmt, () => `Deleted task ${id}`);
+    });
+
+  deleteCmd
+    .command("agent <id>")
+    .description("Delete an agent")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (id: string, opts) => {
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+      const agent = await client.deleteAgent(id);
+      output(agent, fmt, () => `Deleted agent ${id}`);
+    });
+
+  deleteCmd
+    .command("repo <id>")
+    .description("Delete a repository")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (id: string, opts) => {
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+      const repo = await client.deleteRepository(id);
+      output(repo, fmt, () => `Deleted repository ${id}`);
     });
 }

--- a/packages/cli/src/commands/describe.ts
+++ b/packages/cli/src/commands/describe.ts
@@ -1,0 +1,173 @@
+import type { Command } from "commander";
+import { createClient } from "../client.js";
+import { getFormat, output } from "../output.js";
+
+function pad(label: string): string {
+  return `${label}:`.padEnd(14);
+}
+
+function formatDescribeTask(task: any, notes: any[], messages: any[]): string {
+  const lines: string[] = [];
+
+  lines.push(`${pad("Name")} ${task.title}`);
+  lines.push(`${pad("ID")} ${task.id}`);
+  lines.push(`${pad("Status")} ${task.status}`);
+  lines.push(`${pad("Priority")} ${task.priority || "none"}`);
+  if (task.board_id) lines.push(`${pad("Board")} ${task.board_id}`);
+  if (task.repository_name) lines.push(`${pad("Repo")} ${task.repository_name}`);
+  if (task.assigned_to) lines.push(`${pad("Agent")} ${task.assigned_to}`);
+  if (task.labels?.length) lines.push(`${pad("Labels")} ${task.labels.join(", ")}`);
+  if (task.created_at) lines.push(`${pad("Created")} ${task.created_at}`);
+  if (task.depends_on?.length) {
+    lines.push(`${pad("Dependencies")} ${task.depends_on.join(", ")}`);
+  }
+  lines.push(`${pad("Blocked")} ${task.blocked ? "true" : "false"}`);
+  if (task.pr_url) lines.push(`${pad("PR")} ${task.pr_url}`);
+  if (task.description) {
+    lines.push("");
+    lines.push("Description:");
+    lines.push(`  ${task.description}`);
+  }
+
+  if (notes.length > 0) {
+    lines.push("");
+    lines.push("Logs:");
+    for (const n of notes) {
+      const time = n.created_at;
+      const detail = n.detail || n.action || "";
+      lines.push(`  ${time}  ${detail}`);
+    }
+  }
+
+  if (messages.length > 0) {
+    lines.push("");
+    lines.push("Messages:");
+    for (const m of messages) {
+      const time = m.created_at;
+      const sender = m.sender_type === "agent" ? `[agent:${m.sender_id?.slice(0, 8)}]` : "[human]";
+      lines.push(`  ${time}  ${sender}  ${m.content}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatDescribeAgent(agent: any, sessions: any[]): string {
+  const lines: string[] = [];
+
+  lines.push(`${pad("Name")} ${agent.name}`);
+  lines.push(`${pad("ID")} ${agent.id}`);
+  lines.push(`${pad("Status")} ${agent.status}`);
+  if (agent.role) lines.push(`${pad("Role")} ${agent.role}`);
+  if (agent.bio) lines.push(`${pad("Bio")} ${agent.bio}`);
+  lines.push(`${pad("Runtime")} ${agent.runtime}`);
+  if (agent.model) lines.push(`${pad("Model")} ${agent.model}`);
+  if (agent.fingerprint) lines.push(`${pad("Fingerprint")} ${agent.fingerprint}`);
+  if (agent.skills?.length) lines.push(`${pad("Skills")} ${agent.skills.join(", ")}`);
+  if (agent.handoff_to?.length) lines.push(`${pad("Handoff")} ${agent.handoff_to.join(", ")}`);
+  if (agent.task_count != null) lines.push(`${pad("Task count")} ${agent.task_count}`);
+  if (agent.last_active_at) lines.push(`${pad("Last active")} ${agent.last_active_at}`);
+
+  if (sessions.length > 0) {
+    lines.push("");
+    lines.push("Sessions:");
+    for (const s of sessions) {
+      const status = s.closed_at ? "closed" : "open";
+      lines.push(`  ${s.id}  [${status}]  started: ${s.started_at}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function formatDescribeBoard(board: any): string {
+  const columnOrder = ["todo", "in_progress", "in_review", "done", "cancelled"];
+  const columnLabels: Record<string, string> = {
+    todo: "Todo",
+    in_progress: "In Progress",
+    in_review: "In Review",
+    done: "Done",
+    cancelled: "Cancelled",
+  };
+
+  const tasks: any[] = board.tasks || [];
+  const grouped: Record<string, any[]> = {};
+  for (const col of columnOrder) grouped[col] = [];
+  for (const t of tasks) {
+    if (grouped[t.status]) grouped[t.status].push(t);
+  }
+
+  const counts = columnOrder.map((k) => `${columnLabels[k]}: ${grouped[k].length}`).join("  ");
+  const lines: string[] = [];
+
+  lines.push(`${pad("Name")} ${board.name}`);
+  lines.push(`${pad("ID")} ${board.id}`);
+  if (board.type) lines.push(`${pad("Type")} ${board.type}`);
+  if (board.description) lines.push(`${pad("Description")} ${board.description}`);
+  lines.push(`${pad("Tasks")} ${tasks.length} total  (${counts})`);
+
+  for (const key of columnOrder) {
+    const col = grouped[key];
+    if (col.length === 0) continue;
+    lines.push("");
+    lines.push(`${columnLabels[key]} (${col.length}):`);
+    for (const t of col) {
+      const agent = t.assigned_to ? ` → ${t.assigned_to.slice(0, 8)}` : "";
+      const blocked = t.blocked ? " BLOCKED" : "";
+      const pr = t.pr_url ? ` PR: ${t.pr_url}` : "";
+      const priority = t.priority ? ` [${t.priority}]` : "";
+      lines.push(`  ${t.id}  ${t.title}${priority}${blocked}${agent}${pr}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function registerDescribeCommand(program: Command) {
+  const describeCmd = program.command("describe").description("Show detailed view of a resource");
+
+  describeCmd
+    .command("task <id>")
+    .description("Show full detail for a task: logs, messages")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (id: string, opts) => {
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+      const [task, notes, messages] = await Promise.all([client.getTask(id), client.getTaskNotes(id), client.getMessages(id)]);
+      if (fmt === "json") {
+        output({ task, notes, messages }, fmt);
+      } else {
+        console.log(formatDescribeTask(task, notes as any[], messages as any[]));
+      }
+    });
+
+  describeCmd
+    .command("agent <id>")
+    .description("Show full detail for an agent: sessions, task history")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (id: string, opts) => {
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+      const [agent, sessions] = await Promise.all([client.getAgent(id), client.listSessions(id)]);
+      if (fmt === "json") {
+        output({ agent, sessions }, fmt);
+      } else {
+        console.log(formatDescribeAgent(agent, sessions));
+      }
+    });
+
+  describeCmd
+    .command("board <id>")
+    .description("Show full detail for a board: all tasks with status counts")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (id: string, opts) => {
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+      const board = await client.getBoard(id);
+      if (fmt === "json") {
+        output(board, fmt);
+      } else {
+        console.log(formatDescribeBoard(board));
+      }
+    });
+}

--- a/packages/cli/src/commands/get.ts
+++ b/packages/cli/src/commands/get.ts
@@ -13,76 +13,98 @@ import {
   getFormat,
   output,
 } from "../output.js";
-import { normalizeResource } from "./resources.js";
 
 export function registerGetCommand(program: Command) {
-  program
-    .command("get <resource> [id]")
-    .description("Get a resource or list resources")
+  const getCmd = program.command("get").description("Get a resource or list resources");
+
+  getCmd
+    .command("board [id]")
+    .description("Get a board or list boards")
     .option("--format <format>", "Output format (json, text)")
-    .option("--board <id>", "Filter tasks by board ID")
-    .option("--status <status>", "Filter tasks by status")
-    .option("--label <label>", "Filter tasks by label")
-    .option("--repo <id>", "Filter tasks by repository ID")
-    .option("--task <id>", "Task ID (required for notes)")
-    .option("--since <timestamp>", "Only show notes after this timestamp")
-    .action(async (resource: string, id: string | undefined, opts) => {
-      const name = normalizeResource(resource);
+    .action(async (id: string | undefined, opts) => {
       const client = await createClient();
       const fmt = getFormat(opts.format);
-
-      switch (name) {
-        case "board":
-          if (id) {
-            const board = await client.getBoard(id);
-            output(board, fmt, formatBoard);
-          } else {
-            const boards = await client.listBoards();
-            output(boards, fmt, formatBoardList);
-          }
-          break;
-        case "task":
-          if (id) {
-            const task = await client.getTask(id);
-            output(task, fmt, formatTask);
-          } else {
-            const params: Record<string, string> = {};
-            if (opts.board) params.board_id = opts.board;
-            if (opts.status) params.status = opts.status;
-            if (opts.label) params.label = opts.label;
-            if (opts.repo) params.repository_id = opts.repo;
-            const tasks = await client.listTasks(params);
-            output(tasks, fmt, formatTaskList);
-          }
-          break;
-        case "agent":
-          if (id) {
-            const agent = await client.getAgent(id);
-            output(agent, fmt, formatAgent);
-          } else {
-            const agents = await client.listAgents();
-            output(agents, fmt, formatAgentList);
-          }
-          break;
-        case "repo":
-          if (id) {
-            const repo = await client.getRepository(id);
-            output(repo, fmt, formatRepository);
-          } else {
-            const repos = await client.listRepositories();
-            output(repos, fmt, formatRepositoryList);
-          }
-          break;
-        case "note": {
-          const noteTaskId = id ?? opts.task;
-          if (!noteTaskId) {
-            console.error("Usage: ak get note --task <task-id> or ak get note <task-id>");
-            process.exit(1);
-          }
-          const notes = await client.getTaskNotes(noteTaskId, opts.since);
-          output(notes, fmt, formatTaskNotes);
-          break;
-        }
+      if (id) {
+        const board = await client.getBoard(id);
+        output(board, fmt, formatBoard);
+      } else {
+        const boards = await client.listBoards();
+        output(boards, fmt, formatBoardList);
       }
+    });
+
+  getCmd
+    .command("task [id]")
+    .description("Get a task or list tasks")
+    .option("--format <format>", "Output format (json, text)")
+    .option("--board <id>", "Filter by board ID")
+    .option("--status <status>", "Filter by status")
+    .option("--label <label>", "Filter by label")
+    .option("--repo <id>", "Filter by repository ID")
+    .action(async (id: string | undefined, opts) => {
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+      if (id) {
+        const task = await client.getTask(id);
+        output(task, fmt, formatTask);
+      } else {
+        const params: Record<string, string> = {};
+        if (opts.board) params.board_id = opts.board;
+        if (opts.status) params.status = opts.status;
+        if (opts.label) params.label = opts.label;
+        if (opts.repo) params.repository_id = opts.repo;
+        const tasks = await client.listTasks(params);
+        output(tasks, fmt, formatTaskList);
+      }
+    });
+
+  getCmd
+    .command("agent [id]")
+    .description("Get an agent or list agents")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (id: string | undefined, opts) => {
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+      if (id) {
+        const agent = await client.getAgent(id);
+        output(agent, fmt, formatAgent);
+      } else {
+        const agents = await client.listAgents();
+        output(agents, fmt, formatAgentList);
+      }
+    });
+
+  getCmd
+    .command("repo [id]")
+    .description("Get a repository or list repositories")
+    .option("--format <format>", "Output format (json, text)")
+    .action(async (id: string | undefined, opts) => {
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+      if (id) {
+        const repo = await client.getRepository(id);
+        output(repo, fmt, formatRepository);
+      } else {
+        const repos = await client.listRepositories();
+        output(repos, fmt, formatRepositoryList);
+      }
+    });
+
+  getCmd
+    .command("note [task-id]")
+    .description("Get notes for a task")
+    .option("--format <format>", "Output format (json, text)")
+    .option("--task <id>", "Task ID")
+    .option("--since <timestamp>", "Only show notes after this timestamp")
+    .action(async (taskId: string | undefined, opts) => {
+      const client = await createClient();
+      const fmt = getFormat(opts.format);
+      const id = taskId ?? opts.task;
+      if (!id) {
+        console.error("Usage: ak get note <task-id>  or  ak get note --task <task-id>");
+        process.exit(1);
+      }
+      const notes = await client.getTaskNotes(id, opts.since);
+      output(notes, fmt, formatTaskNotes);
     });
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { createClient } from "./client.js";
 import { registerApplyCommand } from "./commands/apply.js";
 import { registerCreateCommand } from "./commands/create.js";
 import { registerDeleteCommand } from "./commands/delete.js";
+import { registerDescribeCommand } from "./commands/describe.js";
 import { registerGetCommand } from "./commands/get.js";
 import { registerLogsCommand, registerStartCommand, registerStatusCommand, registerStopCommand } from "./commands/start.js";
 import { registerUpdateCommand } from "./commands/update.js";
@@ -24,6 +25,9 @@ const helpSections: [string, [string, string][]][] = [
     "Resources",
     [
       ["get <resource> [id]", "Get a resource or list resources"],
+      ["  get board|task|agent|repo|note", "Resource-specific subcommands with own filters"],
+      ["describe <resource> <id>", "Show detailed view of a resource"],
+      ["  describe task|agent|board", "Rich multi-section output with logs/sessions"],
       ["create <resource>", "Create a resource (board, task, agent, repo, note)"],
       ["  create board", "Create a board (--name, --type)"],
       ["  create task", "Create a task (--board, --title, ...)"],
@@ -204,6 +208,7 @@ taskCmd
 // ─── Top-level CRUD ───
 
 registerGetCommand(program);
+registerDescribeCommand(program);
 registerCreateCommand(program);
 registerUpdateCommand(program);
 registerDeleteCommand(program);


### PR DESCRIPTION
## Summary

- **`ak get`**: Refactored from a single command with a resource positional arg into resource-specific subcommands (`ak get board [id]`, `ak get task [id]`, `ak get agent [id]`, `ak get repo [id]`, `ak get note [task-id]`). Each subcommand now exposes only its own relevant filter flags.
- **`ak delete`**: Same pattern — refactored into `ak delete board|task|agent|repo <id>` subcommands.
- **`ak describe`** (new): Rich multi-section text view for `task`, `agent`, and `board`. For tasks: name, status, priority, labels, dependencies, logs, and messages. For agents: identity, sessions. For boards: task counts per status + full task listing grouped by column.

## Files changed

- `packages/cli/src/commands/get.ts` — subcommand refactor
- `packages/cli/src/commands/delete.ts` — subcommand refactor
- `packages/cli/src/commands/describe.ts` — new command
- `packages/cli/src/index.ts` — register describe + updated help text

## Test plan

- [ ] `ak get board` lists boards; `ak get board <id>` shows one board
- [ ] `ak get task --board <id> --status todo` filters correctly
- [ ] `ak get agent`, `ak get repo`, `ak get note --task <id>` all work
- [ ] `ak delete board|task|agent|repo <id>` each deletes correctly
- [ ] `ak describe task <id>` shows task detail with logs and messages
- [ ] `ak describe agent <id>` shows agent detail with sessions
- [ ] `ak describe board <id>` shows board with status-grouped tasks
- [ ] All existing tests pass (201 CLI tests + full suite green)