### PR TITLE
[codex] Add runtime circuit breaker for pre-claim exits

### DIFF
--- a/packages/cli/src/daemon/dispatcher.ts
+++ b/packages/cli/src/daemon/dispatcher.ts
@@ -26,6 +26,7 @@ import { createRepoWorkspace, createTempWorkspace } from "../workspace/workspace
 import { apiCallIdempotent, apiCallOptional, cryptoBoundary, execBoundary, fsSync } from "./boundaries.js";
 import type { PrMonitor } from "./prMonitor.js";
 import type { RateLimiter } from "./rateLimiter.js";
+import type { RuntimeCircuitBreaker } from "./runtimeCircuitBreaker.js";
 import { isRuntimeLimitIgnored } from "./runtimeOverrides.js";
 import type { RuntimePool } from "./runtimePool.js";
 
@@ -122,6 +123,7 @@ export async function dispatchTasks(
   rateLimiter: RateLimiter,
   prMonitor: PrMonitor,
   opts: DispatchOpts,
+  circuitBreaker?: RuntimeCircuitBreaker,
 ): Promise<boolean> {
   const tasks = (await client.listTasks({ status: "todo" })) as any[];
   const repos = await client.listRepositories();
@@ -176,7 +178,10 @@ export async function dispatchTasks(
     const ignoreRuntimeLimit = isRuntimeLimitIgnored(agentState.runtime);
     const localAvailability = ignoreRuntimeLimit ? null : await getProvider(agentState.runtime).checkAvailability?.();
     if (localAvailability && localAvailability.status !== "ready") continue;
-    if (ignoreRuntimeLimit || !rateLimiter.isRuntimePaused(agentState.runtime)) {
+    if (
+      (ignoreRuntimeLimit || !rateLimiter.isRuntimePaused(agentState.runtime)) &&
+      (!circuitBreaker || circuitBreaker.canDispatch(agentState.runtime))
+    ) {
       task = t;
       break;
     }

--- a/packages/cli/src/daemon/dispatcher.ts
+++ b/packages/cli/src/daemon/dispatcher.ts
@@ -155,6 +155,7 @@ export async function dispatchTasks(
   const localRuntimes = new Set(getAvailableProviders().map((provider) => provider.name));
   const agentCache = new Map<string, { runtime: AgentRuntime | null; available: boolean }>();
   let task: any = null;
+  let taskRuntime: AgentRuntime | null = null;
   for (const t of available) {
     let agentState = agentCache.get(t.assigned_to);
     if (agentState === undefined) {
@@ -183,6 +184,7 @@ export async function dispatchTasks(
       (!circuitBreaker || circuitBreaker.canDispatch(agentState.runtime))
     ) {
       task = t;
+      taskRuntime = agentState.runtime;
       break;
     }
   }
@@ -206,7 +208,10 @@ export async function dispatchTasks(
     return false;
   }
 
+  if (circuitBreaker && taskRuntime && !circuitBreaker.tryAcquireDispatch(taskRuntime)) return false;
+
   const dispatched = await dispatchOne(task, dir, boardType, client, pool);
+  if (!dispatched && circuitBreaker && taskRuntime) circuitBreaker.releaseDispatch(taskRuntime);
   if (dispatched) prMonitor.track(task.id);
   return dispatched;
 }

--- a/packages/cli/src/daemon/index.ts
+++ b/packages/cli/src/daemon/index.ts
@@ -62,13 +62,16 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     },
   });
 
-  const machineInfo = await getMachineInfo(availableProviders, rateLimiter);
+  const machineInfo = await getMachineInfo(availableProviders, rateLimiter, circuitBreaker);
   const deviceId = generateDeviceId();
   const machine = await client.registerMachine({ ...machineInfo, device_id: deviceId });
   const machineId = machine.id;
   logger.info(`Machine ready: ${machineId} (device: ${deviceId})`);
 
-  await client.heartbeat(machineId, { version: machineInfo.version, runtimes: await buildRuntimeStates(availableProviders, rateLimiter) });
+  await client.heartbeat(machineId, {
+    version: machineInfo.version,
+    runtimes: await buildRuntimeStates(availableProviders, rateLimiter, circuitBreaker),
+  });
   migrateLegacySessions();
   await cleanupStaleSessions(client, machineId);
   await auditOrphanedTasks(client, machineId);
@@ -82,7 +85,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   sendHeartbeat = async () => {
     await client.heartbeat(machineId, {
       version: machineInfo.version,
-      runtimes: await buildRuntimeStates(availableProviders, rateLimiter),
+      runtimes: await buildRuntimeStates(availableProviders, rateLimiter, circuitBreaker),
       usage_info: usageCollector.getSnapshot(),
     });
   };
@@ -178,13 +181,17 @@ function removePidFile(): void {
   }
 }
 
