### PR TITLE
feat(cli): replace --format with -o flag, add yaml and wide output

### DIFF
--- a/packages/cli/src/apply/kinds.ts
+++ b/packages/cli/src/apply/kinds.ts
@@ -1,5 +1,5 @@
 import type { ApiClient } from "../client.js";
-import { output } from "../output.js";
+import { type OutputFormat, output } from "../output.js";
 
 function isUrl(value: string): boolean {
   return value.includes("://") || value.startsWith("git@");
@@ -21,7 +21,7 @@ async function resolveRepoField(client: ApiClient, spec: Record<string, unknown>
   }
 }
 
-export async function applyResource(client: ApiClient, kind: string, spec: Record<string, unknown>, fmt: "json" | "text"): Promise<void> {
+export async function applyResource(client: ApiClient, kind: string, spec: Record<string, unknown>, fmt: OutputFormat): Promise<void> {
   const id = spec.id as string | undefined;
 
   switch (kind.toLowerCase()) {
@@ -30,10 +30,10 @@ export async function applyResource(client: ApiClient, kind: string, spec: Recor
       if (id) {
         const { id: _, ...body } = spec;
         const task = (await client.updateTask(id, body)) as any;
-        output(task, fmt, (t) => `Updated task ${t.id}: ${t.title}`);
+        output(task, fmt, (t) => `Updated task ${t.id}: ${t.title}`, { kind: "task" });
       } else {
         const task = (await client.createTask(spec)) as any;
-        output(task, fmt, (t) => `Created task ${t.id}: ${t.title}`);
+        output(task, fmt, (t) => `Created task ${t.id}: ${t.title}`, { kind: "task" });
       }
       break;
     }
@@ -41,10 +41,10 @@ export async function applyResource(client: ApiClient, kind: string, spec: Recor
       if (id) {
         const { id: _, ...body } = spec;
         const board = (await client.updateBoard(id, body)) as any;
-        output(board, fmt, (b) => `Updated board ${b.id}: ${b.name}`);
+        output(board, fmt, (b) => `Updated board ${b.id}: ${b.name}`, { kind: "board" });
       } else {
         const board = (await client.createBoard(spec as any)) as any;
-        output(board, fmt, (b) => `Created board ${b.id}: ${b.name}`);
+        output(board, fmt, (b) => `Created board ${b.id}: ${b.name}`, { kind: "board" });
       }
       break;
     }
@@ -52,16 +52,16 @@ export async function applyResource(client: ApiClient, kind: string, spec: Recor
       if (id) {
         const { id: _, ...body } = spec;
         const agent = (await client.updateAgent(id, body)) as any;
-        output(agent, fmt, (a) => `Updated agent ${a.id}: ${a.name}`);
+        output(agent, fmt, (a) => `Updated agent ${a.id}: ${a.name}`, { kind: "agent" });
       } else {
         const agent = (await client.createAgent(spec as any)) as any;
-        output(agent, fmt, (a) => `Created agent ${a.id}: ${a.name} (${a.role || "no role"})`);
+        output(agent, fmt, (a) => `Created agent ${a.id}: ${a.name} (${a.role || "no role"})`, { kind: "agent" });
       }
       break;
     }
     case "repo": {
       const repo = (await client.createRepository(spec as any)) as any;
-      output(repo, fmt, (r) => `Added repository ${r.id}: ${r.name}`);
+      output(repo, fmt, (r) => `Added repository ${r.id}: ${r.name}`, { kind: "repo" });
       break;
     }
     default:

--- a/packages/cli/src/commands/apply.ts
+++ b/packages/cli/src/commands/apply.ts
@@ -2,17 +2,17 @@ import type { Command } from "commander";
 import { applyResource } from "../apply/kinds.js";
 import { parseResourceDocs } from "../apply/parser.js";
 import { createClient } from "../client.js";
-import { getFormat } from "../output.js";
+import { getOutputFormat } from "../output.js";
 
 export function registerApplyCommand(program: Command) {
   program
     .command("apply")
     .description("Apply a YAML/JSON resource spec from file or stdin")
     .requiredOption("-f <file>", "File to apply (use - for stdin)")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       const docs = parseResourceDocs(opts.f);
       for (const doc of docs) {
         if (!doc.kind) {

--- a/packages/cli/src/commands/create.ts
+++ b/packages/cli/src/commands/create.ts
@@ -1,7 +1,7 @@
 import { fetchTemplate, isBoardType, parseScheduledAt } from "@agent-kanban/shared";
 import type { Command } from "commander";
 import { type ApiClient, createClient } from "../client.js";
-import { getFormat, output } from "../output.js";
+import { getOutputFormat, output } from "../output.js";
 import { getAvailableProviders } from "../providers/registry.js";
 
 function detectRuntime(): string {
@@ -36,7 +36,7 @@ export function registerCreateCommand(program: Command) {
     .requiredOption("--name <name>", "Board name")
     .requiredOption("--type <type>", "Board type: dev, ops")
     .option("--description <desc>", "Board description")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (opts) => {
       if (!isBoardType(opts.type)) {
         console.error(`Unknown type "${opts.type}" — must be dev or ops`);
@@ -44,7 +44,7 @@ export function registerCreateCommand(program: Command) {
       }
       const client = await createClient();
       const board = await client.createBoard({ name: opts.name, type: opts.type, description: opts.description });
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       output(board, fmt, (b) => `Created board ${b.id}: ${b.name}`);
     });
 
@@ -62,7 +62,7 @@ export function registerCreateCommand(program: Command) {
     .option("--parent <id>", "Parent task ID")
     .option("--depends-on <ids>", "Comma-separated dependency task IDs")
     .option("--scheduled-at <time>", "ISO 8601 time to schedule task")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (opts) => {
       const client = await createClient();
       const body: Record<string, unknown> = { title: opts.title, board_id: opts.board };
@@ -90,7 +90,7 @@ export function registerCreateCommand(program: Command) {
         }
       }
       const task = await client.createTask(body);
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       output(task, fmt, (t) => `Created task ${t.id}: ${t.title}`);
     });
 
@@ -108,7 +108,7 @@ export function registerCreateCommand(program: Command) {
     .option("--kind <kind>", "Agent kind: worker, leader")
     .option("--handoff-to <ids>", "Comma-separated agent IDs for handoff")
     .option("--skills <skills>", "Comma-separated skill slugs")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (opts) => {
       const client = await createClient();
       let body: Record<string, unknown>;
@@ -154,7 +154,7 @@ export function registerCreateCommand(program: Command) {
       }
 
       const agent = await client.createAgent(body as any);
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       output(agent, fmt, (a) => `Created agent ${a.id}: ${a.name} (${a.role || "no role"})`);
     });
 
@@ -163,11 +163,11 @@ export function registerCreateCommand(program: Command) {
     .description("Create a repository")
     .requiredOption("--name <name>", "Repository name")
     .requiredOption("--url <url>", "Clone URL")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (opts) => {
       const client = await createClient();
       const repo = await client.createRepository({ name: opts.name, url: opts.url });
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       output(repo, fmt, (r) => `Added repository ${r.id}: ${r.name}`);
     });
 

--- a/packages/cli/src/commands/delete.ts
+++ b/packages/cli/src/commands/delete.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createClient } from "../client.js";
-import { getFormat, output } from "../output.js";
+import { getOutputFormat, output } from "../output.js";
 
 export function registerDeleteCommand(program: Command) {
   const deleteCmd = program.command("delete").description("Delete a resource (board, task, agent, repo)");
@@ -8,10 +8,10 @@ export function registerDeleteCommand(program: Command) {
   deleteCmd
     .command("board <id>")
     .description("Delete a board")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       const board = await client.deleteBoard(id);
       output(board, fmt, () => `Deleted board ${id}`);
     });
@@ -19,10 +19,10 @@ export function registerDeleteCommand(program: Command) {
   deleteCmd
     .command("task <id>")
     .description("Delete a task")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       const task = await client.deleteTask(id);
       output(task, fmt, () => `Deleted task ${id}`);
     });
@@ -30,10 +30,10 @@ export function registerDeleteCommand(program: Command) {
   deleteCmd
     .command("agent <id>")
     .description("Delete an agent")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       const agent = await client.deleteAgent(id);
       output(agent, fmt, () => `Deleted agent ${id}`);
     });
@@ -41,10 +41,10 @@ export function registerDeleteCommand(program: Command) {
   deleteCmd
     .command("repo <id>")
     .description("Delete a repository")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       const repo = await client.deleteRepository(id);
       output(repo, fmt, () => `Deleted repository ${id}`);
     });

--- a/packages/cli/src/commands/describe.ts
+++ b/packages/cli/src/commands/describe.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createClient } from "../client.js";
-import { getFormat, output } from "../output.js";
+import { getOutputFormat, output } from "../output.js";
 
 function pad(label: string): string {
   return `${label}:`.padEnd(14);
@@ -129,45 +129,33 @@ export function registerDescribeCommand(program: Command) {
   describeCmd
     .command("task <id>")
     .description("Show full detail for a task: logs, messages")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       const [task, notes, messages] = await Promise.all([client.getTask(id), client.getTaskNotes(id), client.getMessages(id)]);
-      if (fmt === "json") {
-        output({ task, notes, messages }, fmt);
-      } else {
-        console.log(formatDescribeTask(task, notes as any[], messages as any[]));
-      }
+      output({ task, notes, messages }, fmt, () => formatDescribeTask(task, notes as any[], messages as any[]), { kind: "task" });
     });
 
   describeCmd
     .command("agent <id>")
     .description("Show full detail for an agent: sessions, task history")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       const [agent, sessions] = await Promise.all([client.getAgent(id), client.listSessions(id)]);
-      if (fmt === "json") {
-        output({ agent, sessions }, fmt);
-      } else {
-        console.log(formatDescribeAgent(agent, sessions));
-      }
+      output({ agent, sessions }, fmt, () => formatDescribeAgent(agent, sessions), { kind: "agent" });
     });
 
   describeCmd
     .command("board <id>")
     .description("Show full detail for a board: all tasks with status counts")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       const board = await client.getBoard(id);
