### PR TITLE
fix(cli): Windows compatibility — leader anchor, JWT clock skew, MSYS gpg GNUPGHOME, Session 0 EPERM

### DIFF
--- a/packages/cli/src/agent/leader.ts
+++ b/packages/cli/src/agent/leader.ts
@@ -15,8 +15,14 @@ function isDaemonAlive(): boolean {
     const pid = parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    // EPERM means the daemon process exists but lives in a security context we
+    // may not signal. On Windows this happens when `ak start` is launched by
+    // Task Scheduler (S4U) into Session 0 (Services) and we probe it from a
+    // normal user session — the cross-session signal is denied, not absent.
+    // Treat EPERM as alive, otherwise `ak get task` aborts with the spurious
+    // "Could not locate claude process in ancestry" error.
+    return (err as NodeJS.ErrnoException)?.code === "EPERM";
   }
 }
 

--- a/packages/cli/src/agent/runtime.ts
+++ b/packages/cli/src/agent/runtime.ts
@@ -1,4 +1,7 @@
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { PID_FILE } from "../paths.js";
+import { isPidAlive } from "../session/store.js";
 
 interface RuntimeSpec {
   /** Environment variables set by the runtime when it spawns subprocesses. */
@@ -48,12 +51,32 @@ function readProcess(pid: number): { ppid: number; command: string } | null {
 export function findRuntimeAncestorPid(runtime: string): number | null {
   const pattern = RUNTIMES[runtime]?.commandPattern;
   if (!pattern) return null;
+  const override = Number.parseInt(process.env.AK_LEADER_PID ?? "", 10);
+  if (Number.isInteger(override) && override > 0) return override;
+  if (process.platform === "win32") return findDaemonAnchorPid();
   let pid = process.ppid;
   for (let i = 0; i < 32 && pid > 1; i++) {
     const info = readProcess(pid);
     if (!info) return null;
     if (pattern.test(info.command)) return pid;
     pid = info.ppid;
+  }
+  return null;
+}
+
+/**
+ * Windows fallback: POSIX `ps` does not exist and the WMI/PowerShell
+ * equivalents can hang for minutes on some machines, so the parent chain
+ * cannot be walked reliably. Anchor leader sessions to the daemon process
+ * instead — the only long-lived local pid discoverable without WMI. Callers
+ * that need a precise anchor can set AK_LEADER_PID explicitly.
+ */
+function findDaemonAnchorPid(): number | null {
+  try {
+    const pid = Number.parseInt(readFileSync(PID_FILE, "utf-8").trim(), 10);
+    if (Number.isInteger(pid) && pid > 0 && isPidAlive(pid)) return pid;
+  } catch {
+    /* no daemon pid file — same as "no ancestor found" */
   }
   return null;
 }

--- a/packages/cli/src/client/agent.ts
+++ b/packages/cli/src/client/agent.ts
@@ -26,9 +26,13 @@ export class AgentClient extends ApiClient {
   }
 
   protected async authorize(): Promise<string> {
+    // Backdate iat by 30s: the server verifies with zero clock tolerance, so a
+    // client clock even one second ahead of the server rejects every request
+    // with invalid_jwt. exp is still resolved from the current time, so the
+    // token's validity window is unchanged.
     const jwt = await new SignJWT({ sub: this.sessionId, aid: this.agentId, jti: randomUUID(), aud: this.baseUrl })
       .setProtectedHeader({ alg: "EdDSA", typ: "agent+jwt" })
-      .setIssuedAt()
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 30)
       .setExpirationTime("60s")
       .sign(this.privateKey);
     return `Bearer ${jwt}`;

--- a/packages/cli/src/daemon/dispatcher.ts
+++ b/packages/cli/src/daemon/dispatcher.ts
@@ -44,6 +44,38 @@ async function getSubagentDetails(client: ApiClient, subagentIds: string[]): Pro
 
 // ---- Agent environment / GPG helpers ----
 
+let msysGpg: boolean | null = null;
+
+/**
+ * Git for Windows ships an MSYS build of gpg that resolves Windows-style
+ * GNUPGHOME values (`C:\...` and even `C:/...`) as paths relative to the
+ * current directory and aborts with "directory does not exist" / "no writable
+ * keyring". Detect that build by the path dialect gpgconf reports for its
+ * compiled-in bindir (POSIX-style for MSYS, drive-letter for native builds
+ * like Gpg4win) — `--list-dirs` output is machine-readable and not localized.
+ */
+function isMsysGpg(): boolean {
+  if (msysGpg !== null) return msysGpg;
+  const out = execBoundary("gpgconf-detect", () => execFileSync("gpgconf", ["--list-dirs", "bindir"], { encoding: "utf-8", stdio: "pipe" }));
+  msysGpg = String(out ?? "")
+    .trim()
+    .startsWith("/");
+  return msysGpg;
+}
+
+/**
+ * Convert a GNUPGHOME path to the dialect the local gpg build understands.
+ * Only rewrites drive-letter paths on win32 with an MSYS gpg:
+ * `C:\Users\x` → `/c/Users/x`. Node-side fs calls must keep using the
+ * original Windows path.
+ */
+export function gpgEnvPath(gnupgHome: string): string {
+  if (process.platform !== "win32") return gnupgHome;
+  if (!/^[A-Za-z]:[\\/]/.test(gnupgHome)) return gnupgHome;
+  if (!isMsysGpg()) return gnupgHome;
+  return gnupgHome.replace(/^([A-Za-z]):[\\/]/, (_m, drive: string) => `/${drive.toLowerCase()}/`).replace(/\\/g, "/");
+}
+
 export interface BuildEnvOpts {
   agentId: string;
   sessionId: string;
@@ -69,7 +101,7 @@ export function buildAgentEnv(opts: BuildEnvOpts): Record<string, string> {
     GIT_COMMITTER_EMAIL: email,
   };
   if (gnupgHome && gpgSubkeyId) {
-    env.GNUPGHOME = gnupgHome;
+    env.GNUPGHOME = gpgEnvPath(gnupgHome);
     env.GIT_CONFIG_COUNT = "3";
     env.GIT_CONFIG_KEY_0 = "gpg.format";
     env.GIT_CONFIG_VALUE_0 = "openpgp";
@@ -87,7 +119,7 @@ export function setupGnupgHome(armoredPrivateKey: string): string {
   fsSync("write-gpg-key", () => writeFileSync(keyFile, armoredPrivateKey, { mode: 0o600 }));
   execBoundary("gpg-import", () =>
     execFileSync("gpg", ["--batch", "--import", keyFile], {
-      env: { ...process.env, GNUPGHOME: gnupgHome },
+      env: { ...process.env, GNUPGHOME: gpgEnvPath(gnupgHome) },
       stdio: "pipe",
     }),
   );
@@ -99,7 +131,7 @@ export function cleanupGnupgHome(gnupgHome: string | null): void {
   if (!gnupgHome) return;
   execBoundary("gpg-kill-agent", () =>
     execFileSync("gpgconf", ["--kill", "gpg-agent"], {
-      env: { ...process.env, GNUPGHOME: gnupgHome },
+      env: { ...process.env, GNUPGHOME: gpgEnvPath(gnupgHome) },
       stdio: "pipe",
     }),
   );

--- a/packages/cli/src/session/store.ts
+++ b/packages/cli/src/session/store.ts
@@ -109,8 +109,13 @@ export function isPidAlive(pid: number | undefined): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    // EPERM means the process exists but belongs to another security context
+    // we may not signal. On Windows this happens when the daemon was started
+    // by Task Scheduler (S4U) in Session 0 (Services) and we probe it from a
+    // normal user session — the cross-session signal is denied, not absent.
+    // Treat EPERM as alive so daemon/leader liveness checks don't false-negative.
+    return (err as NodeJS.ErrnoException)?.code === "EPERM";
   }
 }
 

--- a/packages/cli/tests/client.test.ts
+++ b/packages/cli/tests/client.test.ts
@@ -425,6 +425,24 @@ describe("AgentClient — authorize and messaging methods", () => {
     expect(opts.headers.Authorization).toMatch(/^Bearer /);
   });
 
+  it("backdates iat by 30s for clock skew without shrinking the validity window", async () => {
+    const client = await makeAgentClient();
+    stubFetchOk([]);
+    const before = Math.floor(Date.now() / 1000);
+    await client.listAgents();
+    const after = Math.floor(Date.now() / 1000);
+    const [, opts] = (vi.mocked(fetch) as any).mock.calls[0];
+    const token = (opts.headers.Authorization as string).replace(/^Bearer /, "");
+    const payload = JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString("utf-8"));
+    // iat sits 30s in the past so a server whose clock trails the client's
+    // by up to 30s still sees it as not-from-the-future
+    expect(payload.iat).toBeGreaterThanOrEqual(before - 30);
+    expect(payload.iat).toBeLessThanOrEqual(after - 30);
+    // exp is still resolved from the current time, not the backdated iat
+    expect(payload.exp).toBeGreaterThanOrEqual(before + 60);
+    expect(payload.exp).toBeLessThanOrEqual(after + 60);
+  });
+
   it("sendMessage posts to the messages endpoint", async () => {
     const client = await makeAgentClient();
     stubFetchOk({});

--- a/packages/cli/tests/dispatcher-gpg.test.ts
+++ b/packages/cli/tests/dispatcher-gpg.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment node
+/**
+ * Tests for dispatcher.ts GPG path handling — gpgEnvPath() and the GNUPGHOME
+ * value buildAgentEnv() hands to spawned agents.
+ *
+ * Git for Windows ships an MSYS build of gpg that resolves Windows-style
+ * GNUPGHOME values as relative paths. gpgEnvPath() detects that build via
+ * `gpgconf --list-dirs bindir` (mocked here through node:child_process) and
+ * converts `C:\...` to `/c/...` only in that case. The detection result is
+ * cached at module scope, so each test re-imports a fresh dispatcher module.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Mock child_process before any imports touch it ────────────────────────────
+const mockExecFileSync = vi.fn<[string, string[], object], string>();
+
+vi.mock("node:child_process", () => ({
+  execFileSync: mockExecFileSync,
+}));
+
+// ── Logger mock ───────────────────────────────────────────────────────────────
+vi.mock("../src/logger.js", () => ({
+  createLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+// ── config mock (buildAgentEnv reads apiUrl) ─────────────────────────────────
+vi.mock("../src/config.js", () => ({
+  getCredentials: () => ({ apiUrl: "https://api.example.com", apiKey: "test-key" }),
+}));
+
+// ── shared mock ───────────────────────────────────────────────────────────────
+vi.mock("@agent-kanban/shared", () => ({
+  isBoardType: vi.fn().mockReturnValue(true),
+}));
+
+// ── modules pulled in by dispatcher that are irrelevant to these tests ────────
+vi.mock("../src/providers/registry.js", () => ({
+  getAvailableProviders: vi.fn().mockReturnValue([]),
+  getProvider: vi.fn(),
+  normalizeRuntime: vi.fn((r: string) => r),
+}));
+vi.mock("../src/session/manager.js", () => ({
+  getSessionManager: vi.fn(),
+}));
+vi.mock("../src/agent/systemPrompt.js", () => ({
+  generateSystemPrompt: vi.fn(),
+  writePromptFile: vi.fn(),
+}));
+vi.mock("../src/workspace/agents.js", () => ({
+  ensureSubagents: vi.fn(),
+}));
+vi.mock("../src/workspace/skills.js", () => ({
+  ensureSkills: vi.fn(),
+}));
+vi.mock("../src/workspace/repoOps.js", () => ({
+  ensureCloned: vi.fn(),
+  prepareRepo: vi.fn(),
+  repoDir: vi.fn(),
+}));
+vi.mock("../src/workspace/workspace.js", () => ({
+  createRepoWorkspace: vi.fn(),
+  createTempWorkspace: vi.fn(),
+}));
+
+// ── Platform pinning ──────────────────────────────────────────────────────────
+
+const realPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
+
+/** Fresh dispatcher module — resets the cached MSYS-gpg detection result. */
+async function freshDispatcher() {
+  vi.resetModules();
+  return await import("../src/daemon/dispatcher.js");
+}
+
+function mockGpgconfBindir(bindir: string) {
+  mockExecFileSync.mockImplementation((cmd: string, args: string[]) => {
+    if (cmd === "gpgconf" && args[0] === "--list-dirs") return `${bindir}\n`;
+    throw new Error(`Unexpected execFileSync call: ${cmd} ${args.join(" ")}`);
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  setPlatform(realPlatform);
+});
+
+// ── gpgEnvPath ────────────────────────────────────────────────────────────────
+
+describe("gpgEnvPath", () => {
+  it("returns the path unchanged on non-Windows platforms without probing gpg", async () => {
+    setPlatform("linux");
+    const { gpgEnvPath } = await freshDispatcher();
+    expect(gpgEnvPath("/tmp/ak-gpg-abc")).toBe("/tmp/ak-gpg-abc");
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it("converts Windows paths to MSYS form when gpg is an MSYS build", async () => {
+    setPlatform("win32");
+    mockGpgconfBindir("/usr/bin");
+    const { gpgEnvPath } = await freshDispatcher();
+    expect(gpgEnvPath("C:\\Users\\dev\\AppData\\Local\\Temp\\ak-gpg-abc")).toBe("/c/Users/dev/AppData/Local/Temp/ak-gpg-abc");
+    expect(mockExecFileSync).toHaveBeenCalledWith("gpgconf", ["--list-dirs", "bindir"], expect.anything());
+  });
+
+  it("lowercases the drive letter and handles forward-slash input", async () => {
+    setPlatform("win32");
+    mockGpgconfBindir("/usr/bin");
+    const { gpgEnvPath } = await freshDispatcher();
+    expect(gpgEnvPath("D:/tmp/ak-gpg-xyz")).toBe("/d/tmp/ak-gpg-xyz");
+  });
+
+  it("keeps the Windows path for native gpg builds like Gpg4win", async () => {
+    setPlatform("win32");
+    mockGpgconfBindir("C:\\Program Files (x86)\\GnuPG\\bin");
+    const { gpgEnvPath } = await freshDispatcher();
+    const original = "C:\\Users\\dev\\AppData\\Local\\Temp\\ak-gpg-abc";
+    expect(gpgEnvPath(original)).toBe(original);
+  });
+
+  it("caches the gpg build detection across calls", async () => {
+    setPlatform("win32");
+    mockGpgconfBindir("/usr/bin");
+    const { gpgEnvPath } = await freshDispatcher();
+    gpgEnvPath("C:\\tmp\\a");
+    gpgEnvPath("C:\\tmp\\b");
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── buildAgentEnv — GNUPGHOME dialect ────────────────────────────────────────
+
+describe("buildAgentEnv — GNUPGHOME dialect", () => {
+  const baseOpts = {
+    agentId: "agent-1",
+    sessionId: "session-1",
+    privateKeyJwk: { kty: "OKP" } as JsonWebKey,
+    agentName: "Dev Agent",
+    agentUsername: "dev-agent",
+  };
+
+  it("hands MSYS gpg a converted GNUPGHOME on win32", async () => {
+    setPlatform("win32");
+    mockGpgconfBindir("/usr/bin");
+    const { buildAgentEnv } = await freshDispatcher();
+    const env = buildAgentEnv({ ...baseOpts, gpgSubkeyId: "SUBKEY", gnupgHome: "C:\\Users\\dev\\ak-gpg-abc" });
+    expect(env.GNUPGHOME).toBe("/c/Users/dev/ak-gpg-abc");
+    expect(env.GIT_CONFIG_VALUE_1).toBe("SUBKEY!");
+  });
+
+  it("passes GNUPGHOME through unchanged on POSIX", async () => {
+    setPlatform("linux");
+    const { buildAgentEnv } = await freshDispatcher();
+    const env = buildAgentEnv({ ...baseOpts, gpgSubkeyId: "SUBKEY", gnupgHome: "/tmp/ak-gpg-abc" });
+    expect(env.GNUPGHOME).toBe("/tmp/ak-gpg-abc");
+  });
+
+  it("sets no GNUPGHOME when signing data is absent", async () => {
+    setPlatform("win32");
+    const { buildAgentEnv } = await freshDispatcher();
+    const env = buildAgentEnv({ ...baseOpts, gpgSubkeyId: null, gnupgHome: null });
+    expect(env.GNUPGHOME).toBeUndefined();
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/tests/providers.test.ts
+++ b/packages/cli/tests/providers.test.ts
@@ -1176,11 +1176,13 @@ describe("geminiProvider.resolveGeminiCommand", () => {
 
   it("uses the Volta package bin when installed", async () => {
     const fsModule = await import("node:fs");
-    vi.mocked(fsModule.existsSync).mockImplementation((path) => String(path).endsWith("/tools/image/packages/@google/gemini-cli/bin/gemini"));
+    const { join } = await import("node:path");
+    // Build the expected path with join() so the assertion holds on hosts
+    // whose path separator is a backslash.
+    const voltaBin = join("/Users/saltbo/.volta", "tools", "image", "packages", "@google", "gemini-cli", "bin", "gemini");
+    vi.mocked(fsModule.existsSync).mockImplementation((path) => String(path) === voltaBin);
 
-    expect(resolveGeminiCommand({ VOLTA_HOME: "/Users/saltbo/.volta" })).toBe(
-      "/Users/saltbo/.volta/tools/image/packages/@google/gemini-cli/bin/gemini",
-    );
+    expect(resolveGeminiCommand({ VOLTA_HOME: "/Users/saltbo/.volta" })).toBe(voltaBin);
   });
 });
 

--- a/packages/cli/tests/runtime.test.ts
+++ b/packages/cli/tests/runtime.test.ts
@@ -5,6 +5,11 @@
  * findRuntimeAncestorPid() calls execFileSync("ps", ...) internally via the
  * private readProcess() helper. We mock node:child_process to control what
  * process ancestry looks like without spawning real `ps` processes.
+ *
+ * On win32 the ancestry walk is replaced by a daemon-pid anchor read from
+ * PID_FILE; node:fs and session/store are mocked to control that path. The
+ * host platform is pinned per test so the suite behaves identically on
+ * POSIX and Windows dev machines.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -16,8 +21,29 @@ vi.mock("node:child_process", () => ({
   execFileSync: mockExecFileSync,
 }));
 
+// runtime.ts reads PID_FILE via node:fs and checks it with isPidAlive on win32
+const mockReadFileSync = vi.fn<[string, string], string>();
+
+vi.mock("node:fs", () => ({
+  readFileSync: mockReadFileSync,
+}));
+
+const mockIsPidAlive = vi.fn<[number], boolean>();
+
+vi.mock("../src/session/store.js", () => ({
+  isPidAlive: mockIsPidAlive,
+}));
+
 // Import after mocks are registered
 const { detectRuntime, findRuntimeAncestorPid } = await import("../src/agent/runtime.js");
+
+// ── Platform pinning ──────────────────────────────────────────────────────────
+
+const realPlatform = process.platform;
+
+function setPlatform(platform: NodeJS.Platform) {
+  Object.defineProperty(process, "platform", { value: platform, configurable: true });
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -35,15 +61,20 @@ function clearRuntimeEnv() {
   delete process.env.COPILOT_CLI;
   delete process.env.HERMES_INTERACTIVE;
   delete process.env.HERMES_SESSION_KEY;
+  delete process.env.AK_LEADER_PID;
 }
 
 beforeEach(() => {
   clearRuntimeEnv();
   vi.clearAllMocks();
+  // Existing ancestry-walk tests assume a POSIX `ps`; pin the platform so
+  // they pass identically on Windows dev machines. win32 tests override.
+  setPlatform("linux");
 });
 
 afterEach(() => {
   clearRuntimeEnv();
+  setPlatform(realPlatform);
 });
 
 // ── detectRuntime ─────────────────────────────────────────────────────────────
@@ -193,5 +224,68 @@ describe("findRuntimeAncestorPid — 32-hop hard cap", () => {
     expect(result).toBeNull();
     // Should have called ps at most 32 times (the hard cap)
     expect(mockExecFileSync).toHaveBeenCalledTimes(32);
+  });
+});
+
+// ── findRuntimeAncestorPid — AK_LEADER_PID override ──────────────────────────
+
+describe("findRuntimeAncestorPid — AK_LEADER_PID override", () => {
+  it("returns AK_LEADER_PID without walking ancestry when set to a valid pid", () => {
+    process.env.AK_LEADER_PID = "4242";
+    expect(findRuntimeAncestorPid("claude")).toBe(4242);
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it("wins on win32 too, without touching the pid file", () => {
+    setPlatform("win32");
+    process.env.AK_LEADER_PID = "4242";
+    expect(findRuntimeAncestorPid("claude")).toBe(4242);
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it("still returns null for an unknown runtime even when set", () => {
+    process.env.AK_LEADER_PID = "4242";
+    expect(findRuntimeAncestorPid("unknown-runtime")).toBeNull();
+  });
+
+  it.each(["not-a-pid", "0", "-5"])("ignores invalid value %j and falls back to the ancestry walk", (value) => {
+    process.env.AK_LEADER_PID = value;
+    mockExecFileSync.mockReturnValueOnce(psLine(1, "/usr/local/bin/claude"));
+    expect(findRuntimeAncestorPid("claude")).toBe(process.ppid);
+  });
+});
+
+// ── findRuntimeAncestorPid — win32 daemon anchor ──────────────────────────────
+
+describe("findRuntimeAncestorPid — win32 daemon anchor", () => {
+  beforeEach(() => {
+    setPlatform("win32");
+  });
+
+  it("anchors to the daemon pid from PID_FILE when the daemon is alive", () => {
+    mockReadFileSync.mockReturnValue("1234\n");
+    mockIsPidAlive.mockReturnValue(true);
+    expect(findRuntimeAncestorPid("claude")).toBe(1234);
+    // POSIX ps must never be spawned on win32
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  it("returns null when the pid file does not exist", () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    expect(findRuntimeAncestorPid("claude")).toBeNull();
+  });
+
+  it("returns null when the daemon pid is no longer alive", () => {
+    mockReadFileSync.mockReturnValue("1234\n");
+    mockIsPidAlive.mockReturnValue(false);
+    expect(findRuntimeAncestorPid("claude")).toBeNull();
+  });
+
+  it("returns null when the pid file contains garbage", () => {
+    mockReadFileSync.mockReturnValue("not-a-pid");
+    expect(findRuntimeAncestorPid("claude")).toBeNull();
+    expect(mockIsPidAlive).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/tests/sessionStore.test.ts
+++ b/packages/cli/tests/sessionStore.test.ts
@@ -284,6 +284,32 @@ describe("isPidAlive", () => {
     // PID 4194304 is beyond the Linux kernel's pid_max and will always be dead.
     expect(isPidAlive(4194304)).toBe(false);
   });
+
+  it("returns true when process.kill throws EPERM (cross-session process exists)", () => {
+    // Windows S4U daemon runs in Session 0; probing it from a user session is
+    // denied with EPERM. The process is alive — we just may not signal it.
+    const eperm = Object.assign(new Error("operation not permitted"), { code: "EPERM" });
+    const spy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw eperm;
+    });
+    try {
+      expect(isPidAlive(1234)).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("returns false when process.kill throws a non-EPERM error (ESRCH = no such process)", () => {
+    const esrch = Object.assign(new Error("no such process"), { code: "ESRCH" });
+    const spy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw esrch;
+    });
+    try {
+      expect(isPidAlive(1234)).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
 });
 
 // ── clearAllSessions ─────────────────────────────────────────────────────────

--- a/tests/codex-real-jsonl.test.ts
+++ b/tests/codex-real-jsonl.test.ts
@@ -15,8 +15,8 @@ const CODEX_DIR = join(homedir(), ".codex", "sessions");
 const hasCodexSessions = existsSync(CODEX_DIR);
 
 describe.skipIf(!hasCodexSessions)("readCodexJsonl — real JSONL data", () => {
-  // Find a real thread ID from local sessions
-  function findThreadId(): string | null {
+  // Collect real thread IDs from local sessions
+  function* findThreadIds(): Generator<string> {
     const { readdirSync } = require("node:fs");
     try {
       for (const year of readdirSync(CODEX_DIR)) {
@@ -29,13 +29,27 @@ describe.skipIf(!hasCodexSessions)("readCodexJsonl — real JSONL data", () => {
               if (!file.endsWith(".jsonl")) continue;
               // Extract thread ID: rollout-...-{uuid}.jsonl
               const match = file.match(/([0-9a-f-]{36})\.jsonl$/);
-              if (match) return match[1];
+              if (match) yield match[1];
             }
           }
         }
       }
     } catch {
       /* empty */
+    }
+  }
+
+  // The chronologically first session is not guaranteed to contain assistant
+  // messages (it may have been aborted before the first response), so scan
+  // for a thread the assertions below can meaningfully run against.
+  function findThreadId(): string | null {
+    for (const id of findThreadIds()) {
+      try {
+        const events = readCodexJsonl(id);
+        if (events.length > 0 && events.some((e: any) => e.event.type === "message")) return id;
+      } catch {
+        /* unreadable session — try the next one */
+      }
     }
     return null;
   }

--- a/tests/gemini-models.test.ts
+++ b/tests/gemini-models.test.ts
@@ -75,7 +75,8 @@ describe("geminiProvider.listModels", () => {
 
     const models = await geminiProvider.listModels?.();
 
-    expect(fs.readFileSync).toHaveBeenCalledWith(expect.stringMatching(/\.gemini\/oauth_creds\.json$/), "utf-8");
+    // Separator-agnostic so the assertion holds on Windows hosts too
+    expect(fs.readFileSync).toHaveBeenCalledWith(expect.stringMatching(/\.gemini[\\/]oauth_creds\.json$/), "utf-8");
     expect(fetch).toHaveBeenCalledTimes(3);
     expect(fetch).toHaveBeenNthCalledWith(
       1,


### PR DESCRIPTION
## Summary

Four independent fixes that together make the CLI (daemon + leader/worker agents) usable on Windows. Each is fatal on its own — details and repro in #210.

**1. Leader sessions without POSIX `ps`** (`agent/runtime.ts`)
`findRuntimeAncestorPid()` execs `ps`, which doesn't exist on Windows, so every leader `ak` call fails with "Could not locate \<runtime\> process in ancestry". The WMI/PowerShell equivalents can hang for minutes on some machines, so the parent chain can't be walked reliably there. New behavior:
- `AK_LEADER_PID` env var, honored on all platforms, explicitly anchors the leader session (useful for containers without `ps` too).
- On win32, fall back to anchoring at the daemon pid from `PID_FILE` — the only long-lived local pid discoverable without WMI.

Known limitation: concurrent leaders of *different* runtimes on one Windows machine share the daemon anchor pid; `AK_LEADER_PID` is the escape hatch for that setup. An honest native walk (NtQueryInformationProcess / toolhelp) would need a native module, which felt disproportionate.

**2. JWT `iat` vs client clock skew** (`client/agent.ts`)
The agent JWT is signed with `iat = now` while the server verifies with zero clock tolerance, so a client clock even one second ahead of the server gets a permanent `invalid_jwt` 401. `iat` is now backdated by 30s; `exp` is still resolved from the current time, so the token's validity window is unchanged. A complementary `clockTolerance` on the server side (`@better-auth/agent-auth`) would also help, but the client-side backdate works against already-deployed servers.

**3. `GNUPGHOME` dialect for MSYS gpg** (`daemon/dispatcher.ts`)
The gpg most Windows users have on PATH is the MSYS build from Git for Windows, which resolves `C:\...` (and even `C:/...`) `GNUPGHOME` values as *relative* paths and aborts with "directory does not exist" — failing the key import and the entire worker dispatch. `gpgEnvPath()` now detects the MSYS build via the path dialect `gpgconf --list-dirs bindir` reports (machine-readable, not localized) and converts `GNUPGHOME` to `/c/...` form for everything that reaches gpg via env. Native builds (Gpg4win) keep the Windows path; Node-side fs calls keep the original path; non-Windows platforms and POSIX-style paths short-circuit before any probing.

**4. Cross-session pid probe denied with `EPERM`** (`session/store.ts`, `agent/leader.ts`)
`isPidAlive()` and `isDaemonAlive()` probe a process with `process.kill(pid, 0)` and treat any thrown error as "not alive". When the daemon is autostarted by Task Scheduler with an S4U trigger it runs in **Session 0 (Services)**; a probe from a normal interactive user session is denied with `EPERM`, not `ESRCH` — the process is alive, we simply may not signal across the session boundary. Reading `EPERM` as dead makes `isDaemonAlive()` return false while the daemon is running, so the leader handshake bails and `ak get task` aborts with the same spurious "Could not locate claude process in ancestry" as fix #1. Both probes now distinguish the codes: genuine absence (`ESRCH` and friends) still returns false, but `EPERM` returns true, since a permission error proves the pid is owned by a live process. Linux/macOS behavior is unchanged — a dead pid still yields `ESRCH` there.

**5. Test-suite portability to Windows dev hosts** (test code only)
- `providers.test.ts` / `gemini-models.test.ts`: path assertions built with `join()` / separator-agnostic regex instead of hard-coded `/`.
- `codex-real-jsonl.test.ts`: the chronologically first local session isn't guaranteed to contain assistant messages (aborted sessions); scan for a usable thread instead.
- `runtime.test.ts` pins `process.platform` per test so the suite behaves identically on POSIX and Windows hosts.

## Validation

- Full suite green locally on Windows 11: 102 files / 2337 tests (pre-commit hook runs biome + tsc + full vitest).
- New unit tests: `AK_LEADER_PID` override precedence + validation, win32 daemon anchor (alive / dead / missing / garbage pid file), JWT `iat`/`exp` window, `gpgEnvPath` conversion + detection + caching, `buildAgentEnv` GNUPGHOME dialect, `isPidAlive` EPERM-alive / ESRCH-dead.
- GNUPGHOME dialect behavior verified empirically against gpg 2.4.9 (MSYS, Git for Windows): `C:\...` and `C:/...` both fail, `/c/...` works.
- The combined fixes (originally applied to the published 1.13.4 dist) ran a real board end-to-end on Windows: task created → claimed → workflow → review → done, with claude + hermes workers dispatched by the daemon. The EPERM fix in particular is what keeps that board reachable once the daemon is moved to an S4U Session-0 autostart.

Fixes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
