### PR TITLE
docs: update help text, skill doc, and README for kubectl-style CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,55 @@ Agents are not passive workers. They actively participate in the workflow:
 - **Stale detection** — agents inactive for 2h are automatically marked offline
 - **Multi-repo** — one board can track tasks across multiple repositories
 
+## CLI Reference
+
+The `ak` CLI follows a kubectl-style resource model.
+
+```
+Usage: ak [command]
+
+Resources:
+  get <resource> [id]      Get or list resources
+  create <resource>        Create a resource
+  update <resource> <id>   Update a resource
+  delete <resource> <id>   Delete a resource
+  describe <resource> <id> Show detailed resource info
+  apply -f <file>          Apply a YAML/JSON resource spec
+
+Task Lifecycle:
+  task claim <id>          Claim a task
+  task review <id>         Submit for review
+  task complete <id>       Complete a task
+  task reject <id>         Reject back to in-progress
+  task cancel <id>         Cancel a task
+  task release <id>        Release back to todo
+
+Output:
+  -o json|yaml|wide        Output format (default: text table)
+```
+
+### Creating tasks with `apply -f`
+
+The preferred way to create or update tasks is `ak apply -f <file>`:
+
+```yaml
+# task.yaml
+kind: Task
+board: <board-id>
+title: "Fix login redirect bug"
+description: "Users are sent to / after login instead of the page they came from."
+priority: high
+labels: bug,auth
+repo: https://github.com/org/repo
+assign-to: <agent-id>
+```
+
+```bash
+ak apply -f task.yaml
+```
+
+Add an `id:` field to update an existing resource instead of creating a new one.
+
 ## Development
 
 ```bash

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,49 +24,26 @@ const helpSections: [string, [string, string][]][] = [
   [
     "Resources",
     [
-      ["get <resource> [id]", "Get a resource or list resources"],
-      ["  get board|task|agent|repo|note", "Resource-specific subcommands with own filters"],
-      ["describe <resource> <id>", "Show detailed view of a resource"],
-      ["  describe task|agent|board", "Rich multi-section output with logs/sessions"],
-      ["create <resource>", "Create a resource (board, task, agent, repo, note)"],
-      ["  create board", "Create a board (--name, --type)"],
-      ["  create task", "Create a task (--board, --title, ...)"],
-      ["  create agent", "Create an agent (--username, --template, ...)"],
-      ["  create repo", "Create a repository (--name, --url)"],
-      ["  create note <msg>", "Add a log note to a task (--task)"],
-      ["update <resource> <id>", "Update a resource (board, task, agent)"],
-      ["delete <resource> <id>", "Delete a resource (board, task, agent, repo)"],
-      ["apply -f <file>", "Apply a YAML/JSON resource spec (create or update)"],
+      ["get <resource> [id]", "Get or list resources"],
+      ["create <resource>", "Create a resource"],
+      ["update <resource> <id>", "Update a resource"],
+      ["delete <resource> <id>", "Delete a resource"],
+      ["describe <resource> <id>", "Show detailed resource info"],
+      ["apply -f <file>", "Apply a YAML/JSON resource spec"],
     ],
   ],
   [
     "Task Lifecycle",
     [
-      ["task claim <id>", "Claim an assigned task"],
-      ["task review <id>", "Submit task for review"],
+      ["task claim <id>", "Claim a task"],
+      ["task review <id>", "Submit for review"],
       ["task complete <id>", "Complete a task"],
-      ["task reject <id>", "Reject a task back to in-progress"],
+      ["task reject <id>", "Reject back to in-progress"],
       ["task cancel <id>", "Cancel a task"],
-      ["task release <id>", "Release a task back to todo"],
+      ["task release <id>", "Release back to todo"],
     ],
   ],
-  ["Identity", [["whoami", "Show agent identity for current runtime"]]],
-  [
-    "Daemon",
-    [
-      ["start", "Start the Machine daemon"],
-      ["stop", "Stop the Machine daemon"],
-      ["status", "Show daemon status"],
-      ["logs", "Show daemon logs"],
-    ],
-  ],
-  [
-    "Config",
-    [
-      ["config set <key> <value>", "Set a config value"],
-      ["config get <key>", "Get a config value"],
-    ],
-  ],
+  ["Output", [["-o json|yaml|wide", "Output format (default: text table)"]]],
 ];
 
 program.helpInformation = () => {

--- a/skills/agent-kanban/SKILL.md
+++ b/skills/agent-kanban/SKILL.md
@@ -31,14 +31,48 @@ You are an agent. Use the `ak` CLI to work on tasks. Your identity is initialize
 | `ak get task --board <id> --status <s>` | List tasks filtered by board, status, label, repo |
 | `ak get note --task <id>` | View progress logs for a task |
 | `ak create note --task <id> "message"` | Add a progress log entry |
-| `ak create task --board <id> --title "..."` | Create a new task |
+| `ak apply -f <file>` | Apply a YAML/JSON resource spec (preferred for tasks) |
 | `ak get agent` | List agents |
 | `ak get agent --format json` | List agents as JSON |
 | `ak get board` | List boards |
 | `ak get repo` | List repositories |
 | `ak create repo --name "..." --url "..."` | Register a repository |
 
-### Create Task Options
+### Creating Tasks — Use `apply -f` (Preferred)
+
+The preferred way to create tasks is `ak apply -f <file>`. It supports richer specs, is idempotent (add `id:` to update), and is easy to review and version-control.
+
+**task.yaml**
+```yaml
+kind: Task
+board: <board-id>
+title: "Fix login redirect bug"
+description: |
+  After login, users are redirected to / instead of the page they came from.
+  The `returnTo` param is set but not read in the auth callback.
+priority: high
+labels: bug,auth
+repo: https://github.com/org/repo
+assign-to: <agent-id>
+parent: <parent-task-id>
+depends-on:
+  - <task-id>
+```
+
+```bash
+ak apply -f task.yaml
+```
+
+To update an existing task, add the `id` field and re-apply:
+
+```yaml
+kind: Task
+id: <task-id>
+priority: medium
+assign-to: <new-agent-id>
+```
+
+For quick single-task creation, `ak create task` still works:
 
 ```
 ak create task --board <id> --title "Title" \


### PR DESCRIPTION
## Summary

- **`packages/cli/src/index.ts`**: Simplified `helpSections` to match the spec — top-level resource verbs only (get, create, update, delete, describe, apply), removed verbose sub-entries, added new **Output** section showing `-o json|yaml|wide`
- **`skills/agent-kanban/SKILL.md`**: Added `apply -f` as the primary task creation pattern with a full YAML example and idempotent update workflow; `ak create task` kept as a secondary option for quick single-task creation
- **`README.md`**: Added a **CLI Reference** section showing the full command structure and an `apply -f` usage example

## Test plan

- [ ] Run `ak --help` and verify output matches the spec structure
- [ ] Verify skill doc renders correctly in the agent's context
- [ ] Verify README CLI section is accurate and readable