### PR TITLE
fix(agent): validate installable skill refs

### DIFF
--- a/apps/web/server/routes.ts
+++ b/apps/web/server/routes.ts
@@ -1,4 +1,12 @@
-import { AGENT_RUNTIMES, type CreateAgentInput, isBoardType, isValidUsername, parseScheduledAt, RESERVED_ROLES } from "@agent-kanban/shared";
+import {
+  AGENT_RUNTIMES,
+  type CreateAgentInput,
+  findInvalidSkillRef,
+  isBoardType,
+  isValidUsername,
+  parseScheduledAt,
+  RESERVED_ROLES,
+} from "@agent-kanban/shared";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import {
@@ -50,6 +58,17 @@ import type { Env } from "./types";
 
 const api = new Hono<{ Bindings: Env }>();
 const logger = createLogger("api");
+
+function assertValidSkillRefs(skills: unknown) {
+  if (skills === undefined) return;
+  if (!Array.isArray(skills) || skills.some((skill) => typeof skill !== "string")) {
+    throw new HTTPException(400, { message: "skills must be an array of source/repo@skill-name strings" });
+  }
+  const invalid = findInvalidSkillRef(skills);
+  if (invalid) {
+    throw new HTTPException(400, { message: `Invalid skill "${invalid}". Use source/repo@skill-name format.` });
+  }
+}
 
 function resolveActor(c: { get: (key: string) => any }): { actorType: string; actorId: string; sessionId: string | null } {
   const identity: string = c.get("identityType") || "machine";
@@ -415,6 +434,7 @@ api.post("/api/agents", async (c) => {
   if (body.role && RESERVED_ROLES.has(body.role)) {
     throw new HTTPException(403, { message: `Role "${body.role}" is reserved for built-in agents` });
   }
+  assertValidSkillRefs(body.skills);
   const ownerId = c.get("ownerId");
 
   // Validate username uniqueness before GPG mutation
@@ -466,6 +486,7 @@ api.patch("/api/agents/:id", async (c) => {
   if (!existing) throw new HTTPException(404, { message: "Agent not found" });
   if (existing.builtin) throw new HTTPException(403, { message: "Built-in agents cannot be modified" });
   const body = await c.req.json();
+  assertValidSkillRefs(body.skills);
   const agent = await updateAgent(c.env.DB, c.req.param("id"), body);
   return c.json(agent);
 });

--- a/apps/web/src/routes/AgentEditPage.tsx
+++ b/apps/web/src/routes/AgentEditPage.tsx
@@ -1,4 +1,4 @@
-import { AGENT_RUNTIMES, type AgentRuntime, RUNTIME_LABELS } from "@agent-kanban/shared";
+import { AGENT_RUNTIMES, type AgentRuntime, findInvalidSkillRef, RUNTIME_LABELS } from "@agent-kanban/shared";
 import React, { useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { AgentIdenticon } from "../components/AgentIdenticon";
@@ -67,6 +67,11 @@ export function AgentEditPage() {
   async function handleSave() {
     if (!name.trim()) return;
     setError(null);
+    const invalidSkill = findInvalidSkillRef(skills);
+    if (invalidSkill) {
+      setError(`Invalid skill "${invalidSkill}". Use source/repo@skill-name format.`);
+      return;
+    }
     try {
       await updateAgent.mutateAsync({
         id: agent!.id,
@@ -187,7 +192,7 @@ export function AgentEditPage() {
               <legend className="text-[11px] font-mono font-medium text-content-tertiary uppercase tracking-[0.08em] mb-3">Workflow</legend>
               <div className="space-y-1.5">
                 <Label>Skills</Label>
-                <TagInput tags={skills} onChange={setSkills} placeholder="Type a skill and press Enter" />
+                <TagInput tags={skills} onChange={setSkills} placeholder="owner/repo@skill-name" />
               </div>
             </fieldset>
 

--- a/apps/web/src/routes/AgentNewPage.tsx
+++ b/apps/web/src/routes/AgentNewPage.tsx
@@ -4,6 +4,7 @@ import {
   type AgentTemplate,
   fetchTemplate,
   fetchTemplateIndex,
+  findInvalidSkillRef,
   RUNTIME_LABELS,
   type TemplateIndex,
 } from "@agent-kanban/shared";
@@ -72,6 +73,11 @@ export function AgentNewPage() {
   async function handleCreate() {
     if (!username.trim()) return;
     setError(null);
+    const invalidSkill = findInvalidSkillRef(skills);
+    if (invalidSkill) {
+      setError(`Invalid skill "${invalidSkill}". Use source/repo@skill-name format.`);
+      return;
+    }
     try {
       await createAgent.mutateAsync({
         name: name.trim() || undefined,
@@ -463,7 +469,7 @@ function FormStep(props: FormStepProps) {
             </div>
             <div className="space-y-1.5">
               <Label>Skills</Label>
-              <TagInput tags={skills} onChange={setSkills} placeholder="Type a skill and press Enter" />
+              <TagInput tags={skills} onChange={setSkills} placeholder="owner/repo@skill-name" />
             </div>
           </fieldset>
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -155,6 +155,16 @@ export function deriveUsername(name: string): string {
   return derived || "agent";
 }
 
+const SKILL_REF_RE = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+$/;
+
+export function isValidSkillRef(value: string): boolean {
+  return SKILL_REF_RE.test(value);
+}
+
+export function findInvalidSkillRef(skills: string[] | null | undefined): string | null {
+  return skills?.find((skill) => !isValidSkillRef(skill)) ?? null;
+}
+
 export const AGENT_RUNTIMES: readonly AgentRuntime[] = ["claude", "codex", "gemini", "copilot", "hermes"] as const;
 
 export const RUNTIME_LABELS: Record<AgentRuntime, string> = {

--- a/tests/agent-kind-handoff-skills.test.ts
+++ b/tests/agent-kind-handoff-skills.test.ts
@@ -103,11 +103,11 @@ describe("create agent: --skills flag", () => {
       name: "Test Skills",
       runtime: "claude",
       role: "dev",
-      skills: ["agent-kanban"],
+      skills: ["saltbo/agent-kanban@agent-kanban"],
     });
 
     expect(Array.isArray(agent.skills)).toBe(true);
-    expect(agent.skills).toEqual(["agent-kanban"]);
+    expect(agent.skills).toEqual(["saltbo/agent-kanban@agent-kanban"]);
   });
 
   it("multiple skills are stored as array", async () => {
@@ -115,11 +115,11 @@ describe("create agent: --skills flag", () => {
       username: "test-skills-multi",
       name: "Test Skills Multi",
       runtime: "claude",
-      skills: ["agent-kanban", "trailofbits/skills@differential-review"],
+      skills: ["saltbo/agent-kanban@agent-kanban", "trailofbits/skills@differential-review"],
     });
 
     expect(agent.skills).toHaveLength(2);
-    expect(agent.skills).toContain("agent-kanban");
+    expect(agent.skills).toContain("saltbo/agent-kanban@agent-kanban");
     expect(agent.skills).toContain("trailofbits/skills@differential-review");
   });
 });
@@ -146,21 +146,21 @@ describe("update agent: --handoff-to, --skills flags", () => {
 
   it("updates skills via updateAgent", async () => {
     const { updateAgent } = await import("../apps/web/server/agentRepo");
-    const updated = await updateAgent(db, agentId, { skills: ["agent-kanban"] });
+    const updated = await updateAgent(db, agentId, { skills: ["saltbo/agent-kanban@agent-kanban"] });
 
     expect(updated).toBeTruthy();
-    expect(updated!.skills).toEqual(["agent-kanban"]);
+    expect(updated!.skills).toEqual(["saltbo/agent-kanban@agent-kanban"]);
   });
 
   it("handoff_to and skills persist together", async () => {
     const { updateAgent, getAgent } = await import("../apps/web/server/agentRepo");
     await updateAgent(db, agentId, {
       handoff_to: ["final-leader"],
-      skills: ["agent-kanban", "browse"],
+      skills: ["saltbo/agent-kanban@agent-kanban", "trailofbits/skills@differential-review"],
     });
 
     const fetched = await getAgent(db, agentId, "owner-update");
     expect(fetched!.handoff_to).toEqual(["final-leader"]);
-    expect(fetched!.skills).toEqual(["agent-kanban", "browse"]);
+    expect(fetched!.skills).toEqual(["saltbo/agent-kanban@agent-kanban", "trailofbits/skills@differential-review"]);
   });
 });

--- a/tests/agents/agents-new-custom.spec.ts
+++ b/tests/agents/agents-new-custom.spec.ts
@@ -33,7 +33,7 @@ test.describe("Agents Page", () => {
 
     // expect: Workflow fieldset with 'Handoff to' and 'Skills' fields is visible
     await expect(page.getByRole("group", { name: "Workflow" })).toBeVisible();
-    await expect(page.getByRole("textbox", { name: "Type a skill and press Enter" })).toBeVisible();
+    await expect(page.getByRole("textbox", { name: "owner/repo@skill-name" })).toBeVisible();
 
     // expect: A live preview card is shown on the right side
     await expect(page.getByText("Preview")).toBeVisible();

--- a/tests/agents/agents-new-skills-remove.spec.ts
+++ b/tests/agents/agents-new-skills-remove.spec.ts
@@ -6,25 +6,25 @@ import { signUpAndGetBoard } from "../helpers/auth";
 
 test.describe("Agents Page", () => {
   test("Agent creation — remove a skill tag", async ({ page }) => {
-    // 1. Sign in, navigate to /agents/new, click 'Custom', add the skill 'python' using the Skills field
+    // 1. Sign in, navigate to /agents/new, click 'Custom', add a skill using the Skills field
     await signUpAndGetBoard(page, `agents_rmskill_${Date.now()}@example.com`);
     await page.goto("/agents/new");
     await page.getByRole("button", { name: "Custom Build your own from" }).click();
 
-    const skillsInput = page.getByRole("textbox", { name: "Type a skill and press Enter" });
+    const skillsInput = page.getByRole("textbox", { name: "owner/repo@skill-name" });
     await skillsInput.click();
-    await skillsInput.fill("python");
+    await skillsInput.fill("owner/skills@python");
     await page.keyboard.press("Enter");
 
-    // expect: A 'python' skill tag is shown
+    // expect: A skill tag is shown
     const workflowGroup = page.getByRole("group", { name: "Workflow" });
-    await expect(workflowGroup.getByText("python")).toBeVisible();
+    await expect(workflowGroup.getByText("owner/skills@python")).toBeVisible();
 
-    // 2. Click the '×' button on the 'python' tag chip
+    // 2. Click the remove button on the skill tag chip
     await workflowGroup.getByRole("button").click();
 
-    // expect: The 'python' tag is removed from the Skills field
-    await expect(workflowGroup.getByText("python")).not.toBeVisible();
+    // expect: The tag is removed from the Skills field
+    await expect(workflowGroup.getByText("owner/skills@python")).not.toBeVisible();
 
     // expect: The skills input placeholder is visible again
     await expect(skillsInput).toBeVisible();

--- a/tests/agents/agents-new-skills-tag.spec.ts
+++ b/tests/agents/agents-new-skills-tag.spec.ts
@@ -13,29 +13,28 @@ test.describe("Agents Page", () => {
 
     // expect: Skills tag input is visible with placeholder text
     const workflowGroup = page.getByRole("group", { name: "Workflow" });
-    const skillsInput = workflowGroup.getByRole("textbox", { name: "Type a skill and press Enter" });
+    const skillsInput = workflowGroup.getByRole("textbox", { name: "owner/repo@skill-name" });
     await expect(skillsInput).toBeVisible();
 
-    // 2. Click the Skills field, type 'typescript', and press Enter
+    // 2. Click the Skills field, type a valid skill ref, and press Enter
     await skillsInput.click();
-    await skillsInput.fill("typescript");
+    await skillsInput.fill("owner/skills@typescript");
     await page.keyboard.press("Enter");
 
-    // expect: A 'typescript' tag chip appears in the input
-    await expect(workflowGroup.getByText("typescript")).toBeVisible();
+    // expect: A skill tag chip appears in the input
+    await expect(workflowGroup.getByText("owner/skills@typescript")).toBeVisible();
 
     // expect: The text input clears for the next entry
     // After a tag is added, the placeholder is hidden but the input is still present
     const skillsInputAfterFirstTag = workflowGroup.locator('input[type="text"], input:not([type])').last();
     await expect(skillsInputAfterFirstTag).toHaveValue("");
 
-    // 3. Type 'react' and press Enter
-    await skillsInputAfterFirstTag.fill("react");
+    // 3. Type another valid skill ref and press Enter
+    await skillsInputAfterFirstTag.fill("owner/skills@react");
     await page.keyboard.press("Enter");
 
-    // expect: A 'react' tag chip also appears
-    // expect: Two skill tags are now visible: 'typescript' and 'react'
-    await expect(workflowGroup.getByText("typescript")).toBeVisible();
-    await expect(workflowGroup.getByText("react")).toBeVisible();
+    // expect: Two skill tags are now visible
+    await expect(workflowGroup.getByText("owner/skills@typescript")).toBeVisible();
+    await expect(workflowGroup.getByText("owner/skills@react")).toBeVisible();
   });
 });

--- a/tests/routes.test.ts
+++ b/tests/routes.test.ts
@@ -394,6 +394,26 @@ describe("routes", () => {
     expect(res.status).toBe(403);
   });
 
+  it("POST /api/agents rejects malformed skill refs", async () => {
+    const res = await apiRequest(
+      "POST",
+      "/api/agents",
+      { name: "Bad Skill", username: "bad-skill", runtime: "claude", skills: ["agent-kanban"] },
+      apiKey,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error.message).toContain('Invalid skill "agent-kanban"');
+  });
+
+  it("PATCH /api/agents/:id rejects malformed skill refs", async () => {
+    const jwt = await signLeaderSessionJWT();
+    const res = await apiRequest("PATCH", `/api/agents/${agentId}`, { skills: ["trailofbits/skills"] }, jwt);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error.message).toContain('Invalid skill "trailofbits/skills"');
+  });
+
   // ─── Tasks ───
 
   it("POST /api/tasks creates a task", async () => {

--- a/tests/shared.test.ts
+++ b/tests/shared.test.ts
@@ -1,4 +1,13 @@
-import { AGENT_STATUSES, deriveUsername, isValidUsername, PRIORITIES, STALE_TIMEOUT_MS, TASK_ACTIONS } from "@agent-kanban/shared";
+import {
+  AGENT_STATUSES,
+  deriveUsername,
+  findInvalidSkillRef,
+  isValidSkillRef,
+  isValidUsername,
+  PRIORITIES,
+  STALE_TIMEOUT_MS,
+  TASK_ACTIONS,
+} from "@agent-kanban/shared";
 import { describe, expect, it } from "vitest";
 
 describe("isValidUsername", () => {
@@ -61,6 +70,25 @@ describe("deriveUsername", () => {
   it("truncates to 40 characters", () => {
     const long = "a".repeat(50);
     expect(deriveUsername(long).length).toBeLessThanOrEqual(40);
+  });
+});
+
+describe("isValidSkillRef", () => {
+  it("accepts installable owner/repo@skill-name refs", () => {
+    expect(isValidSkillRef("trailofbits/skills@differential-review")).toBe(true);
+    expect(isValidSkillRef("obra/superpowers@verification-before-completion")).toBe(true);
+  });
+
+  it("rejects short names and malformed refs", () => {
+    expect(isValidSkillRef("agent-kanban")).toBe(false);
+    expect(isValidSkillRef("trailofbits/skills")).toBe(false);
+    expect(isValidSkillRef("trailofbits/skills@")).toBe(false);
+    expect(isValidSkillRef("trailofbits/skills@bad skill")).toBe(false);
+  });
+
+  it("returns the first invalid skill ref", () => {
+    expect(findInvalidSkillRef(["owner/repo@good", "browse", "other/repo@good"])).toBe("browse");
+    expect(findInvalidSkillRef(["owner/repo@good"])).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- add a shared `source/repo@skill-name` validator for agent skill refs
- reject malformed `skills` values on agent create/update API boundaries
- update agent form placeholders and submit validation to match installable skill refs
- update tests away from short skill labels and cover malformed create/update requests

## Why
`agent.skills` is intended to contain installable skills. The daemon already treats every value as a skill install ref, so silently skipping free-form values would hide bad agent configuration. This change fails fast when invalid values are submitted instead.

## Validation
- `npx vitest run tests/shared.test.ts tests/routes.test.ts tests/agent-kind-handoff-skills.test.ts`
- `pnpm build && pnpm tsc --noEmit && npx vitest run`
- `npx biome check apps/web/server/routes.ts apps/web/src/routes/AgentNewPage.tsx apps/web/src/routes/AgentEditPage.tsx packages/shared/src/types.ts tests/shared.test.ts tests/routes.test.ts tests/agent-kind-handoff-skills.test.ts tests/agents/agents-new-custom.spec.ts tests/agents/agents-new-skills-remove.spec.ts tests/agents/agents-new-skills-tag.spec.ts`
- `git diff --check`

## Playwright note
Tried `npx playwright test tests/agents/agents-new-custom.spec.ts tests/agents/agents-new-skills-tag.spec.ts tests/agents/agents-new-skills-remove.spec.ts`; all three timed out in `tests/helpers/auth.ts` waiting for `/boards/_new` while the app stayed on `/onboarding`, before reaching the changed agent form.