-      if (fmt === "json") {
-        output(board, fmt);
-      } else {
-        console.log(formatDescribeBoard(board));
-      }
+      output(board, fmt, formatDescribeBoard, { kind: "board" });
     });
 }

--- a/packages/cli/src/commands/get.ts
+++ b/packages/cli/src/commands/get.ts
@@ -9,8 +9,9 @@ import {
   formatRepositoryList,
   formatTask,
   formatTaskList,
+  formatTaskListWide,
   formatTaskNotes,
-  getFormat,
+  getOutputFormat,
   output,
 } from "../output.js";
 
@@ -20,33 +21,33 @@ export function registerGetCommand(program: Command) {
   getCmd
     .command("board [id]")
     .description("Get a board or list boards")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string | undefined, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       if (id) {
         const board = await client.getBoard(id);
-        output(board, fmt, formatBoard);
+        output(board, fmt, formatBoard, { kind: "board" });
       } else {
         const boards = await client.listBoards();
-        output(boards, fmt, formatBoardList);
+        output(boards, fmt, formatBoardList, { kind: "board" });
       }
     });
 
   getCmd
     .command("task [id]")
     .description("Get a task or list tasks")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, wide, text)")
     .option("--board <id>", "Filter by board ID")
     .option("--status <status>", "Filter by status")
     .option("--label <label>", "Filter by label")
     .option("--repo <id>", "Filter by repository ID")
     .action(async (id: string | undefined, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       if (id) {
         const task = await client.getTask(id);
-        output(task, fmt, formatTask);
+        output(task, fmt, formatTask, { kind: "task" });
       } else {
         const params: Record<string, string> = {};
         if (opts.board) params.board_id = opts.board;
@@ -54,51 +55,51 @@ export function registerGetCommand(program: Command) {
         if (opts.label) params.label = opts.label;
         if (opts.repo) params.repository_id = opts.repo;
         const tasks = await client.listTasks(params);
-        output(tasks, fmt, formatTaskList);
+        output(tasks, fmt, formatTaskList, { wideFormatter: formatTaskListWide, kind: "task" });
       }
     });
 
   getCmd
     .command("agent [id]")
     .description("Get an agent or list agents")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string | undefined, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       if (id) {
         const agent = await client.getAgent(id);
-        output(agent, fmt, formatAgent);
+        output(agent, fmt, formatAgent, { kind: "agent" });
       } else {
         const agents = await client.listAgents();
-        output(agents, fmt, formatAgentList);
+        output(agents, fmt, formatAgentList, { kind: "agent" });
       }
     });
 
   getCmd
     .command("repo [id]")
     .description("Get a repository or list repositories")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string | undefined, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       if (id) {
         const repo = await client.getRepository(id);
-        output(repo, fmt, formatRepository);
+        output(repo, fmt, formatRepository, { kind: "repo" });
       } else {
         const repos = await client.listRepositories();
-        output(repos, fmt, formatRepositoryList);
+        output(repos, fmt, formatRepositoryList, { kind: "repo" });
       }
     });
 
   getCmd
     .command("note [task-id]")
     .description("Get notes for a task")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, text)")
     .option("--task <id>", "Task ID")
     .option("--since <timestamp>", "Only show notes after this timestamp")
     .action(async (taskId: string | undefined, opts) => {
       const client = await createClient();
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       const id = taskId ?? opts.task;
       if (!id) {
         console.error("Usage: ak get note <task-id>  or  ak get note --task <task-id>");

--- a/packages/cli/src/commands/update.ts
+++ b/packages/cli/src/commands/update.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { type ApiClient, createClient } from "../client.js";
-import { getFormat, output } from "../output.js";
+import { getOutputFormat, output } from "../output.js";
 
 async function resolveRepoId(client: ApiClient, repoRef: string): Promise<string> {
   if (!repoRef.includes("://") && !repoRef.startsWith("git@")) return repoRef;
@@ -36,7 +36,7 @@ export function registerUpdateCommand(program: Command) {
     .description("Update a board")
     .option("--name <name>", "New name")
     .option("--description <desc>", "New description")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string, opts) => {
       const client = await createClient();
       const boardId = await resolveBoardId(client, id);
@@ -48,7 +48,7 @@ export function registerUpdateCommand(program: Command) {
         process.exit(1);
       }
       const board = await client.updateBoard(boardId, body);
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       output(board, fmt, (b) => `Updated board ${b.id}: ${b.name}`);
     });
 
@@ -62,7 +62,7 @@ export function registerUpdateCommand(program: Command) {
     .option("--input <json>", "JSON input payload")
     .option("--depends-on <ids>", "Comma-separated task IDs")
     .option("--repo <repo>", "Repository ID or URL")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string, opts) => {
       const client = await createClient();
       const body: Record<string, unknown> = {};
@@ -85,7 +85,7 @@ export function registerUpdateCommand(program: Command) {
         process.exit(1);
       }
       const task = await client.updateTask(id, body);
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       output(task, fmt, (t) => `Updated task ${t.id}: ${t.title}`);
     });
 
@@ -101,7 +101,7 @@ export function registerUpdateCommand(program: Command) {
     .option("--kind <kind>", "Agent kind: worker, leader")
     .option("--handoff-to <ids>", "Comma-separated agent IDs for handoff")
     .option("--skills <skills>", "Comma-separated skill slugs")
-    .option("--format <format>", "Output format (json, text)")
+    .option("-o, --output <format>", "Output format (json, yaml, text)")
     .action(async (id: string, opts) => {
       const client = await createClient();
       const body: Record<string, unknown> = {};
@@ -119,7 +119,7 @@ export function registerUpdateCommand(program: Command) {
         process.exit(1);
       }
       const agent = await client.updateAgent(id, body);
-      const fmt = getFormat(opts.format);
+      const fmt = getOutputFormat(opts.output);
       output(agent, fmt, (a) => `Updated agent ${a.id}: ${a.name}`);
     });
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,7 +11,7 @@ import { registerLogsCommand, registerStartCommand, registerStatusCommand, regis
 import { registerUpdateCommand } from "./commands/update.js";
 import { getCredentials, readConfig, saveCredentials } from "./config.js";
 import { loadIdentity } from "./identity.js";
-import { getFormat, output } from "./output.js";
+import { getOutputFormat, output } from "./output.js";
 import { detectRuntime } from "./runtime.js";
 
 const pkg = JSON.parse(readFileSync(join(import.meta.dirname, "../package.json"), "utf-8"));
@@ -131,22 +131,22 @@ const taskCmd = program.command("task").description("Task lifecycle commands");
 taskCmd
   .command("claim <id>")
   .description("Claim an assigned task — start working on it")
-  .option("--format <format>", "Output format (json, text)")
+  .option("-o, --output <format>", "Output format (json, yaml, text)")
   .action(async (id, opts) => {
     const client = await createClient();
     const task = await client.claimTask(id);
-    const fmt = getFormat(opts.format);
+    const fmt = getOutputFormat(opts.output);
     output(task, fmt, (t: any) => `Claimed task ${t.id}: ${t.title} (now in progress)`);
   });
 
 taskCmd
   .command("cancel <id>")
   .description("Cancel a task")
-  .option("--format <format>", "Output format (json, text)")
+  .option("-o, --output <format>", "Output format (json, yaml, text)")
   .action(async (id, opts) => {
     const client = await createClient();
     const task = await client.cancelTask(id);
-    const fmt = getFormat(opts.format);
+    const fmt = getOutputFormat(opts.output);
     output(task, fmt, (t) => `Cancelled task ${t.id}: ${t.title}`);
   });
 
@@ -154,13 +154,13 @@ taskCmd
   .command("review <id>")
   .description("Move a task to In Review")
   .option("--pr-url <url>", "Pull request URL")
-  .option("--format <format>", "Output format (json, text)")
+  .option("-o, --output <format>", "Output format (json, yaml, text)")
   .action(async (id, opts) => {
     const client = await createClient();
     const body: Record<string, unknown> = {};
     if (opts.prUrl) body.pr_url = opts.prUrl;
     const task = await client.reviewTask(id, body);
-    const fmt = getFormat(opts.format);
+    const fmt = getOutputFormat(opts.output);
     output(task, fmt, (t) => `Moved task ${t.id} to review: ${t.title}`);
   });
 
@@ -169,14 +169,14 @@ taskCmd
   .description("Complete a task (ops fallback)")
   .option("--result <result>", "Completion result summary")
   .option("--pr-url <url>", "PR URL")
-  .option("--format <format>", "Output format (json, text)")
+  .option("-o, --output <format>", "Output format (json, yaml, text)")
   .action(async (id, opts) => {
     const client = await createClient();
     const body: Record<string, unknown> = {};
     if (opts.result) body.result = opts.result;
     if (opts.prUrl) body.pr_url = opts.prUrl;
     const task = await client.completeTask(id, body);
-    const fmt = getFormat(opts.format);
+    const fmt = getOutputFormat(opts.output);
     output(task, fmt, (t) => `Completed task ${t.id}: ${t.title}`);
   });
 
@@ -184,24 +184,24 @@ taskCmd
   .command("reject <id>")
   .description("Reject a task from review back to in-progress")
   .option("--reason <reason>", "Reason for rejection (logged)")
-  .option("--format <format>", "Output format (json, text)")
+  .option("-o, --output <format>", "Output format (json, yaml, text)")
   .action(async (id, opts) => {
     const client = await createClient();
     const body: Record<string, unknown> = {};
     if (opts.reason) body.reason = opts.reason;
     const task = await client.rejectTask(id, body);
-    const fmt = getFormat(opts.format);
+    const fmt = getOutputFormat(opts.output);
     output(task, fmt, (t) => `Rejected task ${t.id}: ${t.title} (back to in-progress)`);
   });
 
 taskCmd
   .command("release <id>")
   .description("Release a task back to todo (ops fallback)")
-  .option("--format <format>", "Output format (json, text)")
+  .option("-o, --output <format>", "Output format (json, yaml, text)")
   .action(async (id, opts) => {
     const client = await createClient();
     const task = await client.releaseTask(id);
-    const fmt = getFormat(opts.format);
+    const fmt = getOutputFormat(opts.output);
     output(task, fmt, (t) => `Released task ${t.id}: ${t.title} (back to todo)`);
   });
 

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,15 +1,48 @@
-export function getFormat(explicit?: string): "json" | "text" {
-  if (explicit === "json") return "json";
-  return "text";
+import { stringify } from "yaml";
+
+export type OutputFormat = "json" | "yaml" | "wide" | "text";
+
+export function getOutputFormat(explicit?: string): OutputFormat {
+  switch (explicit) {
+    case "json":
+      return "json";
+    case "yaml":
+      return "yaml";
+    case "wide":
+      return "wide";
+    default:
+      return "text";
+  }
 }
 
-export function output(data: unknown, format: "json" | "text", textFormatter?: (data: any) => string): void {
-  if (format === "json") {
-    console.log(JSON.stringify(data, null, 2));
-  } else if (textFormatter) {
-    console.log(textFormatter(data));
-  } else {
-    console.log(JSON.stringify(data, null, 2));
+function toYamlOutput(data: unknown, kind?: string): string {
+  if (!kind) return stringify(data);
+  if (Array.isArray(data)) {
+    return data.map((item) => `---\n${stringify({ kind, spec: item })}`).join("");
+  }
+  return stringify({ kind, spec: data });
+}
+
+export function output(
+  data: unknown,
+  format: OutputFormat,
+  textFormatter?: (data: any) => string,
+  options?: { wideFormatter?: (data: any) => string; kind?: string },
+): void {
+  switch (format) {
+    case "json":
+      console.log(JSON.stringify(data, null, 2));
+      break;
+    case "yaml":
+      console.log(toYamlOutput(data, options?.kind));
+      break;
+    case "wide": {
+      const fn = options?.wideFormatter ?? textFormatter;
+      console.log(fn ? fn(data) : JSON.stringify(data, null, 2));
+      break;
+    }
+    default:
+      console.log(textFormatter ? textFormatter(data) : JSON.stringify(data, null, 2));
   }
 }
 
@@ -24,6 +57,23 @@ export function formatTaskList(tasks: any[]): string {
     const agent = t.assigned_to ? `→ ${t.assigned_to.slice(0, 8)}` : "";
     const pr = t.pr_url ? `PR: ${t.pr_url}` : "";
     return `  ${t.id}  ${status} ${priority.padEnd(8)} ${t.title} ${blocked} ${repo} ${agent} ${pr}`.trimEnd();
+  });
+
+  return lines.join("\n");
+}
+
+export function formatTaskListWide(tasks: any[]): string {
+  if (tasks.length === 0) return "No tasks found.";
+
+  const lines = tasks.map((t) => {
+    const status = `[${t.status}]`.padEnd(14);
+    const priority = t.priority ? `[${t.priority}]` : "";
+    const blocked = t.blocked ? " BLOCKED" : "";
+    const repo = t.repository_name ? t.repository_name.padEnd(20) : "".padEnd(20);
+    const agent = t.assigned_to ? t.assigned_to.slice(0, 12).padEnd(14) : "".padEnd(14);
+    const created = t.created_at ? new Date(t.created_at).toISOString().slice(0, 10) : "";
+    const pr = t.pr_url ? `PR: ${t.pr_url}` : "";
+    return `  ${t.id}  ${status} ${priority.padEnd(8)} ${t.title} ${blocked} ${repo} ${agent} ${created} ${pr}`.trimEnd();
   });
 
   return lines.join("\n");

--- a/tests/output.test.ts
+++ b/tests/output.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   formatAgent,
   formatAgentList,
@@ -9,7 +9,7 @@ import {
   formatTask,
   formatTaskList,
   formatTaskNotes,
-  getFormat,
+  getOutputFormat,
   output,
 } from "../packages/cli/src/output";
 
@@ -480,55 +480,103 @@ describe("formatBoard", () => {
   });
 });
 
-describe("getFormat", () => {
-  it("returns 'json' when explicit is 'json'", () => {
-    expect(getFormat("json")).toBe("json");
+describe("getOutputFormat", () => {
+  it("returns 'json' when given 'json'", () => {
+    expect(getOutputFormat("json")).toBe("json");
   });
 
-  it("returns 'text' when explicit is 'text'", () => {
-    expect(getFormat("text")).toBe("text");
+  it("returns 'yaml' when given 'yaml'", () => {
+    expect(getOutputFormat("yaml")).toBe("yaml");
   });
 
-  it("returns a valid format string when no explicit value given", () => {
-    const result = getFormat();
-    expect(["json", "text"]).toContain(result);
+  it("returns 'wide' when given 'wide'", () => {
+    expect(getOutputFormat("wide")).toBe("wide");
+  });
+
+  it("returns 'text' when given an unrecognized value", () => {
+    expect(getOutputFormat("unknown")).toBe("text");
+  });
+
+  it("returns 'text' when given undefined", () => {
+    expect(getOutputFormat(undefined)).toBe("text");
   });
 });
 
 describe("output", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("calls textFormatter in text mode when provided", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
     let called = false;
     const formatter = (_data: any) => {
       called = true;
       return "formatted";
     };
-    // Redirect console.log to avoid test noise
-    const original = console.log;
-    console.log = () => {};
     output({ foo: "bar" }, "text", formatter);
-    console.log = original;
     expect(called).toBe(true);
+    spy.mockRestore();
   });
 
   it("falls back to JSON.stringify in text mode when no formatter provided", () => {
-    let logged = "";
-    const original = console.log;
-    console.log = (v: string) => {
-      logged = v;
-    };
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
     output({ foo: "bar" }, "text");
-    console.log = original;
-    expect(logged).toContain('"foo"');
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('"foo"'));
   });
 
   it("outputs pretty-printed JSON in json mode", () => {
-    let logged = "";
-    const original = console.log;
-    console.log = (v: string) => {
-      logged = v;
-    };
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
     output({ foo: "bar" }, "json");
-    console.log = original;
+    const logged = spy.mock.calls[0][0];
     expect(JSON.parse(logged)).toEqual({ foo: "bar" });
+  });
+
+  it("outputs yaml with kind/spec envelope for a single object when kind is provided", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    output({ title: "My Task", status: "todo" }, "yaml", undefined, { kind: "task" });
+    const logged = spy.mock.calls[0][0];
+    expect(logged).toContain("kind: task");
+    expect(logged).toContain("spec:");
+  });
+
+  it("outputs multi-doc yaml for an array when kind is provided", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const item1 = { title: "Task 1", status: "todo" };
+    const item2 = { title: "Task 2", status: "done" };
+    output([item1, item2], "yaml", undefined, { kind: "task" });
+    const logged = spy.mock.calls[0][0];
+    // Each document must start with ---
+    const docSeparators = logged.match(/^---$/gm) || [];
+    expect(docSeparators.length).toBe(2);
+    expect(logged).toContain("Task 1");
+    expect(logged).toContain("Task 2");
+  });
+
+  it("outputs raw yaml without wrapper when no kind is provided", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    output({ foo: "bar" }, "yaml");
+    const logged = spy.mock.calls[0][0];
+    expect(logged).not.toContain("kind:");
+    expect(logged).not.toContain("spec:");
+    expect(logged).toContain("foo:");
+  });
+
+  it("calls wideFormatter in wide mode when wideFormatter is provided", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const textFn = vi.fn(() => "text-output");
+    const wideFn = vi.fn(() => "wide-output");
+    output({ foo: "bar" }, "wide", textFn, { wideFormatter: wideFn });
+    expect(wideFn).toHaveBeenCalledWith({ foo: "bar" });
+    expect(textFn).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith("wide-output");
+  });
+
+  it("falls back to textFormatter in wide mode when wideFormatter is not provided", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const textFn = vi.fn(() => "text-output");
+    output({ foo: "bar" }, "wide", textFn);
+    expect(textFn).toHaveBeenCalledWith({ foo: "bar" });
+    expect(spy).toHaveBeenCalledWith("text-output");
   });
 });


### PR DESCRIPTION
## Summary

- Replaces `--format <format>` with `-o, --output <format>` across all commands (breaking change)
- Adds `yaml` output format: produces apply-compatible YAML with `kind: X\nspec:` envelope; arrays become multi-doc YAML with `---` separators
- Adds `wide` format for task lists: includes repo name, agent name, and `created_at` columns
- Renames `getFormat` → `getOutputFormat` and adds `OutputFormat` type (`json | yaml | wide | text`)
- Fixes `describe` commands which were bypassing `output()` for non-json formats (yaml was silently ignored)
- Fixes `apply/kinds.ts` to pass `kind` to `output()` so yaml output is properly wrapped
- Uses the `yaml` package (already in dependencies) for serialization

## Test plan

- [ ] `ak get task -o yaml` — produces `kind: task\nspec:` wrapped YAML for single task
- [ ] `ak get task --board <id> -o yaml` — produces multi-doc YAML with `---` per task
- [ ] `ak get task --board <id> -o wide` — shows repo, agent, and created_at columns
- [ ] `ak get task --board <id> -o json` — JSON output unchanged
- [ ] `ak get task --board <id>` (no -o) — compact text table unchanged
- [ ] Old `--format` flag no longer accepted
- [ ] All 741 unit tests pass