-async function getMachineInfo(providers: AgentProvider[], rateLimiter: RateLimiter) {
+async function getMachineInfo(providers: AgentProvider[], rateLimiter: RateLimiter, circuitBreaker: RuntimeCircuitBreaker) {
   const os = `${platform()} ${arch()} ${release()}`;
-  const runtimes = await buildRuntimeStates(providers, rateLimiter);
+  const runtimes = await buildRuntimeStates(providers, rateLimiter, circuitBreaker);
   return { name: resolveMachineName(), os, version: getVersion(), runtimes };
 }
 
-async function buildRuntimeStates(providers: AgentProvider[], rateLimiter: RateLimiter): Promise<MachineRuntime[]> {
+async function buildRuntimeStates(
+  providers: AgentProvider[],
+  rateLimiter: RateLimiter,
+  circuitBreaker: RuntimeCircuitBreaker,
+): Promise<MachineRuntime[]> {
   const checked_at = new Date().toISOString();
   return Promise.all(
     providers.map(async (provider) => {
@@ -194,6 +201,15 @@ async function buildRuntimeStates(providers: AgentProvider[], rateLimiter: RateL
       const reset_at = rateLimiter.pauseResetAt(provider.name);
       if (reset_at) {
         return { name: provider.name, status: "limited", detail: "runtime paused by rate limiter", reset_at, checked_at };
+      }
+      if (circuitBreaker.isRuntimePaused(provider.name)) {
+        return {
+          name: provider.name,
+          status: "limited",
+          detail: "runtime paused by circuit breaker",
+          reset_at: circuitBreaker.pauseResetAt(provider.name) ?? undefined,
+          checked_at,
+        };
       }
       const availability = (await provider.checkAvailability?.()) ?? { status: "ready" };
       return { name: provider.name, ...availability, checked_at };

--- a/packages/cli/src/daemon/index.ts
+++ b/packages/cli/src/daemon/index.ts
@@ -17,6 +17,7 @@ import { auditOrphanedTasks, cleanupLeaderSessions, cleanupStaleSessions } from 
 import { DaemonLoop } from "./loop.js";
 import { PrMonitor } from "./prMonitor.js";
 import { RateLimiter } from "./rateLimiter.js";
+import { RuntimeCircuitBreaker } from "./runtimeCircuitBreaker.js";
 import { isRuntimeLimitIgnored } from "./runtimeOverrides.js";
 import { RuntimePool } from "./runtimePool.js";
 import { TunnelClient } from "./tunnel.js";
@@ -40,6 +41,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
   process.on("unhandledRejection", (err: any) => {
     logger.error(`Unhandled rejection: ${err?.message ?? err}`);
   });
+  const circuitBreaker = new RuntimeCircuitBreaker();
 
   mkdirSync(STATE_DIR, { recursive: true });
 
@@ -107,6 +109,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     },
     opts.taskTimeout,
     tunnel,
+    circuitBreaker,
   );
 
   tunnel.onHistoryRequest((sessionId, requestId) => {
@@ -122,10 +125,17 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     }
   });
 
-  loop = new DaemonLoop(client, pool, rateLimiter, prMonitor, {
-    maxConcurrent: opts.maxConcurrent,
-    pollInterval,
-  });
+  loop = new DaemonLoop(
+    client,
+    pool,
+    rateLimiter,
+    prMonitor,
+    {
+      maxConcurrent: opts.maxConcurrent,
+      pollInterval,
+    },
+    circuitBreaker,
+  );
 
   const heartbeatInterval = setInterval(() => {
     (async () => {
@@ -138,6 +148,7 @@ export async function startDaemon(opts: DaemonOptions): Promise<void> {
     logger.info("Shutting down daemon...");
     loop.stop();
     rateLimiter.stop();
+    circuitBreaker.stop();
     prMonitor.stop();
     usageCollector.stop();
     clearInterval(heartbeatInterval);

--- a/packages/cli/src/daemon/loop.ts
+++ b/packages/cli/src/daemon/loop.ts
@@ -23,6 +23,7 @@ import { CleanupError } from "./errors.js";
 import type { PrMonitor } from "./prMonitor.js";
 import { type RateLimiter } from "./rateLimiter.js";
 import { resumeOneSession } from "./resumer.js";
+import { RuntimeCircuitBreaker } from "./runtimeCircuitBreaker.js";
 import type { RuntimePool } from "./runtimePool.js";
 
 const logger = createLogger("loop");
@@ -56,6 +57,7 @@ export class DaemonLoop {
     private rateLimiter: RateLimiter,
     private prMonitor: PrMonitor,
     private opts: LoopOpts,
+    private circuitBreaker: RuntimeCircuitBreaker = new RuntimeCircuitBreaker(),
   ) {
     this.errorBackoffMs = opts.pollInterval;
     this.idleBackoffMs = opts.pollInterval;
@@ -142,7 +144,7 @@ export class DaemonLoop {
     const activeBefore = this.pool.activeCount;
 
     await this.killCancelledTasks();
-    await reapOrphanWorkerSessions(this.sessions, this.pool, this.client);
+    await reapOrphanWorkerSessions(this.sessions, this.pool, this.client, this.circuitBreaker);
     await reapCleanupPending(this.sessions);
     await checkRejectedReviews(
       this.sessions,
@@ -156,10 +158,17 @@ export class DaemonLoop {
 
     const reapedOrResumed = this.pool.activeCount !== activeBefore;
 
-    const dispatched = await dispatchTasks(this.client, this.pool, this.rateLimiter, this.prMonitor, {
-      maxConcurrent: this.opts.maxConcurrent,
-      pollInterval: this.opts.pollInterval,
-    });
+    const dispatched = await dispatchTasks(
+      this.client,
+      this.pool,
+      this.rateLimiter,
+      this.prMonitor,
+      {
+        maxConcurrent: this.opts.maxConcurrent,
+        pollInterval: this.opts.pollInterval,
+      },
+      this.circuitBreaker,
+    );
 
     if (dispatched || reapedOrResumed) {
       this.resetIdleBackoff();
@@ -204,6 +213,7 @@ export async function reapOrphanWorkerSessions(
   sessions: SessionManager,
   pool: RuntimePool,
   client: { getTask(id: string): Promise<unknown>; releaseTask(id: string): Promise<unknown> },
+  circuitBreaker?: RuntimeCircuitBreaker,
 ): Promise<void> {
   for (const s of sessions.list({ type: "worker", status: "active" })) {
     if (!s.taskId || pool.hasTask(s.taskId)) continue;
@@ -222,12 +232,23 @@ export async function reapOrphanWorkerSessions(
       continue;
     }
 
-    await apiFireAndForget(
-      "releaseTask",
-      () => client.releaseTask(s.taskId!),
-      (msg) => logger.warn(`Failed to release orphan task ${s.taskId}: ${msg}`),
-    );
-    logger.info(`Released orphan task ${s.taskId} and reaped its session`);
+    if (task.status === "todo") {
+      circuitBreaker?.recordPreClaimFailure(s.runtime, s.taskId, "orphan session found before task was claimed");
+      logger.warn(`Reaping pre-claim orphan session for task ${s.taskId} (runtime=${s.runtime}) without release`);
+      await completeTerminal(sessions, s);
+      continue;
+    }
+
+    if (task.status === "in_progress") {
+      await apiFireAndForget(
+        "releaseTask",
+        () => client.releaseTask(s.taskId!),
+        (msg) => logger.warn(`Failed to release orphan task ${s.taskId}: ${msg}`),
+      );
+      logger.info(`Released orphan task ${s.taskId} and reaped its session`);
+    } else {
+      logger.warn(`Reaping orphan session for task ${s.taskId} with unexpected status ${task.status ?? "unknown"} without release`);
+    }
     await completeTerminal(sessions, s);
   }
 }

--- a/packages/cli/src/daemon/runtimeCircuitBreaker.ts
+++ b/packages/cli/src/daemon/runtimeCircuitBreaker.ts
@@ -1,0 +1,108 @@
+import { createLogger } from "../logger.js";
+
+const logger = createLogger("runtime-circuit-breaker");
+
+export interface RuntimeCircuitBreakerOptions {
+  failureThreshold?: number;
+  cooldownMs?: number;
+}
+
+type CircuitState = "closed" | "open" | "half-open";
+
+interface RuntimeCircuit {
+  state: CircuitState;
+  openedAt?: number;
+  resumeAt?: number;
+  probeInFlight?: boolean;
+  failuresByTask: Map<string, number>;
+}
+
+export class RuntimeCircuitBreaker {
+  private circuits = new Map<string, RuntimeCircuit>();
+  private failureThreshold: number;
+  private cooldownMs: number;
+
+  constructor(options: RuntimeCircuitBreakerOptions = {}) {
+    this.failureThreshold = options.failureThreshold ?? 3;
+    this.cooldownMs = options.cooldownMs ?? 30 * 60_000;
+  }
+
+  canDispatch(runtime: string): boolean {
+    const circuit = this.circuits.get(runtime);
+    if (!circuit) return true;
+    if (circuit.state === "closed") return true;
+
+    if (circuit.state === "half-open") {
+      if (circuit.probeInFlight) return false;
+      circuit.probeInFlight = true;
+      logger.info(`Runtime "${runtime}" circuit half-open — allowing one probe`);
+      return true;
+    }
+
+    if ((circuit.resumeAt ?? 0) <= Date.now()) {
+      circuit.state = "half-open";
+      circuit.probeInFlight = true;
+      logger.info(`Runtime "${runtime}" circuit cooldown elapsed — allowing one probe`);
+      return true;
+    }
+
+    return false;
+  }
+
+  isRuntimePaused(runtime: string): boolean {
+    return !this.canDispatch(runtime);
+  }
+
+  pauseResetAt(runtime: string): string | null {
+    const circuit = this.circuits.get(runtime);
+    if (!circuit || circuit.state !== "open" || !circuit.resumeAt) return null;
+    return new Date(circuit.resumeAt).toISOString();
+  }
+
+  recordPreClaimFailure(runtime: string, taskId: string, reason: string): void {
+    const circuit = this.getCircuit(runtime);
+
+    if (circuit.state === "half-open") {
+      this.open(runtime, circuit, `half-open probe failed for task ${taskId}: ${reason}`);
+      return;
+    }
+
+    const failures = (circuit.failuresByTask.get(taskId) ?? 0) + 1;
+    circuit.failuresByTask.set(taskId, failures);
+    logger.warn(`Runtime "${runtime}" pre-claim failure ${failures}/${this.failureThreshold} for task ${taskId}: ${reason}`);
+
+    if (failures >= this.failureThreshold) {
+      this.open(runtime, circuit, `task ${taskId} failed to enter workflow ${failures} times: ${reason}`);
+    }
+  }
+
+  recordWorkflowEntered(runtime: string): void {
+    const circuit = this.circuits.get(runtime);
+    if (!circuit) return;
+    if (circuit.state === "closed") return;
+    logger.info(`Runtime "${runtime}" circuit closed after successful workflow entry`);
+    this.circuits.delete(runtime);
+  }
+
+  stop(): void {
+    this.circuits.clear();
+  }
+
+  private getCircuit(runtime: string): RuntimeCircuit {
+    let circuit = this.circuits.get(runtime);
+    if (!circuit) {
+      circuit = { state: "closed", failuresByTask: new Map() };
+      this.circuits.set(runtime, circuit);
+    }
+    return circuit;
+  }
+
+  private open(runtime: string, circuit: RuntimeCircuit, reason: string): void {
+    const resumeAt = Date.now() + this.cooldownMs;
+    circuit.state = "open";
+    circuit.openedAt = Date.now();
+    circuit.resumeAt = resumeAt;
+    circuit.probeInFlight = false;
+    logger.warn(`Runtime "${runtime}" circuit opened — pausing dispatch until ${new Date(resumeAt).toISOString()}; reason: ${reason}`);
+  }
+}

--- a/packages/cli/src/daemon/runtimeCircuitBreaker.ts
+++ b/packages/cli/src/daemon/runtimeCircuitBreaker.ts
@@ -33,20 +33,34 @@ export class RuntimeCircuitBreaker {
     if (circuit.state === "closed") return true;
 
     if (circuit.state === "half-open") {
-      if (circuit.probeInFlight) return false;
-      circuit.probeInFlight = true;
-      logger.info(`Runtime "${runtime}" circuit half-open — allowing one probe`);
-      return true;
+      return !circuit.probeInFlight;
     }
 
-    if ((circuit.resumeAt ?? 0) <= Date.now()) {
+    return (circuit.resumeAt ?? 0) <= Date.now();
+  }
+
+  tryAcquireDispatch(runtime: string): boolean {
+    const circuit = this.circuits.get(runtime);
+    if (!circuit || circuit.state === "closed") return true;
+
+    if (circuit.state === "open") {
+      if ((circuit.resumeAt ?? 0) > Date.now()) return false;
       circuit.state = "half-open";
-      circuit.probeInFlight = true;
+      circuit.probeInFlight = false;
       logger.info(`Runtime "${runtime}" circuit cooldown elapsed — allowing one probe`);
-      return true;
     }
 
-    return false;
+    if (circuit.probeInFlight) return false;
+    circuit.probeInFlight = true;
+    logger.info(`Runtime "${runtime}" circuit half-open — allowing one probe`);
+    return true;
+  }
+
+  releaseDispatch(runtime: string): void {
+    const circuit = this.circuits.get(runtime);
+    if (!circuit || circuit.state !== "half-open" || !circuit.probeInFlight) return;
+    circuit.probeInFlight = false;
+    logger.warn(`Runtime "${runtime}" circuit half-open probe was not started — releasing probe`);
   }
 
   isRuntimePaused(runtime: string): boolean {

--- a/packages/cli/src/daemon/runtimePool.ts
+++ b/packages/cli/src/daemon/runtimePool.ts
@@ -484,6 +484,7 @@ async function finalize(agent: AgentProcess, opts: { crashed: boolean; error?: u
       logger.warn(`Cleanup transition failed for ${sessionId}: ${errMessage(e)}`);
     });
   } else if (nextStatus === "in_review") {
+    ctx.circuitBreaker.recordWorkflowEntered(agent.providerName);
     (ctx.tunnel as TunnelSink & { sendStatus?: (sid: string, s: string) => void })?.sendStatus?.(sessionId, "done");
     logger.info(`Task ${taskId} in review, preserving worktree`);
   } else if (nextStatus === "rate_limited") {

--- a/packages/cli/src/daemon/runtimePool.ts
+++ b/packages/cli/src/daemon/runtimePool.ts
@@ -12,8 +12,9 @@ import { createLogger } from "../logger.js";
 import type { AgentEvent, AgentHandle, AgentProvider } from "../providers/types.js";
 import { getSessionManager } from "../session/manager.js";
 import { classifyIteratorEnd, type SessionEvent } from "../session/stateMachine.js";
-import { apiFireAndForget, providerExecute } from "./boundaries.js";
+import { apiCallOptional, apiFireAndForget, providerExecute } from "./boundaries.js";
 import { classify } from "./errors.js";
+import { RuntimeCircuitBreaker } from "./runtimeCircuitBreaker.js";
 
 const logger = createLogger("runtime-pool");
 
@@ -37,6 +38,7 @@ export interface AgentProcess {
 export interface RuntimeContext {
   client: ApiClient;
   rateLimitSink: RateLimitSink;
+  circuitBreaker: RuntimeCircuitBreaker;
   tunnel: TunnelSink | null;
   isAlive: (taskId: string) => boolean;
 }
@@ -86,6 +88,7 @@ export class RuntimePool {
   private callbacks: PoolCallbacks;
   private taskTimeoutMs: number;
   private rateLimitSink: RateLimitSink;
+  private circuitBreaker: RuntimeCircuitBreaker;
   private tunnel: (TunnelSink & { sendStatus?(sid: string, s: string): void }) | null;
 
   constructor(
@@ -94,10 +97,12 @@ export class RuntimePool {
     rateLimitSink: RateLimitSink,
     taskTimeoutMs = 2 * 60 * 60 * 1000,
     tunnel?: TunnelSink | null,
+    circuitBreaker: RuntimeCircuitBreaker = new RuntimeCircuitBreaker(),
   ) {
     this.client = client;
     this.callbacks = callbacks;
     this.rateLimitSink = rateLimitSink;
+    this.circuitBreaker = circuitBreaker;
     this.taskTimeoutMs = taskTimeoutMs;
     this.tunnel = tunnel ?? null;
   }
@@ -228,6 +233,7 @@ export class RuntimePool {
     return {
       client: this.client,
       rateLimitSink: this.rateLimitSink,
+      circuitBreaker: this.circuitBreaker,
       tunnel: this.tunnel,
       isAlive: (taskId) => this.agents.has(taskId),
     };
@@ -472,16 +478,7 @@ async function finalize(agent: AgentProcess, opts: { crashed: boolean; error?: u
   const nextStatus = next?.status ?? "terminal";
 
   if (nextStatus === "completing") {
-    if (opts.crashed) {
-      logger.warn(`Releasing task ${taskId}: agent crashed`);
-    } else {
-      logger.info(`Releasing task ${taskId}: agent finished without moving task to review`);
-    }
-    apiFireAndForget(
-      "releaseTask",
-      () => ctx.client.releaseTask(taskId),
-      (msg) => logger.warn(`Failed to release task ${taskId}: ${msg}`),
-    );
+    await handleCompletingTask(agent, opts, ctx);
     runCleanup(agent, ctx.tunnel);
     await sessions.applyEvent(sessionId, { type: "cleanup_done" }).catch((e) => {
       logger.warn(`Cleanup transition failed for ${sessionId}: ${errMessage(e)}`);
@@ -498,6 +495,46 @@ async function finalize(agent: AgentProcess, opts: { crashed: boolean; error?: u
       logger.warn(`Agent for task ${taskId} (${agent.providerName}) exited while rate-limited, suspending`);
     }
   }
+}
+
+async function handleCompletingTask(agent: AgentProcess, opts: { crashed: boolean; error?: unknown }, ctx: RuntimeContext): Promise<void> {
+  const { taskId } = agent;
+  const task = (await apiCallOptional("getTask", () => ctx.client.getTask(taskId))) as { status?: string } | null;
+  const reason = opts.crashed ? `agent crashed: ${errMessage(opts.error)}` : "agent exited before submitting review";
+
+  if (!task) {
+    logger.warn(`Task ${taskId} missing during finalize; cleaning up session without release`);
+    return;
+  }
+
+  if (task.status === "todo") {
+    ctx.circuitBreaker.recordPreClaimFailure(agent.providerName, taskId, reason);
+    logger.warn(`Task ${taskId} remained todo after ${agent.providerName} session ended; treating as pre-claim runtime failure`);
+    return;
+  }
+
+  if (task.status === "in_progress") {
+    ctx.circuitBreaker.recordWorkflowEntered(agent.providerName);
+    if (opts.crashed) {
+      logger.warn(`Releasing task ${taskId}: agent crashed`);
+    } else {
+      logger.info(`Releasing task ${taskId}: agent finished without moving task to review`);
+    }
+    apiFireAndForget(
+      "releaseTask",
+      () => ctx.client.releaseTask(taskId),
+      (msg) => logger.warn(`Failed to release task ${taskId}: ${msg}`),
+    );
+    return;
+  }
+
+  if (task.status === "in_review" || task.status === "done" || task.status === "cancelled") {
+    ctx.circuitBreaker.recordWorkflowEntered(agent.providerName);
+    logger.info(`Task ${taskId} is ${task.status}; cleaning up session without release`);
+    return;
+  }
+
+  logger.warn(`Task ${taskId} has unexpected status ${task.status ?? "unknown"}; cleaning up session without release`);
 }
 
 async function finalizeCancelled(agent: AgentProcess, ctx: RuntimeContext): Promise<void> {

--- a/tests/runtime-circuit-breaker.test.ts
+++ b/tests/runtime-circuit-breaker.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { RuntimeCircuitBreaker } from "../packages/cli/src/daemon/runtimeCircuitBreaker";
+
+describe("RuntimeCircuitBreaker", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("opens a runtime circuit after the same task reaches the failure threshold", () => {
+    const breaker = new RuntimeCircuitBreaker({ failureThreshold: 3, cooldownMs: 60_000 });
+
+    breaker.recordPreClaimFailure("codex", "task-1", "agent exited before claim");
+    breaker.recordPreClaimFailure("codex", "task-1", "agent exited before claim");
+    expect(breaker.canDispatch("codex")).toBe(true);
+
+    breaker.recordPreClaimFailure("codex", "task-1", "agent exited before claim");
+
+    expect(breaker.canDispatch("codex")).toBe(false);
+    expect(breaker.pauseResetAt("codex")).toEqual(expect.any(String));
+  });
+
+  it("tracks task failures independently before opening the runtime circuit", () => {
+    const breaker = new RuntimeCircuitBreaker({ failureThreshold: 3, cooldownMs: 60_000 });
+
+    breaker.recordPreClaimFailure("codex", "task-1", "agent exited before claim");
+    breaker.recordPreClaimFailure("codex", "task-2", "agent exited before claim");
+
+    expect(breaker.canDispatch("codex")).toBe(true);
+  });
+
+  it("allows one half-open probe after cooldown", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-19T12:00:00Z"));
+    const breaker = new RuntimeCircuitBreaker({ failureThreshold: 1, cooldownMs: 60_000 });
+
+    breaker.recordPreClaimFailure("codex", "task-1", "agent exited before claim");
+    expect(breaker.canDispatch("codex")).toBe(false);
+
+    vi.setSystemTime(new Date("2026-05-19T12:01:01Z"));
+
+    expect(breaker.canDispatch("codex")).toBe(true);
+    expect(breaker.canDispatch("codex")).toBe(false);
+  });
+
+  it("closes the circuit after successful workflow entry", () => {
+    const breaker = new RuntimeCircuitBreaker({ failureThreshold: 1, cooldownMs: 60_000 });
+
+    breaker.recordPreClaimFailure("codex", "task-1", "agent exited before claim");
+    expect(breaker.canDispatch("codex")).toBe(false);
+
+    breaker.recordWorkflowEntered("codex");
+
+    expect(breaker.canDispatch("codex")).toBe(true);
+    expect(breaker.pauseResetAt("codex")).toBeNull();
+  });
+});

--- a/tests/runtime-circuit-breaker.test.ts
+++ b/tests/runtime-circuit-breaker.test.ts
@@ -39,6 +39,7 @@ describe("RuntimeCircuitBreaker", () => {
     vi.setSystemTime(new Date("2026-05-19T12:01:01Z"));
 
     expect(breaker.canDispatch("codex")).toBe(true);
+    expect(breaker.tryAcquireDispatch("codex")).toBe(true);
     expect(breaker.canDispatch("codex")).toBe(false);
   });
 
@@ -52,5 +53,17 @@ describe("RuntimeCircuitBreaker", () => {
 
     expect(breaker.canDispatch("codex")).toBe(true);
     expect(breaker.pauseResetAt("codex")).toBeNull();
+  });
+
+  it("releases a half-open probe when dispatch does not start", () => {
+    const breaker = new RuntimeCircuitBreaker({ failureThreshold: 1, cooldownMs: 0 });
+
+    breaker.recordPreClaimFailure("codex", "task-1", "agent exited before claim");
+    expect(breaker.tryAcquireDispatch("codex")).toBe(true);
+    expect(breaker.canDispatch("codex")).toBe(false);
+
+    breaker.releaseDispatch("codex");
+
+    expect(breaker.canDispatch("codex")).toBe(true);
   });
 });

--- a/tests/runtimePool-coverage.test.ts
+++ b/tests/runtimePool-coverage.test.ts
@@ -106,6 +106,7 @@ function makeProvider(handle: AgentHandle): AgentProvider {
 
 function makeApiClient(overrides: Partial<Record<string, any>> = {}): ApiClient {
   return {
+    getTask: vi.fn().mockResolvedValue({ status: "in_progress" }),
     releaseTask: vi.fn().mockResolvedValue({}),
     closeSession: vi.fn().mockResolvedValue({}),
     ...overrides,

--- a/tests/runtimePool-finalize.test.ts
+++ b/tests/runtimePool-finalize.test.ts
@@ -59,6 +59,7 @@ vi.mock("../packages/cli/src/agent/systemPrompt.js", () => ({
 
 import { randomUUID } from "node:crypto";
 import type { AgentClient, ApiClient } from "../packages/cli/src/client/index.js";
+import { RuntimeCircuitBreaker } from "../packages/cli/src/daemon/runtimeCircuitBreaker.js";
 import { RuntimePool } from "../packages/cli/src/daemon/runtimePool.js";
 import type { AgentEvent, AgentHandle, AgentProvider } from "../packages/cli/src/providers/types.js";
 import { _setSessionManagerForTest, SessionManager } from "../packages/cli/src/session/manager.js";
@@ -97,6 +98,7 @@ function makeProvider(handle: AgentHandle): AgentProvider {
  */
 function makeApiClient(overrides: Partial<Record<string, any>> = {}): ApiClient {
   return {
+    getTask: vi.fn().mockResolvedValue({ status: "in_progress" }),
     releaseTask: vi.fn().mockResolvedValue({}),
     closeSession: vi.fn().mockResolvedValue({}),
     ...overrides,
@@ -343,6 +345,33 @@ describe("RuntimePool finalize() — releaseTask on completing", () => {
     });
 
     expect(apiClient.releaseTask as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(taskId);
+  });
+
+  it("does NOT release todo tasks and opens the runtime circuit after pre-claim exit", async () => {
+    const taskId = randomUUID();
+    const sessionId = randomUUID();
+    await seedActiveSession(sessions, sessionId, taskId);
+
+    const apiWithTodo = makeApiClient({ getTask: vi.fn().mockResolvedValue({ status: "todo" }) });
+    const circuitBreaker = new RuntimeCircuitBreaker({ failureThreshold: 1, cooldownMs: 60_000 });
+    const agentClient = makeAgentClient(null);
+    const handle = makeHandle([]);
+    const provider = makeProvider(handle);
+
+    await new Promise<void>((resolve) => {
+      const pool = new RuntimePool(
+        apiWithTodo,
+        { onSlotFreed: resolve },
+        { onRateLimited: vi.fn(), onRateLimitResumed: vi.fn() },
+        0,
+        null,
+        circuitBreaker,
+      );
+      pool.spawnAgent({ provider, taskId, sessionId, cwd: "/tmp", taskContext: "test", agentClient, agentEnv: {} });
+    });
+
+    expect(apiWithTodo.releaseTask as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+    expect(circuitBreaker.pauseResetAt("claude")).toEqual(expect.any(String));
   });
 
   // --------------------------------------------------------------------------

--- a/tests/runtimePool-finalize.test.ts
+++ b/tests/runtimePool-finalize.test.ts
@@ -300,6 +300,36 @@ describe("RuntimePool finalize() — releaseTask on completing", () => {
     expect(apiClient.releaseTask as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
   });
 
+  it("closes a half-open runtime circuit when the probe reaches in_review", async () => {
+    const taskId = randomUUID();
+    const sessionId = randomUUID();
+    await seedActiveSession(sessions, sessionId, taskId);
+
+    const circuitBreaker = new RuntimeCircuitBreaker({ failureThreshold: 1, cooldownMs: 0 });
+    circuitBreaker.recordPreClaimFailure("claude", taskId, "agent exited before claim");
+    expect(circuitBreaker.tryAcquireDispatch("claude")).toBe(true);
+    expect(circuitBreaker.canDispatch("claude")).toBe(false);
+
+    const agentClient = makeAgentClient({ status: "in_review" });
+    const handle = makeHandle([makeTurnEndEvent()]);
+    const provider = makeProvider(handle);
+
+    await new Promise<void>((resolve) => {
+      const pool = new RuntimePool(
+        apiClient,
+        { onSlotFreed: resolve },
+        { onRateLimited: vi.fn(), onRateLimitResumed: vi.fn() },
+        0,
+        null,
+        circuitBreaker,
+      );
+      pool.spawnAgent({ provider, taskId, sessionId, cwd: "/tmp", taskContext: "test", agentClient, agentEnv: {} });
+    });
+
+    expect(circuitBreaker.canDispatch("claude")).toBe(true);
+    expect(circuitBreaker.pauseResetAt("claude")).toBeNull();
+  });
+
   // --------------------------------------------------------------------------
   // Case 2: agent finishes normally with result but task is in_progress
   //   (e.g. rejected before finalize ran). Since agent produced a result,

--- a/tests/task-scheduled-at.test.ts
+++ b/tests/task-scheduled-at.test.ts
@@ -321,6 +321,29 @@ describe("dispatchTasks — scheduled_at filter", () => {
     rl.stop();
   });
 
+  it("does not consume the circuit half-open probe when session creation fails before spawn", async () => {
+    const { dispatchTasks } = await import("../packages/cli/src/daemon/dispatcher");
+    const { RuntimeCircuitBreaker } = await import("../packages/cli/src/daemon/runtimeCircuitBreaker");
+    const spawnSpy = vi.fn().mockResolvedValue(undefined);
+    const task = makeTask({ id: "task-half-open" });
+    const client = makeClient([task]);
+    client.createSession = vi.fn().mockResolvedValue(null);
+    const pool = makePool(spawnSpy);
+    const rl = makeRateLimiter();
+    const circuitBreaker = new RuntimeCircuitBreaker({ failureThreshold: 1, cooldownMs: 0 });
+
+    circuitBreaker.recordPreClaimFailure("claude", "task-half-open", "agent exited before claim");
+
+    const first = await dispatchTasks(client as any, pool as any, rl, prMonitor, opts, circuitBreaker);
+    const second = await dispatchTasks(client as any, pool as any, rl, prMonitor, opts, circuitBreaker);
+
+    expect(first).toBe(false);
+    expect(second).toBe(false);
+    expect(client.createSession).toHaveBeenCalledTimes(2);
+    expect(spawnSpy).not.toHaveBeenCalled();
+    rl.stop();
+  });
+
   it("does not dispatch a future-scheduled task while dispatching a past-scheduled task in the same list", async () => {
     const { dispatchTasks } = await import("../packages/cli/src/daemon/dispatcher");
     const spawnSpy = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

- add a daemon runtime circuit breaker that opens when the same task fails to enter the workflow 3 times before claim
- skip release attempts for `todo` tasks in `RuntimePool.finalize()` and orphan session reaping; only release tasks that are actually `in_progress`
- pause dispatch per runtime while the circuit is open, then allow one half-open probe after cooldown
- log pre-claim runtime failures with the captured reason when available

## Root Cause

Worker agents claim tasks themselves. When a spawned runtime session exited before claim, the task stayed `todo`, but daemon cleanup still attempted `releaseTask`. That produced repeated 409s and allowed the same task/runtime pair to keep spawning sessions.

## Validation

- pre-commit passed: biome, typecheck, full vitest suite (`101` files, `2312` tests)
- targeted runtime tests passed: `runtimePool-coverage`, `runtimePool-finalize`, `runtime-circuit-breaker`

## Notes

- I did not run the daemon smoke test because it requires refreshing/installing the local `ak` CLI, and the request explicitly said not to install `ak` locally.