### PR TITLE
fix: detect Hermes gateway runtime

### DIFF
--- a/packages/cli/src/agent/runtime.ts
+++ b/packages/cli/src/agent/runtime.ts
@@ -1,22 +1,25 @@
 import { execFileSync } from "node:child_process";
 
 interface RuntimeSpec {
-  /** Environment variable set by the runtime when it spawns subprocesses. */
-  envVar: string;
+  /** Environment variables set by the runtime when it spawns subprocesses. */
+  envVars: string[];
   commandPattern: RegExp;
 }
 
 const RUNTIMES: Record<string, RuntimeSpec> = {
-  claude: { envVar: "CLAUDECODE", commandPattern: /(^|\/)claude(\s|$)/ },
-  codex: { envVar: "CODEX_CI", commandPattern: /(^|\/)codex(\s|$)/ },
-  gemini: { envVar: "GEMINI_CLI", commandPattern: /(^|\/)gemini(\s|$)/ },
-  copilot: { envVar: "COPILOT_CLI", commandPattern: /(^|\/)copilot(\s|$)/ },
-  hermes: { envVar: "HERMES_INTERACTIVE", commandPattern: /(^|\/)hermes(\s|$)/ },
+  claude: { envVars: ["CLAUDECODE"], commandPattern: /(^|\/)claude(\s|$)/ },
+  codex: { envVars: ["CODEX_CI"], commandPattern: /(^|\/)codex(\s|$)/ },
+  gemini: { envVars: ["GEMINI_CLI"], commandPattern: /(^|\/)gemini(\s|$)/ },
+  copilot: { envVars: ["COPILOT_CLI"], commandPattern: /(^|\/)copilot(\s|$)/ },
+  hermes: {
+    envVars: ["HERMES_INTERACTIVE", "HERMES_SESSION_KEY"],
+    commandPattern: /(^|\/)hermes(\s|$)|(^|\s)hermes_cli\.main(\s|$)/,
+  },
 };
 
 export function detectRuntime(): string | null {
-  for (const [name, { envVar }] of Object.entries(RUNTIMES)) {
-    if (process.env[envVar]) return name;
+  for (const [name, { envVars }] of Object.entries(RUNTIMES)) {
+    if (envVars.some((envVar) => process.env[envVar])) return name;
   }
   return null;
 }

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -33,6 +33,8 @@ function clearRuntimeEnv() {
   delete process.env.CODEX_CI;
   delete process.env.GEMINI_CLI;
   delete process.env.COPILOT_CLI;
+  delete process.env.HERMES_INTERACTIVE;
+  delete process.env.HERMES_SESSION_KEY;
 }
 
 beforeEach(() => {
@@ -69,6 +71,16 @@ describe("detectRuntime", () => {
   it("returns 'copilot' when COPILOT_CLI is set", () => {
     process.env.COPILOT_CLI = "1";
     expect(detectRuntime()).toBe("copilot");
+  });
+
+  it("returns 'hermes' when HERMES_INTERACTIVE is set", () => {
+    process.env.HERMES_INTERACTIVE = "1";
+    expect(detectRuntime()).toBe("hermes");
+  });
+
+  it("returns 'hermes' when HERMES_SESSION_KEY is set", () => {
+    process.env.HERMES_SESSION_KEY = "agent:main:telegram:dm:527035525";
+    expect(detectRuntime()).toBe("hermes");
   });
 
   it("prioritises CLAUDECODE over CODEX_CI when both are set", () => {
@@ -151,6 +163,11 @@ describe("findRuntimeAncestorPid — happy paths", () => {
     // e.g. "claude --dangerously-skip-permissions"
     mockExecFileSync.mockReturnValueOnce(psLine(1, "/usr/local/bin/claude --dangerously-skip-permissions"));
     expect(findRuntimeAncestorPid("claude")).toBe(process.ppid);
+  });
+
+  it("matches Hermes gateway process command", () => {
+    mockExecFileSync.mockReturnValueOnce(psLine(1, "/Users/saltbo/.hermes/hermes-agent/venv/bin/python -m hermes_cli.main gateway run --replace"));
+    expect(findRuntimeAncestorPid("hermes")).toBe(process.ppid);
   });
 
   it("does not match a command where runtime name is a substring of another word", () => {


### PR DESCRIPTION
## Summary
- Re-created this PR from the official repository working directory: /Users/saltbo/Develop/bogit/agent-kanban
- Based on the latest origin/main, not on Agent Kanban temporary worktrees
- Detect Hermes Gateway sessions via HERMES_SESSION_KEY
- Match Hermes Gateway parent command: python -m hermes_cli.main gateway run --replace
- Add regression coverage for Gateway runtime detection

## Test Plan
- pnpm exec vitest run packages/cli/tests/runtime.test.ts
- pnpm --filter agent-kanban lint
- pnpm exec vitest run
- pnpm build

## Notes
This replaces the earlier PR that was created from a temporary Agent Kanban worktree.