### PR TITLE
Add reject-resume regression test comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,4 @@
+# reject-resume regression test
 # Agent Kanban
 
 Agent-first kanban board. React SPA + Hono API on Cloudflare Pages + D1.


### PR DESCRIPTION
## Summary
- Adds a single-line comment `# reject-resume regression test` to the top of CLAUDE.md as requested by the regression test task.

## Test plan
- [x] Verified pre-commit hooks pass (typecheck + tests: 52 files, 1490 tests all passing)
- [x] Change is a single-line addition to a markdown file — no functional impact